### PR TITLE
FEAT: Add resource renaming to render config controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Dark mode requires THREE things simultaneously:
 3. **React tree**: `<ThemeProvider>` wrapping the app in `App.tsx`
 
 ### TanStack Form
-- **Values require `useStore`**: Use `useStore(form.store, selector)` to read form values reactively — NOT `form.state.values`. Example: `const values = useStore(form.store, (state) => state.values);`
+- **Values require `useSelector`**: Use `useSelector(form.store, selector)` to read form values reactively — NOT `form.state.values`. Example: `const values = useSelector(form.store, (state) => state.values);`
 
 ### Tailwind CSS v4
 - No `tailwind.config.ts` file exists. All configuration is done via CSS `@theme` block in `ui/src/index.css`.

--- a/ui/src/utils/render/utils.ts
+++ b/ui/src/utils/render/utils.ts
@@ -205,6 +205,24 @@ function moveKey<T>(
 }
 
 /**
+ * renames a camera and updates all scene references
+ * throughout the config to point to the new name.
+ */
+export function renameCamera(config: RenderConfig, oldName: string, newName: string): RenderConfig {
+  const newConfig = { ...config };
+  newConfig.cameras = moveKey(newConfig.cameras, oldName, newName);
+
+  // update scene camera references
+  Object.values(newConfig.scenes ?? {}).forEach((scene) => {
+    if (scene.camera === oldName) {
+      scene.camera = newName;
+    }
+  });
+
+  return newConfig;
+}
+
+/**
  * renames a texture and updates all texture, material, and geometric references
  * throughout the config to point to the new name.
  */

--- a/ui/src/utils/render/utils.ts
+++ b/ui/src/utils/render/utils.ts
@@ -192,3 +192,154 @@ export function fixReferences(config: RenderConfig): RenderConfig {
 
   return newConfig;
 }
+
+function moveKey<T>(
+  collection: Record<string, T> | undefined,
+  oldName: string,
+  newName: string,
+): Record<string, T> {
+  const newCollection = { ...collection };
+  newCollection[newName] = newCollection[oldName];
+  delete newCollection[oldName];
+  return newCollection;
+}
+
+/**
+ * renames a texture and updates all texture, material, and geometric references
+ * throughout the config to point to the new name.
+ */
+export function renameTexture(
+  config: RenderConfig,
+  oldName: string,
+  newName: string,
+): RenderConfig {
+  const newConfig = { ...config };
+  newConfig.textures = moveKey(newConfig.textures, oldName, newName);
+
+  // checker sub-textures
+  Object.values(newConfig.textures ?? {}).forEach((texture) => {
+    if (texture.type === 'checker') {
+      if (texture.even_texture === oldName) {
+        texture.even_texture = newName;
+      }
+      if (texture.odd_texture === oldName) {
+        texture.odd_texture = newName;
+      }
+    }
+  });
+
+  // material reflectance/emittance textures
+  Object.values(newConfig.materials ?? {}).forEach((material) => {
+    switch (material.type) {
+      case 'dielectric':
+      case 'lambertian':
+      case 'specular': {
+        if (material.reflectance_texture === oldName) {
+          material.reflectance_texture = newName;
+        }
+        if (material.emittance_texture === oldName) {
+          material.emittance_texture = newName;
+        }
+
+        break;
+      }
+    }
+  });
+
+  // constant_volume geometric reflectance_texture
+  Object.values(newConfig.geometrics ?? {}).forEach((geometric) => {
+    switch (geometric.type) {
+      case 'constant_volume': {
+        if (geometric.reflectance_texture === oldName) {
+          geometric.reflectance_texture = newName;
+        }
+
+        break;
+      }
+    }
+  });
+
+  return newConfig;
+}
+
+/**
+ * renames a material and updates all geometric references
+ * throughout the config to point to the new name.
+ */
+export function renameMaterial(
+  config: RenderConfig,
+  oldName: string,
+  newName: string,
+): RenderConfig {
+  const newConfig = { ...config };
+  newConfig.materials = moveKey(newConfig.materials, oldName, newName);
+
+  // leaf geometrics: material reference
+  Object.values(newConfig.geometrics ?? {}).forEach((geometric) => {
+    switch (geometric.type) {
+      case 'box':
+      case 'obj_model':
+      case 'parallelogram':
+      case 'sphere':
+      case 'triangle': {
+        if (geometric.material === oldName) {
+          geometric.material = newName;
+        }
+
+        break;
+      }
+    }
+  });
+
+  return newConfig;
+}
+
+/**
+ * renames a geometric and updates all composite geometric, list geometric,
+ * and scene references throughout the config to point to the new name.
+ */
+export function renameGeometric(
+  config: RenderConfig,
+  oldName: string,
+  newName: string,
+): RenderConfig {
+  const newConfig = { ...config };
+  newConfig.geometrics = moveKey(newConfig.geometrics, oldName, newName);
+
+  // composite geometric references and list geometric arrays
+  Object.values(newConfig.geometrics ?? {}).forEach((geometric) => {
+    switch (geometric.type) {
+      case 'rotate_x':
+      case 'rotate_y':
+      case 'rotate_z':
+      case 'translate':
+      case 'constant_volume': {
+        if (geometric.geometric === oldName) {
+          geometric.geometric = newName;
+        }
+
+        break;
+      }
+      case 'list': {
+        geometric.geometrics = geometric.geometrics.map((name: string) =>
+          name === oldName ? newName : name,
+        );
+
+        break;
+      }
+    }
+  });
+
+  // scene geometric lists
+  if (newConfig.scenes) {
+    const scenes = newConfig.scenes;
+    const activeScene = scenes[newConfig.active_scene];
+    if (activeScene) {
+      activeScene.geometrics = activeScene.geometrics.map((name: string) =>
+        name === oldName ? newName : name,
+      );
+    }
+  }
+
+  return newConfig;
+}

