### PR TITLE
FEAT: add semver Docker tags to metadata action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -100,6 +100,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: build and push docker image
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Add explicit semver tags to `docker/metadata-action` so tag pushes produce full semver Docker tags:

- `v1.0.0` → `1.0.0`, `1.0`, `v1.0.0`, `latest`
- Push to main → `main` (unchanged)