### PR TITLE
FIX: add packages:write permission back to workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
 
     steps:
       ## SHARED STEPS (always run) ##


### PR DESCRIPTION
`packages: write` was accidentally removed from the workflow permissions during the restructure. The push-to-main path needs it to push Docker images to `ghcr.io`.