--- a/ui/src/views/renders/new/Controls/NewGeometricSpeedDial.tsx
+++ b/ui/src/views/renders/new/Controls/NewGeometricSpeedDial.tsx
@@ -2,7 +2,7 @@ import { Dropdown, DropdownItem } from 'flowbite-react';
 import { defaultGeometricForType, type GeometricData } from '@/utils/render/geometric';
 import { capitalize, getNextUniqueName } from '@/utils/render/utils';
 import type { RenderForm } from '@/hooks/useRenderForm';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 import type { NormalizedSceneData } from '@/utils/render/scene';
 import { HiPlus } from 'react-icons/hi2';
 
@@ -28,7 +28,7 @@ interface NewGeometricSpeedDialProps {
 export function NewGeometricSpeedDial(props: NewGeometricSpeedDialProps) {
   const { form } = props;
 
-  const formValues = useStore(form.store, (state) => state.values);
+  const formValues = useSelector(form.store, (state) => state.values);
 
   function handleNewGeometric(type: GeometricType) {
     const newGeometric = defaultGeometricForType(type);

--- a/ui/src/views/renders/new/Controls/NewMaterialSpeedDial.tsx
+++ b/ui/src/views/renders/new/Controls/NewMaterialSpeedDial.tsx
@@ -2,7 +2,7 @@ import { Dropdown, DropdownItem } from 'flowbite-react';
 import { defaultMaterialForType, type MaterialData } from '@/utils/render/material';
 import { capitalize, getNextUniqueName } from '@/utils/render/utils';
 import type { RenderForm } from '@/hooks/useRenderForm';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 import { HiPlus } from 'react-icons/hi2';
 
 type MaterialType = Exclude<MaterialData['type'], 'dielectric'>;
@@ -14,7 +14,7 @@ interface NewMaterialSpeedDialProps {
 export function NewMaterialSpeedDial(props: NewMaterialSpeedDialProps) {
   const { form } = props;
 
-  const formValues = useStore(form.store, (state) => state.values);
+  const formValues = useSelector(form.store, (state) => state.values);
 
   function handleNewMaterial(type: MaterialType) {
     const newMaterial = defaultMaterialForType(type);

--- a/ui/src/views/renders/new/Controls/NewTextureSpeedDial.tsx
+++ b/ui/src/views/renders/new/Controls/NewTextureSpeedDial.tsx
@@ -2,7 +2,7 @@ import { Dropdown, DropdownItem } from 'flowbite-react';
 import { defaultTextureForType, type TextureData } from '@/utils/render/texture';
 import { capitalize, getNextUniqueName } from '@/utils/render/utils';
 import type { RenderForm } from '@/hooks/useRenderForm';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 import { HiPlus } from 'react-icons/hi2';
 
 type TextureType = Exclude<TextureData['type'], 'checker' | 'image'>;
@@ -14,7 +14,7 @@ interface NewTextureSpeedDialProps {
 export function NewTextureSpeedDial(props: NewTextureSpeedDialProps) {
   const { form } = props;
 
-  const formValues = useStore(form.store, (state) => state.values);
+  const formValues = useSelector(form.store, (state) => state.values);
 
   function handleNewTexture(type: TextureType) {
     const newTexture = defaultTextureForType(type);

--- a/ui/src/views/renders/new/Controls/cards/ControlsCard/LabelText.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCard/LabelText.tsx
@@ -1,0 +1,17 @@
+export type LabelTextProps = {
+  text: string;
+  type: 'bold' | 'light';
+};
+
+export function LabelText(props: LabelTextProps) {
+  const { text, type } = props;
+
+  switch (type) {
+    case 'bold': {
+      return <h2 className="text-xl font-bold">{text}</h2>;
+    }
+    case 'light': {
+      return <h2 className="text-lg font-light italic">{text}</h2>;
+    }
+  }
+}

--- a/ui/src/views/renders/new/Controls/cards/ControlsCard/RenamableLabel.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCard/RenamableLabel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, TextInput } from 'flowbite-react';
+import { Button, TextInput, type ButtonProps } from 'flowbite-react';
 import { HiPencil, HiCheck } from 'react-icons/hi2';
 import { LabelText, type LabelTextProps } from './LabelText';
 
@@ -26,11 +26,17 @@ export function RenamableLabel(props: RenamableLabelProps) {
     setIsEditing(true);
   }
 
+  const buttonProps: ButtonProps = {
+    size: 'xs',
+    outline: true,
+    pill: true,
+    color: 'dark',
+  };
+
   if (isEditing) {
     return (
       <span className="inline-flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
         <TextInput
-          sizing="sm"
           value={editText}
           onChange={(e) => setEditText(e.target.value)}
           onKeyDown={(e) => {
@@ -40,7 +46,7 @@ export function RenamableLabel(props: RenamableLabelProps) {
           }}
           className="w-40"
         />
-        <Button size="sm" onClick={handleConfirm}>
+        <Button {...buttonProps} onClick={handleConfirm}>
           <HiCheck className="h-4 w-4" />
         </Button>
       </span>
@@ -50,7 +56,7 @@ export function RenamableLabel(props: RenamableLabelProps) {
   return (
     <span className="inline-flex items-center gap-2">
       <LabelText text={label} type={labelStyle} />
-      <Button size="sm" onClick={handleStartEditing}>
+      <Button {...buttonProps} onClick={handleStartEditing}>
         <HiPencil className="h-4 w-4" />
       </Button>
     </span>

--- a/ui/src/views/renders/new/Controls/cards/ControlsCard/RenamableLabel.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCard/RenamableLabel.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { Button, TextInput } from 'flowbite-react';
+import { HiPencil, HiCheck } from 'react-icons/hi2';
+import { LabelText, type LabelTextProps } from './LabelText';
+
+export type RenamableLabelProps = {
+  label: string;
+  labelStyle: LabelTextProps['type'];
+  onRename: (newName: string) => void;
+};
+
+export function RenamableLabel(props: RenamableLabelProps) {
+  const { label, labelStyle, onRename } = props;
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState(label);
+
+  function handleConfirm() {
+    onRename(editText.trim());
+    setIsEditing(false);
+  }
+
+  function handleStartEditing(e: React.MouseEvent) {
+    e.stopPropagation();
+    setEditText(label);
+    setIsEditing(true);
+  }
+
+  if (isEditing) {
+    return (
+      <span className="inline-flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+        <TextInput
+          sizing="sm"
+          value={editText}
+          onChange={(e) => setEditText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              handleConfirm();
+            }
+          }}
+          className="w-40"
+        />
+        <Button size="sm" onClick={handleConfirm}>
+          <HiCheck className="h-4 w-4" />
+        </Button>
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <LabelText text={label} type={labelStyle} />
+      <Button size="sm" onClick={handleStartEditing}>
+        <HiPencil className="h-4 w-4" />
+      </Button>
+    </span>
+  );
+}

--- a/ui/src/views/renders/new/Controls/cards/ControlsCard/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCard/index.tsx
@@ -5,24 +5,18 @@ import type { DeepPartial } from 'flowbite-react/types';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Separator } from '@/components/Separator';
 import { HiTrash } from 'react-icons/hi2';
-
-type LabelType = 'bold' | 'light';
+import { RenamableLabel } from './RenamableLabel';
+import { LabelText, type LabelTextProps } from './LabelText';
 
 interface ControlsCardProps {
   children: React.ReactNode;
   startExpanded?: boolean;
-  leftLabel?: string;
-  leftLabelStyle?: LabelType;
+  leftLabel: string;
+  leftLabelStyle?: LabelTextProps['type'];
   rightLabel?: string;
-  rightLabelStyle?: LabelType;
+  rightLabelStyle?: LabelTextProps['type'];
+  onRename?: (newName: string) => void;
   onDelete?: () => void;
-}
-
-function LabelText({ text, type }: { text: string; type: LabelType }) {
-  if (type === 'bold') {
-    return <h2 className="text-xl font-bold">{text}</h2>;
-  }
-  return <h2 className="text-lg font-light italic">{text}</h2>;
 }
 
 export function ControlsCard(props: ControlsCardProps) {
@@ -33,6 +27,7 @@ export function ControlsCard(props: ControlsCardProps) {
     leftLabelStyle = 'bold',
     rightLabel,
     rightLabelStyle = 'light',
+    onRename,
     onDelete,
   } = props;
 
@@ -52,7 +47,11 @@ export function ControlsCard(props: ControlsCardProps) {
         onClick={() => setIsExpanded(!isExpanded)}
         type="button"
       >
-        {leftLabel ? <LabelText text={leftLabel} type={leftLabelStyle} /> : <span />}
+        {onRename ? (
+          <RenamableLabel label={leftLabel} labelStyle={leftLabelStyle} onRename={onRename} />
+        ) : (
+          <LabelText text={leftLabel} type={leftLabelStyle} />
+        )}
         <div className="flex flex-row items-center gap-2">
           {rightLabel && <LabelText text={rightLabel} type={rightLabelStyle} />}
           {isExpanded ? (

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardCamera.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardCamera.tsx
@@ -2,9 +2,11 @@ import { ControlsCard } from './ControlsCard';
 import { WarningIconUnaffectedPreview } from '../icons/WarningIconUnaffectedPreview';
 import { RangeControl } from './form-controls/RangeControl';
 import { TextArrayInputControl } from './form-controls/TextArrayInputControl';
+import { renameCamera } from '@/utils/render/utils';
 import type { RenderForm, RenderFormPath } from '@/hooks/useRenderForm';
 import type { DeepKeys } from '@tanstack/react-form';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
+import { useSelector } from '@tanstack/react-store';
 
 interface ControlsCardCameraProps {
   form: RenderForm;
@@ -14,10 +16,24 @@ interface ControlsCardCameraProps {
 export function ControlsCardCamera(props: ControlsCardCameraProps) {
   const { form, cameraName } = props;
 
+  const renderConfig = useSelector(form.store, (state) => state.values);
+
+  function handleRename(newName: string) {
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === cameraName) {
+      return;
+    }
+
+    const renamed = renameCamera(renderConfig, cameraName, trimmed);
+
+    form.setFieldValue('cameras', renamed.cameras);
+    form.setFieldValue('scenes', renamed.scenes);
+  }
+
   const formPath: RenderFormPath = `cameras.${cameraName}`;
 
   return (
-    <ControlsCard leftLabel={cameraName} startExpanded>
+    <ControlsCard leftLabel={cameraName} onRename={handleRename} startExpanded>
       <div className="flex flex-col gap-2 p-4">
         <RangeControl
           form={form}

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
@@ -5,10 +5,10 @@ import { TextInputControl } from '../form-controls/TextInputControl';
 import { RangeControl } from '../form-controls/RangeControl';
 import { SelectControl } from '../form-controls/SelectControl';
 import { getGeometricData, getGeometricDataSafe } from '@/utils/render/geometric';
-import { fixReferences } from '@/utils/render/utils';
+import { fixReferences, renameGeometric } from '@/utils/render/utils';
 import type { RenderConfig } from '@/utils/render/config';
 import type { RenderForm } from '@/hooks/useRenderForm';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 import { Separator } from '@/components/Separator';
 
 function GeometricMaterialSelect({
@@ -38,9 +38,23 @@ interface ControlsCardGeometricProps {
 export function ControlsCardGeometric(props: ControlsCardGeometricProps) {
   const { form, geometricName } = props;
 
-  const renderConfig = useStore(form.store, (state) => state.values);
+  const renderConfig = useSelector(form.store, (state) => state.values);
 
   const { data: geometricData } = getGeometricDataSafe(renderConfig, geometricName);
+
+  function handleRename(newName: string) {
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === geometricName) {
+      return;
+    }
+
+    const renamed = renameGeometric(renderConfig, geometricName, trimmed);
+
+    form.setFieldValue('textures', renamed.textures);
+    form.setFieldValue('materials', renamed.materials);
+    form.setFieldValue('geometrics', renamed.geometrics);
+    form.setFieldValue('scenes', renamed.scenes);
+  }
 
   function handleDeleteGeometric(name: string) {
     const newGeometrics = { ...renderConfig.geometrics };
@@ -227,6 +241,7 @@ export function ControlsCardGeometric(props: ControlsCardGeometricProps) {
   return (
     <ControlsCard
       leftLabel={geometricName}
+      onRename={handleRename}
       rightLabel={geometricData.type}
       rightLabelStyle="light"
       onDelete={() => handleDeleteGeometric(geometricName)}

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
@@ -2,10 +2,10 @@ import { ControlsCard } from './ControlsCard';
 import { RangeControl } from './form-controls/RangeControl';
 import { SelectControl } from './form-controls/SelectControl';
 import { getMaterialData } from '@/utils/render/material';
-import { fixReferences } from '@/utils/render/utils';
+import { fixReferences, renameMaterial } from '@/utils/render/utils';
 import type { RenderConfig } from '@/utils/render/config';
 import type { RenderForm } from '@/hooks/useRenderForm';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 
 interface ControlsCardMaterialProps {
   form: RenderForm;
@@ -15,9 +15,23 @@ interface ControlsCardMaterialProps {
 export function ControlsCardMaterial(props: ControlsCardMaterialProps) {
   const { form, materialName } = props;
 
-  const renderConfig = useStore(form.store, (state) => state.values);
+  const renderConfig = useSelector(form.store, (state) => state.values);
 
   const { data: materialData } = getMaterialData(renderConfig, materialName);
+
+  function handleRename(newName: string) {
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === materialName) {
+      return;
+    }
+
+    const renamed = renameMaterial(renderConfig, materialName, trimmed);
+
+    form.setFieldValue('textures', renamed.textures);
+    form.setFieldValue('materials', renamed.materials);
+    form.setFieldValue('geometrics', renamed.geometrics);
+    form.setFieldValue('scenes', renamed.scenes);
+  }
 
   function handleDeleteMaterial(name: string) {
     const newMaterials = { ...renderConfig.materials };
@@ -102,6 +116,7 @@ export function ControlsCardMaterial(props: ControlsCardMaterialProps) {
   return (
     <ControlsCard
       leftLabel={materialName}
+      onRename={handleRename}
       rightLabel={materialData.type}
       rightLabelStyle="light"
       onDelete={() => handleDeleteMaterial(materialName)}

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardParameters.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardParameters.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '@/providers/auth';
 import { Separator } from '@/components/Separator';
 import { useState } from 'react';
 import type { RenderForm } from '@/hooks/useRenderForm';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 
 interface ControlsCardParametersProps {
   form: RenderForm;
@@ -19,7 +19,7 @@ export function ControlsCardParameters(props: ControlsCardParametersProps) {
   const { form } = props;
 
   const { user } = useAuth();
-  const renderConfig = useStore(form.store, (state) => state.values);
+  const renderConfig = useSelector(form.store, (state) => state.values);
   const parameters = renderConfig.parameters;
   const savedCheckpointLimit = parameters.saved_checkpoint_limit ?? 1;
   const maxCheckpoints = user?.max_checkpoints_per_render ?? null;

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardTexture/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardTexture/index.tsx
@@ -4,10 +4,10 @@ import { TextArrayInputControl } from '../form-controls/TextArrayInputControl';
 import { InfoIconAdditionalInfo } from '@/views/renders/new/Controls/icons/InfoIconAdditionalInfo';
 import { NestedTextureHeader } from './NestedTextureHeader';
 import { getTextureData } from '@/utils/render/texture';
-import { fixReferences } from '@/utils/render/utils';
+import { fixReferences, renameTexture } from '@/utils/render/utils';
 import type { RenderConfig } from '@/utils/render/config';
 import type { RenderForm } from '@/hooks/useRenderForm';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 import { Separator } from '@/components/Separator';
 
 interface ControlsCardTextureProps {
@@ -18,9 +18,23 @@ interface ControlsCardTextureProps {
 export function ControlsCardTexture(props: ControlsCardTextureProps) {
   const { form, textureName } = props;
 
-  const renderConfig = useStore(form.store, (state) => state.values);
+  const renderConfig = useSelector(form.store, (state) => state.values);
 
   const { data: textureData } = getTextureData(renderConfig, textureName);
+
+  function handleRename(newName: string) {
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === textureName) {
+      return;
+    }
+
+    const renamed = renameTexture(renderConfig, textureName, trimmed);
+
+    form.setFieldValue('textures', renamed.textures);
+    form.setFieldValue('materials', renamed.materials);
+    form.setFieldValue('geometrics', renamed.geometrics);
+    form.setFieldValue('scenes', renamed.scenes);
+  }
 
   function handleDeleteTexture(name: string) {
     const newTextures = { ...renderConfig.textures };
@@ -94,6 +108,7 @@ export function ControlsCardTexture(props: ControlsCardTextureProps) {
   return (
     <ControlsCard
       leftLabel={textureName}
+      onRename={handleRename}
       rightLabel={textureData.type}
       rightLabelStyle="light"
       onDelete={() => handleDeleteTexture(textureName)}

--- a/ui/src/views/renders/new/Controls/index.tsx
+++ b/ui/src/views/renders/new/Controls/index.tsx
@@ -15,7 +15,7 @@ import {
   getTopLevelTextureNames,
 } from '@/utils/render/utils';
 import type { RenderForm } from '@/hooks/useRenderForm';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 import type { DeepPartial } from 'flowbite-react/types';
 
 interface ControlsProps {
@@ -25,7 +25,7 @@ interface ControlsProps {
 export function Controls(props: ControlsProps) {
   const { form } = props;
 
-  const renderConfig = useStore(form.store, (state) => state.values);
+  const renderConfig = useSelector(form.store, (state) => state.values);
 
   const activeScene = useMemo(
     () => getSceneData(renderConfig, renderConfig.active_scene),

--- a/ui/src/views/renders/new/NewRenderSidebar/index.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 import {
   Sidebar,
   SidebarItems,
@@ -27,8 +27,8 @@ export function NewRenderSidebar({ form }: NewRenderSidebarProps) {
   const [copied, setCopied] = useState(false);
   const [isCreatingRender, setIsCreatingRender] = useState(false);
 
-  const formValues = useStore(form.store, (state) => state.values);
-  const configName = useStore(form.store, (state) => state.values.name);
+  const formValues = useSelector(form.store, (state) => state.values);
+  const configName = useSelector(form.store, (state) => state.values.name);
 
   const jsonString = JSON.stringify(formValues, null, 2);
 

--- a/ui/src/views/renders/new/Scene/index.tsx
+++ b/ui/src/views/renders/new/Scene/index.tsx
@@ -1,7 +1,7 @@
 import { Canvas } from '@react-three/fiber';
 import { PerspectiveCamera } from '@react-three/drei';
 import { useRef, useEffect } from 'react';
-import { useStore } from '@tanstack/react-form';
+import { useSelector } from '@tanstack/react-store';
 import * as THREE from 'three';
 import { GeometricRenderer } from './GeometricRenderer';
 import { getSceneData } from '@/utils/render/scene';
@@ -38,7 +38,7 @@ function CameraUpdater({ cameraData }: { cameraData: RawCameraData }) {
 export function Scene(props: SceneProps) {
   const { form } = props;
 
-  const renderConfig = useStore(form.store, (state) => state.values);
+  const renderConfig = useSelector(form.store, (state) => state.values);
   const activeScene = getSceneData(renderConfig, renderConfig.active_scene);
   const { data: cameraData } = getCameraData(renderConfig, activeScene.camera);
 

--- a/ui/src/views/renders/new/index.tsx
+++ b/ui/src/views/renders/new/index.tsx
@@ -1,11 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
-import { useStore } from '@tanstack/react-form';
 import { useLocation } from 'react-router-dom';
 import { useAuth } from '@/providers/auth';
 import { useRenderForm } from '@/hooks/useRenderForm';
 import { NewRenderSidebar } from './NewRenderSidebar';
 import { Scene } from './Scene';
 import type { RenderConfig } from '@/utils/render/config';
+import { useSelector } from '@tanstack/react-store';
 
 export function NewRenderPage() {
   const { user } = useAuth();
@@ -33,7 +33,10 @@ export function NewRenderPage() {
   const form = useRenderForm({ user, initialValues: importedConfig });
 
   // canvas sizing - maintain aspect ratio in container
-  const imageDimensions = useStore(form.store, (state) => state.values.parameters.image_dimensions);
+  const imageDimensions = useSelector(
+    form.store,
+    (state) => state.values.parameters.image_dimensions,
+  );
   const aspectRatio = imageDimensions[0] / imageDimensions[1];
 
   let canvasWidth = 0;


### PR DESCRIPTION
## Summary

Adds the ability to rename textures, materials, geometrics, and cameras directly from their control card headers in the render config editor.

## Changes

### New feature: inline resource renaming
- **Rename utilities** (`ui/src/utils/render/utils.ts`): `renameTexture`, `renameMaterial`, `renameGeometric`, `renameCamera` — each moves the key and updates all cross-references throughout the config
- **RenamableLabel** (`ControlsCard/RenamableLabel.tsx`): extracted subcomponent managing edit-mode state, pen icon → text input → check button workflow
- **LabelText** (`ControlsCard/LabelText.tsx`): extracted from ControlsCard into its own file
- **ControlsCard** moved to `ControlsCard/index.tsx`: renders `RenamableLabel` when `onRename` prop is provided; `leftLabel` changed from optional string to required string

### Collateral: TanStack API migration
- Migrated `useStore` from `@tanstack/react-form` to `useSelector` from `@tanstack/react-store` across 9 files
- Updated AGENTS.md docs to reflect the correct API

## Files
- 17 files changed, +354 / −41 lines