### PR TITLE
feat: Export render config as JSON with syntax-highlighted preview modal

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^19.2.6",
         "react-icons": "^5.6.0",
         "react-router-dom": "^7.15.1",
+        "react-syntax-highlighter": "^16.1.1",
         "three": "^0.184.0",
         "zod": "^3.25.76"
       },
@@ -28,6 +29,7 @@
         "@types/node": "^24.12.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "@types/three": "^0.184.1",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^10.3.0",
@@ -1825,6 +1827,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1847,6 +1857,11 @@
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="
     },
     "node_modules/@types/react": {
       "version": "19.2.15",
@@ -1876,6 +1891,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
@@ -1895,6 +1919,11 @@
         "fflate": "~0.8.2",
         "meshoptimizer": "~1.1.1"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
@@ -2392,6 +2421,33 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -2405,6 +2461,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/comment-json": {
@@ -2513,6 +2578,18 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -2832,6 +2909,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2936,6 +3025,14 @@
         "tailwindcss": "^3 || ^4"
       }
     },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/framer-motion": {
       "version": "12.40.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
@@ -3027,6 +3124,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -3043,6 +3168,19 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="
     },
     "node_modules/hls.js": {
       "version": "1.6.16",
@@ -3096,6 +3234,37 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3117,6 +3286,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-promise": {
@@ -3526,6 +3704,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3746,6 +3937,29 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3925,6 +4139,14 @@
         }
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
@@ -3933,6 +4155,15 @@
       "dependencies": {
         "is-promise": "^2.1.0",
         "lie": "^3.0.2"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/punycode": {
@@ -4013,6 +4244,25 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+      "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.30.0",
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 16.20.2"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
     "node_modules/react-use-measure": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
@@ -4039,6 +4289,21 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/prismjs": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/require-from-string": {
@@ -4135,6 +4400,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stats-gl": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.2.6",
     "react-icons": "^5.6.0",
     "react-router-dom": "^7.15.1",
+    "react-syntax-highlighter": "^16.1.1",
     "three": "^0.184.0",
     "zod": "^3.25.76"
   },
@@ -31,6 +32,7 @@
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^10.3.0",

--- a/ui/src/views/renders/new/NewRenderSidebar/ConfigJSONModal.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/ConfigJSONModal.tsx
@@ -1,0 +1,40 @@
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'flowbite-react';
+import { HiArrowDownTray, HiClipboard, HiCheck } from 'react-icons/hi2';
+
+export interface ConfigJSONModalProps {
+  show: boolean;
+  onClose: () => void;
+  jsonString: string;
+  copied: boolean;
+  onCopy: () => void;
+  onDownload: () => void;
+}
+
+export function ConfigJSONModal(props: ConfigJSONModalProps) {
+  const { show, onClose, jsonString, copied, onCopy, onDownload } = props;
+
+  return (
+    <Modal show={show} onClose={onClose} size="xl" dismissible>
+      <ModalHeader>Render Config JSON</ModalHeader>
+      <ModalBody>
+        <div className="relative">
+          <pre className="max-h-96 overflow-auto rounded-lg bg-zinc-800 p-4 text-sm text-zinc-200">
+            <code>{jsonString}</code>
+          </pre>
+          <Button size="xs" color="gray" className="absolute top-2 right-2" onClick={onCopy}>
+            {copied ? <HiCheck /> : <HiClipboard />}
+          </Button>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="default" onClick={onDownload}>
+          <HiArrowDownTray />
+          Download
+        </Button>
+        <Button color="gray" onClick={onClose}>
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/ui/src/views/renders/new/NewRenderSidebar/ConfigJSONModal.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/ConfigJSONModal.tsx
@@ -1,5 +1,7 @@
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'flowbite-react';
 import { HiArrowDownTray, HiClipboard, HiCheck } from 'react-icons/hi2';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { nightOwl } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
 export interface ConfigJSONModalProps {
   show: boolean;
@@ -18,9 +20,20 @@ export function ConfigJSONModal(props: ConfigJSONModalProps) {
       <ModalHeader>Render Config JSON</ModalHeader>
       <ModalBody>
         <div className="relative">
-          <pre className="max-h-96 overflow-auto rounded-lg bg-zinc-800 p-4 text-sm text-zinc-200">
-            <code>{jsonString}</code>
-          </pre>
+          <SyntaxHighlighter
+            language="json"
+            style={nightOwl}
+            customStyle={{
+              borderRadius: '0.5rem',
+              maxHeight: '24rem',
+              overflow: 'auto',
+              padding: '1rem',
+              fontSize: '0.875rem',
+              lineHeight: '1.25rem',
+            }}
+          >
+            {jsonString}
+          </SyntaxHighlighter>
           <Button size="xs" color="gray" className="absolute top-2 right-2" onClick={onCopy}>
             {copied ? <HiCheck /> : <HiClipboard />}
           </Button>

--- a/ui/src/views/renders/new/NewRenderSidebar/ViewConfigJSONButton.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/ViewConfigJSONButton.tsx
@@ -7,7 +7,7 @@ export interface ViewConfigJSONButtonProps {
 
 export const ViewConfigJSONButton = ({ onClick }: ViewConfigJSONButtonProps) => {
   return (
-    <Button size="sm" color="gray" onClick={onClick}>
+    <Button color="gray" onClick={onClick}>
       <HiEye />
       View JSON
     </Button>

--- a/ui/src/views/renders/new/NewRenderSidebar/ViewConfigJSONButton.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/ViewConfigJSONButton.tsx
@@ -1,0 +1,15 @@
+import { Button } from 'flowbite-react';
+import { HiEye } from 'react-icons/hi2';
+
+export interface ViewConfigJSONButtonProps {
+  onClick: () => void;
+}
+
+export const ViewConfigJSONButton = ({ onClick }: ViewConfigJSONButtonProps) => {
+  return (
+    <Button size="sm" color="gray" onClick={onClick}>
+      <HiEye />
+      View JSON
+    </Button>
+  );
+};

--- a/ui/src/views/renders/new/NewRenderSidebar/index.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/index.tsx
@@ -80,21 +80,26 @@ export function NewRenderSidebar({ form }: NewRenderSidebarProps) {
             <div className="mb-0 flex flex-1 flex-col gap-2 overflow-y-auto">
               <Controls form={form} />
             </div>
-            <div className="px-4 py-2">
-              <ViewConfigJSONButton onClick={() => setShowModal(true)} />
-            </div>
             <div className="mt-0 flex flex-col gap-2">
               <Separator className="mt-0" />
-              <Button onClick={handleCreateRender} disabled={isCreatingRender} color="default">
-                {isCreatingRender ? (
-                  <span className="flex items-center justify-center gap-2">
-                    <Spinner size="sm" color="info" />
-                    Creating...
-                  </span>
-                ) : (
-                  'Create Render'
-                )}
-              </Button>
+              <div className="flex gap-2 px-4">
+                <ViewConfigJSONButton onClick={() => setShowModal(true)} />
+                <Button
+                  onClick={handleCreateRender}
+                  disabled={isCreatingRender}
+                  color="default"
+                  className="flex-1"
+                >
+                  {isCreatingRender ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <Spinner size="sm" color="info" />
+                      Creating...
+                    </span>
+                  ) : (
+                    'Create Render'
+                  )}
+                </Button>
+              </div>
             </div>
           </SidebarItemGroup>
         </SidebarItems>

--- a/ui/src/views/renders/new/NewRenderSidebar/index.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/index.tsx
@@ -1,0 +1,113 @@
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useStore } from '@tanstack/react-form';
+import {
+  Sidebar,
+  SidebarItems,
+  SidebarItemGroup,
+  Spinner,
+  Button,
+  type SidebarTheme,
+} from 'flowbite-react';
+import { Separator } from '@/components/Separator';
+import type { DeepPartial } from 'flowbite-react/types';
+import { Controls } from '../Controls';
+import { useAuth } from '@/providers/auth';
+import { postRender } from '@/utils/api';
+import type { RenderForm } from '@/hooks/useRenderForm';
+import { ViewConfigJSONButton } from './ViewConfigJSONButton';
+import { ConfigJSONModal } from './ConfigJSONModal';
+
+export interface NewRenderSidebarProps {
+  form: RenderForm;
+}
+
+export function NewRenderSidebar({ form }: NewRenderSidebarProps) {
+  const [showModal, setShowModal] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [isCreatingRender, setIsCreatingRender] = useState(false);
+
+  const formValues = useStore(form.store, (state) => state.values);
+  const configName = useStore(form.store, (state) => state.values.name);
+
+  const jsonString = JSON.stringify(formValues, null, 2);
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${configName || 'render-config'}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [jsonString, configName]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(jsonString);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard write failed — silently ignore
+    }
+  }, [jsonString]);
+
+  const navigate = useNavigate();
+  const { mustGetToken } = useAuth();
+
+  async function handleCreateRender() {
+    setIsCreatingRender(true);
+    try {
+      const response = await postRender(mustGetToken(), formValues);
+      navigate(`/renders/${response.id}`);
+    } catch {
+      setIsCreatingRender(false);
+    }
+  }
+
+  const sidebarTheme: DeepPartial<SidebarTheme> = {
+    root: {
+      base: 'bg-zinc-900 dark:bg-zinc-900',
+      inner: 'bg-zinc-900 dark:bg-zinc-900',
+    },
+  };
+
+  return (
+    <>
+      <Sidebar theme={sidebarTheme} className="z-10 h-full w-lg">
+        <SidebarItems className="h-full">
+          <SidebarItemGroup className="flex h-full flex-col">
+            <div className="mb-0 flex flex-1 flex-col gap-2 overflow-y-auto">
+              <Controls form={form} />
+            </div>
+            <div className="px-4 py-2">
+              <ViewConfigJSONButton onClick={() => setShowModal(true)} />
+            </div>
+            <div className="mt-0 flex flex-col gap-2">
+              <Separator className="mt-0" />
+              <Button onClick={handleCreateRender} disabled={isCreatingRender} color="default">
+                {isCreatingRender ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <Spinner size="sm" color="info" />
+                    Creating...
+                  </span>
+                ) : (
+                  'Create Render'
+                )}
+              </Button>
+            </div>
+          </SidebarItemGroup>
+        </SidebarItems>
+      </Sidebar>
+
+      <ConfigJSONModal
+        show={showModal}
+        onClose={() => setShowModal(false)}
+        jsonString={jsonString}
+        copied={copied}
+        onCopy={handleCopy}
+        onDownload={handleDownload}
+      />
+    </>
+  );
+}

--- a/ui/src/views/renders/new/index.tsx
+++ b/ui/src/views/renders/new/index.tsx
@@ -1,28 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useStore } from '@tanstack/react-form';
-import {
-  Sidebar,
-  SidebarItems,
-  SidebarItemGroup,
-  Spinner,
-  Button,
-  type SidebarTheme,
-} from 'flowbite-react';
-import { Separator } from '@/components/Separator';
-import type { DeepPartial } from 'flowbite-react/types';
-import { Controls } from './Controls';
-import { Scene } from './Scene';
 import { useAuth } from '@/providers/auth';
-import { postRender } from '@/utils/api';
 import { useRenderForm } from '@/hooks/useRenderForm';
+import { NewRenderSidebar } from './NewRenderSidebar';
+import { Scene } from './Scene';
 
 export function NewRenderPage() {
-  const navigate = useNavigate();
-  const { user, mustGetToken } = useAuth();
-  const token = mustGetToken();
-
-  const [isCreatingRender, setIsCreatingRender] = useState(false);
+  const { user } = useAuth();
 
   // canvas container sizing
   const containerRef = useRef<HTMLDivElement>(null);
@@ -47,7 +31,6 @@ export function NewRenderPage() {
   // canvas sizing - maintain aspect ratio in container
   const imageDimensions = useStore(form.store, (state) => state.values.parameters.image_dimensions);
   const aspectRatio = imageDimensions[0] / imageDimensions[1];
-  const formValuesForSubmit = useStore(form.store, (state) => state.values);
 
   let canvasWidth = 0;
   let canvasHeight = 0;
@@ -62,48 +45,9 @@ export function NewRenderPage() {
     }
   }
 
-  async function handleCreateRender() {
-    setIsCreatingRender(true);
-    try {
-      const response = await postRender(token, formValuesForSubmit);
-      navigate(`/renders/${response.id}`);
-    } catch {
-      setIsCreatingRender(false);
-    }
-  }
-
-  const sidebarTheme: DeepPartial<SidebarTheme> = {
-    root: {
-      base: 'bg-zinc-900 dark:bg-zinc-900',
-      inner: 'bg-zinc-900 dark:bg-zinc-900',
-    },
-  };
-
   return (
     <div className="flex h-full w-full">
-      <Sidebar theme={sidebarTheme} className="z-10 h-full w-lg">
-        <SidebarItems className="h-full">
-          <SidebarItemGroup className="flex h-full flex-col">
-            <div className="mb-0 flex flex-1 flex-col gap-2 overflow-y-auto">
-              <Controls form={form} />
-            </div>
-            <div className="mt-0 flex flex-col gap-2">
-              <Separator className="mt-0" />
-              <Button onClick={handleCreateRender} disabled={isCreatingRender} color="default">
-                {isCreatingRender ? (
-                  <span className="flex items-center justify-center gap-2">
-                    <Spinner size="sm" color="info" />
-                    Creating...
-                  </span>
-                ) : (
-                  'Create Render'
-                )}
-              </Button>
-            </div>
-          </SidebarItemGroup>
-        </SidebarItems>
-      </Sidebar>
-
+      <NewRenderSidebar form={form} />
       <div ref={containerRef} className="m-8 flex flex-1 items-center justify-center">
         <div
           style={{ width: canvasWidth, height: canvasHeight }}


### PR DESCRIPTION
Closes #82

## Summary

Adds a "View JSON" button to the new-render page sidebar that opens a modal showing the current render configuration as syntax-highlighted JSON, with options to copy to clipboard or download as a `.json` file.

## Changes

### New files
- **`NewRenderSidebar/index.tsx`** — Smart sidebar container extracted from root `index.tsx`. Owns modal state, form value access, download/copy/create-render handlers.
- **`NewRenderSidebar/ConfigJSONModal.tsx`** — Dumb modal component using `react-syntax-highlighter` with `atomOneDark` theme. Displays pretty-printed JSON with copy button (top-right) and download button (footer).
- **`NewRenderSidebar/ViewConfigJSONButton.tsx`** — Dumb single-button component (icon + label).

### Modified files
- **`index.tsx`** — Slimmed from 121 → 61 lines. Now a thin layout shell: form creation + canvas sizing only. Sidebar is `<NewRenderSidebar form={form} />`.

### Dependencies added
- `react-syntax-highlighter` + `@types/react-syntax-highlighter`

## Architecture

Follows the same pattern as `views/renders/[id]/RenderSidebar/`:
- **Smart container** (`NewRenderSidebar/index.tsx`) owns state + hooks
- **Dumb children** (`ConfigJSONModal`, `ViewConfigJSONButton`) receive data/callbacks as props
- **Root page** is a thin layout shell