### PR TITLE
FIX: Four panic/crash bugs in Rust API server

### DIFF
--- a/src/geometry/compounds/bvh.rs
+++ b/src/geometry/compounds/bvh.rs
@@ -11,6 +11,7 @@ use super::List;
 enum BvhNode {
     Branch { left: Arc<Bvh>, right: Arc<Bvh> },
     Leaf(Arc<dyn Geometric>),
+    Empty,
 }
 
 #[derive(Clone)]
@@ -59,7 +60,7 @@ impl Bvh {
 
         let list_length = geometrics.len();
         let node = match list_length {
-            0 => panic!("Cannot create Bvh from empty list"),
+            0 => BvhNode::Empty,
             1 => BvhNode::Leaf(geometrics.pop().unwrap()),
             _ => {
                 let right = Self::new(geometrics.drain(list_length / 2..).collect());
@@ -77,6 +78,7 @@ impl Bvh {
                 ref right,
             } => Aabb::from_aabbs(left.bounding_box(), right.bounding_box()),
             BvhNode::Leaf(ref leaf) => leaf.bounding_box(),
+            BvhNode::Empty => Aabb::EMPTY,
         };
 
         Self {
@@ -92,7 +94,7 @@ impl Bvh {
 
 impl Geometric for Bvh {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
-        if !self.bounding_box.hit(ray, ray_t) {
+        if matches!(&self.tree, BvhNode::Empty) || !self.bounding_box.hit(ray, ray_t) {
             return None;
         }
 
@@ -107,6 +109,7 @@ impl Geometric for Bvh {
                 right_intersection.or(left_intersection)
             }
             BvhNode::Leaf(leaf) => leaf.intersect(ray, ray_t),
+            BvhNode::Empty => unreachable!("handled in early return"),
         }
     }
 

--- a/src/server/auth_manager.rs
+++ b/src/server/auth_manager.rs
@@ -188,12 +188,13 @@ impl AuthManager {
         .map_err(|e| e.to_string())
     }
 
-    pub fn get_auth_url_and_state(&self, origin: Option<String>) -> (String, CsrfToken) {
+    pub fn get_auth_url_and_state(&self, origin: Option<String>) -> Result<(String, CsrfToken), AuthManagerError> {
         let oauth_client = match origin {
             // update redirect uri if we were given an origin from the API caller
             Some(ref origin) => {
                 let redirect_url = format!("{origin}/auth/github/callback");
-                let redirect_url = RedirectUrl::new(redirect_url).expect("invalid redirect URL");
+                let redirect_url = RedirectUrl::new(redirect_url)
+                    .map_err(|e| format!("Invalid redirect URL from origin header: {e}"))?;
 
                 &self.oauth_client.clone().set_redirect_uri(redirect_url)
             }
@@ -202,7 +203,7 @@ impl AuthManager {
 
         let (url, state) = oauth_client.authorize_url(CsrfToken::new_random).url();
 
-        (url.to_string(), state)
+        Ok((url.to_string(), state))
     }
 
     pub async fn exchange_code(

--- a/src/server/handlers/auth_callback.rs
+++ b/src/server/handlers/auth_callback.rs
@@ -151,7 +151,7 @@ async fn get_user_by_github_id(
                         .auth_manager
                         .get_next_user_id()
                         .await
-                        .expect("Failed to get next user ID"),
+                        ?,
                     github_id,
                     user_info.login.clone(),
                     user_info.avatar_url.clone(),
@@ -162,7 +162,7 @@ async fn get_user_by_github_id(
                         .auth_manager
                         .get_next_user_id()
                         .await
-                        .expect("Failed to get next user ID"),
+                        ?,
                     github_id,
                     user_info.login.clone(),
                     user_info.avatar_url.clone(),

--- a/src/server/handlers/auth_login.rs
+++ b/src/server/handlers/auth_login.rs
@@ -1,6 +1,7 @@
 use axum::{
     Json,
     extract::{Query, State},
+    http::StatusCode,
     response::{IntoResponse, Response},
 };
 use axum_extra::extract::{SignedCookieJar, cookie::Cookie};
@@ -33,9 +34,15 @@ pub async fn auth_login(
         .secure(true)
         .http_only(true);
 
-    let (url, auth_state) = state
+    let (url, auth_state) = match state
         .auth_manager
-        .get_auth_url_and_state(query_parameters.origin);
+        .get_auth_url_and_state(query_parameters.origin)
+    {
+        Ok(result) => result,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, e).into_response();
+        }
+    };
 
     state
         .auth_manager

--- a/src/tracing/render_manager.rs
+++ b/src/tracing/render_manager.rs
@@ -420,7 +420,16 @@ impl RenderManager {
             ));
         }
 
-        let render = self.storage.get_render(id).await?.unwrap();
+        let render = self
+            .storage
+            .get_render(id)
+            .await?
+            .ok_or_else(|| {
+                RenderManagerError::ClientError(
+                    StatusCode::NOT_FOUND,
+                    "Render not found".to_string(),
+                )
+            })?;
         let checkpoints_meta = self
             .storage
             .get_render_checkpoints_excluding_pixel_data(id)


### PR DESCRIPTION
## Summary

Fixes 4 crash paths in the Rust API server that could be triggered by user input.

### Changes

| # | File | Issue | Fix |
|---|------|-------|-----|
| 1 | `bvh.rs` | Empty geometrics list panic-kills server (502 error in UI) | Added `BvhNode::Empty` variant — empty scenes render background color |
| 2 | `auth_manager.rs` + `auth_login.rs` | Malformed `Origin` header crashes entire server (zero-effort DoS) | `get_auth_url_and_state` now returns `Result` — bad origin → 400 |
| 3 | `auth_callback.rs` | DB failure during user registration crashes server | Replaced 2× `.expect()` with `?` propagation |
| 4 | `render_manager.rs` | TOCTOU race: concurrent render deletion crashes stats endpoint | `.unwrap()` → `.ok_or_else()` → 404 |

### Files changed

- `src/geometry/compounds/bvh.rs` — +5/-2
- `src/server/auth_manager.rs` — +3/-4
- `src/server/handlers/auth_callback.rs` — +2/-2
- `src/server/handlers/auth_login.rs` — +9/-2
- `src/tracing/render_manager.rs` — +9/-2