### PR TITLE
Add confirmation dialogs before deleting scene elements

### DIFF
--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
@@ -43,6 +43,9 @@ export function ControlsCardGeometric(props: ControlsCardGeometricProps) {
   const { data: geometricData } = getGeometricDataSafe(renderConfig, geometricName);
 
   function handleDeleteGeometric(name: string) {
+      if (!window.confirm(`Delete texture "${name}"?`)) {
+    return;
+  }
     const newGeometrics = { ...renderConfig.geometrics };
     delete newGeometrics[name];
 

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
@@ -20,6 +20,9 @@ export function ControlsCardMaterial(props: ControlsCardMaterialProps) {
   const { data: materialData } = getMaterialData(renderConfig, materialName);
 
   function handleDeleteMaterial(name: string) {
+      if (!window.confirm(`Delete material "${name}"?`)) {
+    return;
+  }
     const newMaterials = { ...renderConfig.materials };
     delete newMaterials[name];
 

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardTexture/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardTexture/index.tsx
@@ -23,6 +23,9 @@ export function ControlsCardTexture(props: ControlsCardTextureProps) {
   const { data: textureData } = getTextureData(renderConfig, textureName);
 
   function handleDeleteTexture(name: string) {
+      if (!window.confirm(`Delete texture "${name}"?`)) {
+    return;
+  }
     const newTextures = { ...renderConfig.textures };
     delete newTextures[name];
 


### PR DESCRIPTION
## Summary

Adds confirmation dialogs before deleting scene elements from the render editor.

## Changes

* Added confirmation dialog before deleting a geometric
* Added confirmation dialog before deleting a material
* Added confirmation dialog before deleting a texture

## Motivation

The current delete actions execute immediately with no confirmation step, making accidental deletions easy. This change adds a confirmation prompt before removal while keeping the existing deletion and reference-fixing logic unchanged.

## Validation

* Production build completed successfully using `npm run build`

## Related Issue

Closes #61
