### PR TITLE
chore: error on ESLint warnings in CI

### DIFF
--- a/justfile
+++ b/justfile
@@ -80,7 +80,7 @@ lint-ui: setup-ui-env
     cd ui && npm run lint
 [group('validate')]
 lint-ui-ci:
-    cd ui && npm run lint
+    cd ui && npm run lint -- --max-warnings 0
 
 [group('validate')]
 typecheck-ui: setup-ui-env

--- a/ui/src/views/renders/ImportConfigModal/RenderConfigEditor.tsx
+++ b/ui/src/views/renders/ImportConfigModal/RenderConfigEditor.tsx
@@ -4,7 +4,11 @@ import { json, jsonParseLinter } from '@codemirror/lang-json';
 import { linter, lintGutter, type Diagnostic } from '@codemirror/lint';
 import { vscodeDark } from '@uiw/codemirror-theme-vscode';
 import type { EditorView } from '@codemirror/view';
-import { RenderConfigSchema, normalizeRenderConfig } from '@/utils/render/config';
+import {
+  RenderConfigSchema,
+  normalizeRenderConfig,
+  type RawRenderConfig,
+} from '@/utils/render/config';
 import jsonSourceMap from 'json-source-map';
 
 function schemaLintSource(view: EditorView): Diagnostic[] {
@@ -12,7 +16,7 @@ function schemaLintSource(view: EditorView): Diagnostic[] {
   if (!text.trim()) return [];
   try {
     const { data, pointers } = jsonSourceMap.parse(text);
-    const normalized = normalizeRenderConfig(data as any);
+    const normalized = normalizeRenderConfig(data as RawRenderConfig);
     const result = RenderConfigSchema.safeParse(normalized);
     if (!result.success) {
       return result.error.issues.map((issue) => {

--- a/ui/src/views/renders/ImportConfigModal/index.tsx
+++ b/ui/src/views/renders/ImportConfigModal/index.tsx
@@ -40,7 +40,7 @@ export function ImportConfigModal(props: ImportConfigModalProps) {
     setError(null);
     try {
       const parsed = JSON.parse(jsonText);
-      const normalized = normalizeRenderConfig(parsed as any);
+      const normalized = normalizeRenderConfig(parsed);
       const result = RenderConfigSchema.safeParse(normalized);
       if (!result.success) {
         setError('Configuration has validation errors — see inline markers above.');


### PR DESCRIPTION
Add `--max-warnings 0` to the `lint-ui-ci` justfile recipe so that ESLint warnings (including `no-explicit-any`) fail in CI. The local dev lint command remains unchanged — warnings are still non-blocking during development.

Also fixes the two existing `no-explicit-any` warnings in the import config UI:
- `RenderConfigEditor.tsx` — replaced `as any` cast with the proper `RawRenderConfig` type import
- `ImportConfigModal/index.tsx` — removed the unnecessary `as any` cast since `JSON.parse` already returns `unknown`, which is the expected parameter type