### PR TITLE
FIX: Two panic bugs in render manager background thread

### DIFF
--- a/src/tracing/render_manager.rs
+++ b/src/tracing/render_manager.rs
@@ -199,10 +199,17 @@ impl RenderManager {
                 None => PixelData::new(),
             };
 
-            let render_data = render
-                .config
-                .compile()
-                .expect("Failing to compile render config at tracing time!");
+            let render_data = match render.config.compile() {
+                Ok(data) => data,
+                Err(e) => {
+                    println!(
+                        "Failed to compile render config for render {} at tracing time: {e}",
+                        render.id
+                    );
+                    running_renders.lock().unwrap().remove(&render.id);
+                    return;
+                }
+            };
 
             let (sender, mut receiver) = mpsc::channel(100);
 
@@ -428,16 +435,9 @@ impl RenderManager {
             ));
         }
 
-        let render = self
-            .storage
-            .get_render(id)
-            .await?
-            .ok_or_else(|| {
-                RenderManagerError::ClientError(
-                    StatusCode::NOT_FOUND,
-                    "Render not found".to_string(),
-                )
-            })?;
+        let render = self.storage.get_render(id).await?.ok_or_else(|| {
+            RenderManagerError::ClientError(StatusCode::NOT_FOUND, "Render not found".to_string())
+        })?;
         let checkpoints_meta = self
             .storage
             .get_render_checkpoints_excluding_pixel_data(id)

--- a/src/tracing/render_manager.rs
+++ b/src/tracing/render_manager.rs
@@ -185,9 +185,17 @@ impl RenderManager {
             }
 
             let initial_pixel_data = match previous_checkpoint {
-                Some(rcp) => rcp.pixel_data.expect(
-                    "previous checkpoint pixel data should not be cleared during active render",
-                ),
+                Some(rcp) => match rcp.pixel_data {
+                    Some(pixel_data) => pixel_data,
+                    None => {
+                        println!(
+                            "Checkpoint pixel data unexpectedly missing for render {} at iteration {}",
+                            render.id, rcp.iteration
+                        );
+                        running_renders.lock().unwrap().remove(&render.id);
+                        return;
+                    }
+                },
                 None => PixelData::new(),
             };
 


### PR DESCRIPTION
## Summary

Fixes 2 crash paths in `spawn_tracer_thread_to_next_checkpoint()` — the background render task. Both follow the existing error-handling pattern in the function (log + cleanup + early return).

### Changes

| # | Line | Issue | Fix |
|---|------|-------|-----|
| 1 | `render_manager.rs:188` | `rcp.pixel_data.expect()` panics if checkpoint data was corrupted/cleared | `match` on `Option` — on `None`, logs and returns early |
| 2 | `render_manager.rs:205` | `.expect("Failing to compile render config at tracing time!")` panics if config re-compile fails (e.g. OBJ file deleted after validation) | `match` on `Result` — on `Err`, logs and returns early |

Both use the same pattern established at lines 171-184:
```rust
println!("error message");
running_renders.lock().unwrap().remove(&render.id);
return;
```

### Files changed
- `src/tracing/render_manager.rs` — +25/-17