### PR TITLE
Fix preview rotations not rotating around object center

### DIFF
--- a/ui/src/views/render-new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/render-new/Scene/GeometricRenderer.tsx
@@ -7,10 +7,11 @@ import type { RenderConfig } from '@/utils/render/config';
 interface GeometricRendererProps {
   config: RenderConfig;
   name: string;
+  rotation?: [number, number, number];
 }
 
 export function GeometricRenderer(props: GeometricRendererProps) {
-  const { config, name } = props;
+  const { config, name, rotation = [0, 0, 0] } = props;
 
   const { data } = getGeometricDataSafe(config, name);
 
@@ -25,7 +26,7 @@ export function GeometricRenderer(props: GeometricRendererProps) {
         (data.a[2] + data.b[2]) / 2,
       ];
       return (
-        <mesh position={position} castShadow receiveShadow>
+        <mesh position={position} rotation={rotation} castShadow receiveShadow>
           <boxGeometry args={[width, height, depth]} />
           <MaterialResolver config={config} materialRef={data.material} geometricName={name} />
         </mesh>
@@ -34,7 +35,7 @@ export function GeometricRenderer(props: GeometricRendererProps) {
 
     case 'sphere':
       return (
-        <mesh position={data.center} castShadow receiveShadow>
+        <mesh position={data.center} rotation={rotation} castShadow receiveShadow>
           <sphereGeometry args={[data.radius]} />
           <MaterialResolver config={config} materialRef={data.material} geometricName={name} />
         </mesh>
@@ -44,43 +45,49 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       return (
         <>
           {data.geometrics.map((subName: string) => (
-            <GeometricRenderer key={subName} config={config} name={subName} />
+            <GeometricRenderer key={subName} config={config} name={subName} rotation={rotation} />
           ))}
         </>
       );
 
     case 'rotate_x':
       return (
-        <group rotation-x={toRadians(data)}>
-          <GeometricRenderer config={config} name={data.geometric} />
-        </group>
+        <GeometricRenderer
+          config={config}
+          name={data.geometric}
+          rotation={[rotation[0] + toRadians(data), rotation[1], rotation[2]]}
+        />
       );
 
     case 'rotate_y':
       return (
-        <group rotation-y={toRadians(data)}>
-          <GeometricRenderer config={config} name={data.geometric} />
-        </group>
+        <GeometricRenderer
+          config={config}
+          name={data.geometric}
+          rotation={[rotation[0], rotation[1] + toRadians(data), rotation[2]]}
+        />
       );
 
     case 'rotate_z':
       return (
-        <group rotation-z={toRadians(data)}>
-          <GeometricRenderer config={config} name={data.geometric} />
-        </group>
+        <GeometricRenderer
+          config={config}
+          name={data.geometric}
+          rotation={[rotation[0], rotation[1], rotation[2] + toRadians(data)]}
+        />
       );
 
     case 'translate':
       return (
         <group position={data.translation}>
-          <GeometricRenderer config={config} name={data.geometric} />
+          <GeometricRenderer config={config} name={data.geometric} rotation={rotation} />
         </group>
       );
 
     case 'parallelogram': {
       const mesh = createParallelogramMesh(data);
       return (
-        <primitive object={mesh} castShadow receiveShadow>
+        <primitive object={mesh} rotation={rotation} castShadow receiveShadow>
           <MaterialResolver config={config} materialRef={data.material} geometricName={name} />
         </primitive>
       );
@@ -89,7 +96,7 @@ export function GeometricRenderer(props: GeometricRendererProps) {
     case 'triangle': {
       const mesh = createTriangleMesh(data);
       return (
-        <primitive object={mesh} castShadow receiveShadow>
+        <primitive object={mesh} rotation={rotation} castShadow receiveShadow>
           <MaterialResolver config={config} materialRef={data.material} geometricName={name} />
         </primitive>
       );


### PR DESCRIPTION
## Summary

Fixes #65 — the 3D preview was rotating objects around the scene origin instead of around their own center.

## Root Cause

The rotation cases (`rotate_x/y/z`) wrapped the child in a `<group rotation-{axis}={angle}>`, which produced a transform composition of `R × T` (rotation before translation). This caused the positioned child mesh to orbit the world origin.

## Fix

Instead of wrapping in a parent `<group>`, rotation is accumulated into a `rotation?: [number, number, number]` prop and passed down to the leaf `<mesh>` / `<primitive>`. Applying `rotation` directly on the same `<mesh>` as `position` produces `T × R` order (Three.js's natural `Object3D` local transform), so the mesh rotates around its own center, then gets translated to world position.

### Changes
- **1 file**: `ui/src/views/render-new/Scene/GeometricRenderer.tsx` (+23 / −16)
- Added optional `rotation?: [number, number, number]` prop
- `rotate_x/y/z`: accumulate angle into `rotation` tuple, pass down (no more `<group>` wrapper)
- `list`, `translate`: pass `rotation` through to children
- `box`, `sphere`, `parallelogram`, `triangle`: apply `rotation` on the leaf `<mesh>` / `<primitive>`

## Related
- #68: `around` pivot point is still not handled in the preview (separate follow-up)
- #69: `around` values go stale when child geometric positions change