### PR TITLE
Add about page

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,7 +10,7 @@ import { AuthCallbackPage } from './views/auth/github/callback';
 import { RendersPage } from './views/renders';
 import { RenderDetailPage } from './views/renders/[id]';
 import { NewRenderPage } from './views/renders/new';
-
+import { AboutPage } from './views/about';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -29,6 +29,7 @@ export default function App() {
               <Route element={<Layout />}>
                 {/* public routes */}
                 <Route path="/" element={<HomePage />} />
+                <Route path="/about" element={<AboutPage />} />
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/auth/github/callback" element={<AuthCallbackPage />} />
 

--- a/ui/src/layouts/Layout/LayoutNavbar/index.tsx
+++ b/ui/src/layouts/Layout/LayoutNavbar/index.tsx
@@ -42,6 +42,10 @@ export function LayoutNavbar() {
         <NavbarLink as={Link} to="/renders">
           Renders
         </NavbarLink>
+        {/* @ts-expect-error polymorphic 'as' prop not typed in flowbite-react */}
+<NavbarLink as={Link} to="/about">
+  About
+</NavbarLink>
       </NavbarCollapse>
     </Navbar>
   );

--- a/ui/src/views/about/index.tsx
+++ b/ui/src/views/about/index.tsx
@@ -1,0 +1,17 @@
+export function AboutPage() {
+  return (
+    <div className="mx-auto max-w-4xl p-8">
+      <h1 className="mb-4 text-3xl font-bold">About Luxide</h1>
+
+      <p className="mb-4">
+        Luxide is a ray tracing application for creating and rendering scenes
+        using physically based rendering techniques.
+      </p>
+
+      <p>
+        This page provides general information about the project and its
+        features.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds an About page to the frontend and integrates it into the application's navigation.

## Changes

* Added a new About page component
* Added the `/about` route
* Added an About link to the navigation bar

## Validation

* Verified the page renders successfully
* Verified navigation to `/about`
* Verified the project builds successfully with `npm run build`

## Related Issue

Closes #37

