### PR TITLE
FIX: Deep-normalize imported render configs + prevent null serialization of Option fields

### DIFF
--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -41,20 +41,26 @@ pub enum GeometricData {
     CompoundAxisAlignedPBox {
         a: [f64; 3],
         b: [f64; 3],
+        #[serde(skip_serializing_if = "Option::is_none")]
         is_culled: Option<bool>,
         material: MaterialRefOrInline,
     },
     #[serde(rename = "list")]
     CompoundList {
+        #[serde(skip_serializing_if = "Option::is_none")]
         use_bvh: Option<bool>,
         geometrics: Vec<GeometricRefOrInline>,
     },
     #[serde(rename = "obj_model")]
     CompoundModelObj {
         filename: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         origin: Option<[f64; 3]>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         scale: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         recalculate_normals: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         use_bvh: Option<bool>,
         material: MaterialRefOrInline,
     },
@@ -63,6 +69,7 @@ pub enum GeometricData {
         geometric: GeometricRefOrInline,
         #[serde(flatten)]
         angle: Angle,
+        #[serde(skip_serializing_if = "Option::is_none")]
         around: Option<[f64; 3]>,
     },
     #[serde(rename = "rotate_y")]
@@ -70,6 +77,7 @@ pub enum GeometricData {
         geometric: GeometricRefOrInline,
         #[serde(flatten)]
         angle: Angle,
+        #[serde(skip_serializing_if = "Option::is_none")]
         around: Option<[f64; 3]>,
     },
     #[serde(rename = "rotate_z")]
@@ -77,6 +85,7 @@ pub enum GeometricData {
         geometric: GeometricRefOrInline,
         #[serde(flatten)]
         angle: Angle,
+        #[serde(skip_serializing_if = "Option::is_none")]
         around: Option<[f64; 3]>,
     },
     #[serde(rename = "translate")]
@@ -89,6 +98,7 @@ pub enum GeometricData {
         lower_left: [f64; 3],
         u: [f64; 3],
         v: [f64; 3],
+        #[serde(skip_serializing_if = "Option::is_none")]
         is_culled: Option<bool>,
         material: MaterialRefOrInline,
     },
@@ -103,9 +113,13 @@ pub enum GeometricData {
         a: [f64; 3],
         b: [f64; 3],
         c: [f64; 3],
+        #[serde(skip_serializing_if = "Option::is_none")]
         a_normal: Option<[f64; 3]>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         b_normal: Option<[f64; 3]>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         c_normal: Option<[f64; 3]>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         is_culled: Option<bool>,
         material: MaterialRefOrInline,
     },

--- a/ui/src/hooks/useRenderForm.ts
+++ b/ui/src/hooks/useRenderForm.ts
@@ -1,15 +1,15 @@
 import { useForm, type DeepKeys } from '@tanstack/react-form';
-import { RenderConfigSchema, type RenderConfig } from '../utils/render/config';
+import { RenderConfigSchema, type NormalizedRenderConfig } from '../utils/render/config';
 import { getDefaultRenderConfig } from '../utils/render/templates';
 import type { User } from '../utils/api';
 
 export type UseRenderFormOptions = {
   user: User | undefined;
-  initialValues?: RenderConfig;
+  initialValues?: NormalizedRenderConfig;
 };
 
 export type RenderForm = ReturnType<typeof useRenderForm>;
-export type RenderFormPath = DeepKeys<RenderConfig>;
+export type RenderFormPath = DeepKeys<NormalizedRenderConfig>;
 
 export function useRenderForm(options: UseRenderFormOptions) {
   const { user, initialValues } = options;

--- a/ui/src/hooks/useRenderMutations.ts
+++ b/ui/src/hooks/useRenderMutations.ts
@@ -7,7 +7,7 @@ import {
   updateRenderTotalCheckpoints,
 } from '../utils/api';
 import { useAuth } from '../providers/auth';
-import type { RenderConfig } from '../utils/render/config';
+import type { NormalizedRenderConfig } from '../utils/render/config';
 
 export function useCreateRender() {
   const { mustGetToken } = useAuth();
@@ -16,7 +16,7 @@ export function useCreateRender() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (config: RenderConfig) => postRender(token, config),
+    mutationFn: (config: NormalizedRenderConfig) => postRender(token, config),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['renders'] });
     },

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -1,4 +1,4 @@
-import type { RawRenderConfig, RenderConfig } from './render/config';
+import type { RawRenderConfig, NormalizedRenderConfig } from './render/config';
 
 function getAPIURL(): string {
   // in production, the UI and API are served from the same origin (Rust embeds both)
@@ -93,7 +93,7 @@ export type PostRenderResponse = Render & {
 
 export async function postRender(
   token: string,
-  renderConfig: RenderConfig,
+  renderConfig: NormalizedRenderConfig,
 ): Promise<PostRenderResponse> {
   const response = await fetch(`${getAPIURL()}/renders`, {
     headers: {

--- a/ui/src/utils/render/camera.ts
+++ b/ui/src/utils/render/camera.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { RenderConfig } from './config';
+import type { NormalizedRenderConfig } from './config';
 import { isNonNullObject } from './utils';
 
 export const CameraDataSchema = z.object({
@@ -44,7 +44,7 @@ export type CameraDataResult = {
 };
 
 export function getCameraData(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   nameOrData: string | CameraData,
 ): CameraDataResult {
   if (isCameraData(nameOrData)) {

--- a/ui/src/utils/render/config.ts
+++ b/ui/src/utils/render/config.ts
@@ -2,18 +2,30 @@ import z from 'zod';
 import { CameraDataSchema, type NormalizedCameraData, type RawCameraData } from './camera';
 import {
   GeometricDataSchema,
+  normalizeGeometricData,
   type NormalizedGeometricData,
   type RawGeometricData,
 } from './geometric';
-import { MaterialDataSchema, type NormalizedMaterialData, type RawMaterialData } from './material';
+import {
+  MaterialDataSchema,
+  normalizeMaterialData,
+  type NormalizedMaterialData,
+  type RawMaterialData,
+} from './material';
 import { RenderParametersSchema, type RenderParameters } from './parameters';
 import {
+  normalizeSceneData,
   SceneDataSchema,
   type NormalizedSceneData,
   type RawSceneData,
   type SceneData,
 } from './scene';
-import { TextureDataSchema, type NormalizedTextureData, type RawTextureData } from './texture';
+import {
+  normalizeTextureData,
+  TextureDataSchema,
+  type NormalizedTextureData,
+  type RawTextureData,
+} from './texture';
 import { getNextUniqueName } from './utils';
 
 export const RenderConfigSchema = z.object({
@@ -27,11 +39,78 @@ export const RenderConfigSchema = z.object({
   textures: z.record(z.string(), TextureDataSchema),
 });
 
-export type RenderConfig = NormalizedRenderConfig;
+export type RenderConfig = RawRenderConfig | NormalizedRenderConfig;
 
-export function normalizeRenderConfig(config: RawRenderConfig): NormalizedRenderConfig {
+function pruneNormalizedConfig(config: NormalizedRenderConfig): void {
+  const activeScene = config.scenes?.[config.active_scene];
+  if (!activeScene) return;
+
+  const reachableCameras = new Set<string>([activeScene.camera]);
+  const reachableGeometrics = new Set<string>();
+  const reachableMaterials = new Set<string>();
+  const reachableTextures = new Set<string>();
+
+  // walk geometrics reachable from the active scene
+  const geoStack = [...activeScene.geometrics];
+  while (geoStack.length > 0) {
+    const geoName = geoStack.pop()!;
+    if (reachableGeometrics.has(geoName)) continue;
+    const geo = config.geometrics?.[geoName];
+    if (!geo) continue;
+    reachableGeometrics.add(geoName);
+
+    switch (geo.type) {
+      case 'box':
+      case 'parallelogram':
+      case 'sphere':
+      case 'triangle':
+      case 'obj_model':
+        reachableMaterials.add(geo.material);
+        break;
+      case 'translate':
+      case 'rotate_x':
+      case 'rotate_y':
+      case 'rotate_z':
+        geoStack.push(geo.geometric);
+        break;
+      case 'constant_volume':
+        geoStack.push(geo.geometric);
+        reachableTextures.add(geo.reflectance_texture);
+        break;
+      case 'list':
+        for (const childName of geo.geometrics) {
+          geoStack.push(childName);
+        }
+        break;
+    }
+  }
+
+  // walk materials to collect textures, then walk textures for checker sub-textures
+  const matStack = [...reachableMaterials];
+  while (matStack.length > 0) {
+    const matName = matStack.pop()!;
+    const mat = config.materials?.[matName];
+    if (!mat) continue;
+    for (const texName of [mat.reflectance_texture, mat.emittance_texture]) {
+      if (!reachableTextures.has(texName)) {
+        reachableTextures.add(texName);
+        collectTextureRefs(config, texName, reachableTextures);
+      }
+    }
+  }
+
+  // prune maps to reachable entries only
+  config.scenes = pick(config.scenes, new Set([config.active_scene]));
+  config.cameras = pick(config.cameras, reachableCameras);
+  config.geometrics = pick(config.geometrics, reachableGeometrics);
+  config.materials = pick(config.materials, reachableMaterials);
+  config.textures = pick(config.textures, reachableTextures);
+}
+
+export function normalizeRenderConfig(config: RenderConfig): NormalizedRenderConfig {
   const renderConfig = config;
 
+  // PASS 1: extract inline active_scene into the scenes map
   if (typeof renderConfig.active_scene !== 'string') {
     if (!renderConfig.scenes) {
       renderConfig.scenes = {};
@@ -42,7 +121,54 @@ export function normalizeRenderConfig(config: RawRenderConfig): NormalizedRender
     renderConfig.active_scene = sceneName;
   }
 
+  // PASS 2: normalize all maps — convert inline data to named references
+  for (const scene of Object.values(renderConfig.scenes ?? {})) {
+    normalizeSceneData(renderConfig, scene);
+  }
+  for (const geo of Object.values(renderConfig.geometrics ?? {})) {
+    normalizeGeometricData(renderConfig, geo);
+  }
+  for (const mat of Object.values(renderConfig.materials ?? {})) {
+    normalizeMaterialData(renderConfig, mat);
+  }
+  for (const tex of Object.values(renderConfig.textures ?? {})) {
+    normalizeTextureData(renderConfig, tex);
+  }
+
+  // PASS 3: prune unreferenced entries
+  // After normalization, the config is effectively normalized — cast at this boundary
+  pruneNormalizedConfig(renderConfig as NormalizedRenderConfig);
+
   return renderConfig as NormalizedRenderConfig;
+}
+
+function pick<T>(
+  record: Record<string, T> | undefined,
+  keys: Set<string>,
+): Record<string, T> | undefined {
+  if (!record) return record;
+  const result: Record<string, T> = {};
+  for (const key of keys) {
+    if (key in record) {
+      result[key] = record[key];
+    }
+  }
+  return result;
+}
+
+function collectTextureRefs(
+  config: NormalizedRenderConfig,
+  texName: string,
+  reachableTextures: Set<string>,
+): void {
+  const tex = config.textures?.[texName];
+  if (!tex || tex.type !== 'checker') return;
+  for (const subName of [tex.even_texture, tex.odd_texture]) {
+    if (!reachableTextures.has(subName)) {
+      reachableTextures.add(subName);
+      collectTextureRefs(config, subName, reachableTextures);
+    }
+  }
 }
 
 // NormalizedRenderConfig is the same as a RenderConfig, but with all the

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -320,7 +320,7 @@ export const GeometricBoxSchema = z.object({
   type: z.literal('box'),
   a: z.tuple([z.number(), z.number(), z.number()]),
   b: z.tuple([z.number(), z.number(), z.number()]),
-  is_culled: z.boolean().optional(),
+  is_culled: z.boolean().nullish(),
   material: z.string().nonempty(),
 });
 
@@ -359,7 +359,7 @@ export type RawGeometricBox = {
 
 export const GeometricListSchema = z.object({
   type: z.literal('list'),
-  use_bvh: z.boolean().optional(),
+  use_bvh: z.boolean().nullish(),
   geometrics: z.array(z.string().nonempty()),
 });
 
@@ -399,10 +399,10 @@ export type RawGeometricList = {
 export const GeometricObjModelSchema = z.object({
   type: z.literal('obj_model'),
   filename: z.string(),
-  origin: z.tuple([z.number(), z.number(), z.number()]).optional(),
-  scale: z.number().optional(),
-  recalculate_normals: z.boolean().optional(),
-  use_bvh: z.boolean().optional(),
+  origin: z.tuple([z.number(), z.number(), z.number()]).nullish(),
+  scale: z.number().nullish(),
+  recalculate_normals: z.boolean().nullish(),
+  use_bvh: z.boolean().nullish(),
   material: z.string().nonempty(),
 });
 
@@ -445,6 +445,7 @@ export const GeometricInstanceRotateXSchema = z
   .object({
     type: z.literal('rotate_x'),
     geometric: z.string().nonempty(),
+    around: z.tuple([z.number(), z.number(), z.number()]).nullish(),
   })
   .and(AngleSchema);
 
@@ -452,6 +453,7 @@ export const GeometricInstanceRotateYSchema = z
   .object({
     type: z.literal('rotate_y'),
     geometric: z.string().nonempty(),
+    around: z.tuple([z.number(), z.number(), z.number()]).nullish(),
   })
   .and(AngleSchema);
 
@@ -459,6 +461,7 @@ export const GeometricInstanceRotateZSchema = z
   .object({
     type: z.literal('rotate_z'),
     geometric: z.string().nonempty(),
+    around: z.tuple([z.number(), z.number(), z.number()]).nullish(),
   })
   .and(AngleSchema);
 
@@ -548,7 +551,7 @@ export const GeometricParallelogramSchema = z.object({
   lower_left: z.tuple([z.number(), z.number(), z.number()]),
   u: z.tuple([z.number(), z.number(), z.number()]),
   v: z.tuple([z.number(), z.number(), z.number()]),
-  is_culled: z.boolean().optional(),
+  is_culled: z.boolean().nullish(),
   material: z.string().nonempty(),
 });
 
@@ -630,10 +633,10 @@ export const GeometricTriangleSchema = z.object({
   a: z.tuple([z.number(), z.number(), z.number()]),
   b: z.tuple([z.number(), z.number(), z.number()]),
   c: z.tuple([z.number(), z.number(), z.number()]),
-  a_normal: z.tuple([z.number(), z.number(), z.number()]).optional(),
-  b_normal: z.tuple([z.number(), z.number(), z.number()]).optional(),
-  c_normal: z.tuple([z.number(), z.number(), z.number()]).optional(),
-  is_culled: z.boolean().optional(),
+  a_normal: z.tuple([z.number(), z.number(), z.number()]).nullish(),
+  b_normal: z.tuple([z.number(), z.number(), z.number()]).nullish(),
+  c_normal: z.tuple([z.number(), z.number(), z.number()]).nullish(),
+  is_culled: z.boolean().nullish(),
   material: z.string().nonempty(),
 });
 
@@ -747,30 +750,28 @@ const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   constant_volume: GeometricConstantVolumeSchema,
 };
 
-export const GeometricDataSchema = z
-  .any()
-  .superRefine((data, ctx) => {
-    if (typeof data !== 'object' || data === null || !('type' in data)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Geometric data must be an object with a type field',
-      });
-      return;
-    }
+export const GeometricDataSchema = z.any().superRefine((data, ctx) => {
+  if (typeof data !== 'object' || data === null || !('type' in data)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Geometric data must be an object with a type field',
+    });
+    return;
+  }
 
-    const schema = geometricSchemaByType[data.type as string];
-    if (!schema) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Unknown geometric type: ${data.type}`,
-      });
-      return;
-    }
+  const schema = geometricSchemaByType[data.type as string];
+  if (!schema) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Unknown geometric type: ${data.type}`,
+    });
+    return;
+  }
 
-    const result = schema.safeParse(data);
-    if (!result.success) {
-      for (const issue of result.error.issues) {
-        ctx.addIssue(issue);
-      }
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      ctx.addIssue(issue);
     }
-  }) as z.ZodType<NormalizedGeometricData>;
+  }
+}) as z.ZodType<NormalizedGeometricData>;

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -179,7 +179,7 @@ export type GeometricDataResult = {
 };
 
 export function getGeometricDataSafe(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   nameOrData: string | GeometricData,
 ): GeometricDataResult {
   try {
@@ -194,7 +194,7 @@ export function getGeometricDataSafe(
 }
 
 export function getGeometricData(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   nameOrData: string | GeometricData,
 ): GeometricDataResult {
   if (isGeometricData(nameOrData)) {

--- a/ui/src/utils/render/material.ts
+++ b/ui/src/utils/render/material.ts
@@ -55,7 +55,7 @@ export type MaterialDataResult = {
 };
 
 export function getMaterialDataSafe(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   nameOrData: string | MaterialData,
 ): MaterialDataResult {
   try {
@@ -70,7 +70,7 @@ export function getMaterialDataSafe(
 }
 
 export function getMaterialData(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   nameOrData: string | MaterialData,
 ): MaterialDataResult {
   if (isMaterialData(nameOrData)) {

--- a/ui/src/utils/render/scene.ts
+++ b/ui/src/utils/render/scene.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { type RawCameraData } from './camera';
-import type { RenderConfig } from './config';
+import type { RenderConfig, NormalizedRenderConfig } from './config';
 import { normalizeGeometricData, type RawGeometricData } from './geometric';
 import { capitalize, getNextUniqueName, isNonNullObject } from './utils';
 
@@ -65,7 +65,7 @@ export function isSceneData(x: unknown): x is SceneData {
   );
 }
 
-export function getSceneData(config: RenderConfig, nameOrData: string | SceneData): SceneData {
+export function getSceneData(config: NormalizedRenderConfig, nameOrData: string | SceneData): SceneData {
   if (isSceneData(nameOrData)) {
     return nameOrData;
   }

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -1,4 +1,4 @@
-import type { RenderConfig } from './config';
+import type { NormalizedRenderConfig } from './config';
 import type { GeometricData } from './geometric';
 import type { MaterialData } from './material';
 import type { TextureData } from './texture';
@@ -8,7 +8,7 @@ export type Template = {
   name: string;
   description: string;
   thumbnail?: string;
-  config: RenderConfig;
+  config: NormalizedRenderConfig;
 };
 
 export const TEMPLATES: Template[] = [
@@ -27,11 +27,11 @@ export const TEMPLATES: Template[] = [
   },
 ];
 
-export function getDefaultRenderConfig(): RenderConfig {
+export function getDefaultRenderConfig(): NormalizedRenderConfig {
   return getCornellBoxRenderConfig();
 }
 
-export function getEmptyRenderConfig(): RenderConfig {
+export function getEmptyRenderConfig(): NormalizedRenderConfig {
   return withDefaultResources({
     name: 'Empty',
     parameters: {
@@ -69,7 +69,7 @@ export function getEmptyRenderConfig(): RenderConfig {
   });
 }
 
-export function getCornellBoxRenderConfig(): RenderConfig {
+export function getCornellBoxRenderConfig(): NormalizedRenderConfig {
   return withDefaultResources({
     name: 'Cornell Box',
     parameters: {
@@ -242,7 +242,7 @@ export function getCornellBoxRenderConfig(): RenderConfig {
   });
 }
 
-function withDefaultResources(config: RenderConfig): RenderConfig {
+function withDefaultResources(config: NormalizedRenderConfig): NormalizedRenderConfig {
   return {
     ...config,
     geometrics: {

--- a/ui/src/utils/render/texture.ts
+++ b/ui/src/utils/render/texture.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { RenderConfig } from './config';
+import type { RenderConfig, NormalizedRenderConfig } from './config';
 import { capitalize, getNextUniqueName, isTypedObject } from './utils';
 
 export type TextureData = NormalizedTextureData;
@@ -36,7 +36,7 @@ export type TextureDataResult = {
 };
 
 export function getTextureDataSafe(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   nameOrData: string | TextureData,
 ): TextureDataResult {
   try {
@@ -51,7 +51,7 @@ export function getTextureDataSafe(
 }
 
 export function getTextureData(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   nameOrData: string | TextureData,
 ): TextureDataResult {
   if (isTextureData(nameOrData)) {

--- a/ui/src/utils/render/utils.ts
+++ b/ui/src/utils/render/utils.ts
@@ -1,6 +1,6 @@
 import { degreesToRadians, radiansToDegrees } from '../math';
 import { z } from 'zod';
-import type { RenderConfig } from './config';
+import type { NormalizedRenderConfig } from './config';
 
 /* CONFIG HELPER FUNCTIONS */
 
@@ -8,7 +8,7 @@ export function removeDefaults(array: string[]) {
   return array.filter((item) => !item.startsWith('__'));
 }
 
-export function getTopLevelGeometricNames(config: RenderConfig) {
+export function getTopLevelGeometricNames(config: NormalizedRenderConfig) {
   return Object.keys(config.geometrics ?? {}).filter(
     (name) =>
       !Object.values(config.geometrics ?? {})
@@ -30,11 +30,11 @@ export function getTopLevelGeometricNames(config: RenderConfig) {
   );
 }
 
-export function getTopLevelMaterialNames(config: RenderConfig) {
+export function getTopLevelMaterialNames(config: NormalizedRenderConfig) {
   return Object.keys(config.materials ?? {});
 }
 
-export function getTopLevelTextureNames(config: RenderConfig) {
+export function getTopLevelTextureNames(config: NormalizedRenderConfig) {
   return Object.keys(config.textures ?? {}).filter(
     (name) =>
       !Object.values(config.textures ?? {})
@@ -107,7 +107,7 @@ export function toDegrees(angle: Angle): number {
  * replaces broken references with default values (__white, __black, __lambertian_white, __unit_box).
  * also filters deleted items from the active scene's geometric list and list-type geometrics.
  */
-export function fixReferences(config: RenderConfig): RenderConfig {
+export function fixReferences(config: NormalizedRenderConfig): NormalizedRenderConfig {
   const newConfig = { ...config };
   const textures = newConfig.textures ?? {};
   const materials = newConfig.materials ?? {};
@@ -208,7 +208,7 @@ function moveKey<T>(
  * renames a camera and updates all scene references
  * throughout the config to point to the new name.
  */
-export function renameCamera(config: RenderConfig, oldName: string, newName: string): RenderConfig {
+export function renameCamera(config: NormalizedRenderConfig, oldName: string, newName: string): NormalizedRenderConfig {
   const newConfig = { ...config };
   newConfig.cameras = moveKey(newConfig.cameras, oldName, newName);
 
@@ -227,10 +227,10 @@ export function renameCamera(config: RenderConfig, oldName: string, newName: str
  * throughout the config to point to the new name.
  */
 export function renameTexture(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   oldName: string,
   newName: string,
-): RenderConfig {
+): NormalizedRenderConfig {
   const newConfig = { ...config };
   newConfig.textures = moveKey(newConfig.textures, oldName, newName);
 
@@ -285,10 +285,10 @@ export function renameTexture(
  * throughout the config to point to the new name.
  */
 export function renameMaterial(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   oldName: string,
   newName: string,
-): RenderConfig {
+): NormalizedRenderConfig {
   const newConfig = { ...config };
   newConfig.materials = moveKey(newConfig.materials, oldName, newName);
 
@@ -317,10 +317,10 @@ export function renameMaterial(
  * and scene references throughout the config to point to the new name.
  */
 export function renameGeometric(
-  config: RenderConfig,
+  config: NormalizedRenderConfig,
   oldName: string,
   newName: string,
-): RenderConfig {
+): NormalizedRenderConfig {
   const newConfig = { ...config };
   newConfig.geometrics = moveKey(newConfig.geometrics, oldName, newName);
 

--- a/ui/src/views/renders/CreateRenderModal/ImportConfigModal/ImportConfigBody.tsx
+++ b/ui/src/views/renders/CreateRenderModal/ImportConfigModal/ImportConfigBody.tsx
@@ -1,12 +1,12 @@
 import { useState, useRef, useCallback } from 'react';
 import { Button, ModalHeader, ModalBody, ModalFooter } from 'flowbite-react';
 import { HiFolderOpen } from 'react-icons/hi2';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { RenderConfigSchema, normalizeRenderConfig } from '@/utils/render/config';
 import { RenderConfigEditor } from './RenderConfigEditor';
 
 export type ImportConfigBodyProps = {
-  onImportSuccess: (config: RenderConfig) => void;
+  onImportSuccess: (config: NormalizedRenderConfig) => void;
   onCancel?: () => void;
 };
 

--- a/ui/src/views/renders/CreateRenderModal/index.tsx
+++ b/ui/src/views/renders/CreateRenderModal/index.tsx
@@ -4,7 +4,7 @@ import { Modal } from 'flowbite-react';
 import { SourceChoice } from './SourceChoice';
 import { TemplatePicker } from './TemplatePicker';
 import { ImportConfigBody } from './ImportConfigModal/ImportConfigBody';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 import type { Template } from '@/utils/render/templates';
 
 type Stage = 'source-choice' | 'template-picker' | 'import-json';
@@ -31,7 +31,7 @@ export function CreateRenderModal(props: CreateRenderModalProps) {
     onClose();
   };
 
-  const handleImportSuccess = (config: RenderConfig) => {
+  const handleImportSuccess = (config: NormalizedRenderConfig) => {
     navigate('/renders/new', { state: { importedConfig: config } });
     onClose();
   };

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/NestedGeometricHeader.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/NestedGeometricHeader.tsx
@@ -1,10 +1,10 @@
 import { Separator } from '@/components/Separator';
 import { getGeometricData } from '@/utils/render/geometric';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 
 interface NestedGeometricHeaderProps {
   geometricName: string;
-  renderConfig: RenderConfig;
+  renderConfig: NormalizedRenderConfig;
 }
 
 export function NestedGeometricHeader(props: NestedGeometricHeaderProps) {

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
@@ -6,7 +6,7 @@ import { RangeControl } from '../form-controls/RangeControl';
 import { SelectControl } from '../form-controls/SelectControl';
 import { getGeometricData, getGeometricDataSafe } from '@/utils/render/geometric';
 import { fixReferences, renameGeometric } from '@/utils/render/utils';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
 import { Separator } from '@/components/Separator';
@@ -60,7 +60,7 @@ export function ControlsCardGeometric(props: ControlsCardGeometricProps) {
     const newGeometrics = { ...renderConfig.geometrics };
     delete newGeometrics[name];
 
-    const newConfig: RenderConfig = {
+    const newConfig: NormalizedRenderConfig = {
       ...renderConfig,
       geometrics: newGeometrics,
     };

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
@@ -3,7 +3,7 @@ import { RangeControl } from './form-controls/RangeControl';
 import { SelectControl } from './form-controls/SelectControl';
 import { getMaterialData } from '@/utils/render/material';
 import { fixReferences, renameMaterial } from '@/utils/render/utils';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
 
@@ -37,7 +37,7 @@ export function ControlsCardMaterial(props: ControlsCardMaterialProps) {
     const newMaterials = { ...renderConfig.materials };
     delete newMaterials[name];
 
-    const newConfig: RenderConfig = {
+    const newConfig: NormalizedRenderConfig = {
       ...renderConfig,
       materials: newMaterials,
     };

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardTexture/NestedTextureHeader.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardTexture/NestedTextureHeader.tsx
@@ -1,10 +1,10 @@
 import { Separator } from '@/components/Separator';
 import { getTextureData } from '@/utils/render/texture';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 
 interface NestedTextureHeaderProps {
   textureName: string;
-  renderConfig: RenderConfig;
+  renderConfig: NormalizedRenderConfig;
 }
 
 export function NestedTextureHeader(props: NestedTextureHeaderProps) {

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardTexture/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardTexture/index.tsx
@@ -5,7 +5,7 @@ import { InfoIconAdditionalInfo } from '@/views/renders/new/Controls/icons/InfoI
 import { NestedTextureHeader } from './NestedTextureHeader';
 import { getTextureData } from '@/utils/render/texture';
 import { fixReferences, renameTexture } from '@/utils/render/utils';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
 import { Separator } from '@/components/Separator';
@@ -40,7 +40,7 @@ export function ControlsCardTexture(props: ControlsCardTextureProps) {
     const newTextures = { ...renderConfig.textures };
     delete newTextures[name];
 
-    const newConfig: RenderConfig = {
+    const newConfig: NormalizedRenderConfig = {
       ...renderConfig,
       textures: newTextures,
     };

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -2,10 +2,10 @@ import { getGeometricDataSafe } from '@/utils/render/geometric';
 import { toRadians } from '@/utils/render/utils';
 import { createParallelogramMesh, createTriangleMesh } from '@/utils/three';
 import { MaterialResolver } from './MaterialResolver';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 
 interface GeometricRendererProps {
-  config: RenderConfig;
+  config: NormalizedRenderConfig;
   name: string;
   rotation?: [number, number, number];
 }

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -4,10 +4,10 @@ import { getMaterialDataSafe } from '@/utils/render/material';
 import { getTextureDataSafe } from '@/utils/render/texture';
 import { isComposite, getCenterPoint } from '@/utils/render/geometric';
 import { getGeometricDataSafe } from '@/utils/render/geometric';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 
 interface MaterialResolverProps {
-  config: RenderConfig;
+  config: NormalizedRenderConfig;
   materialRef: string;
   geometricName: string;
 }

--- a/ui/src/views/renders/new/index.tsx
+++ b/ui/src/views/renders/new/index.tsx
@@ -4,13 +4,13 @@ import { useAuth } from '@/providers/auth';
 import { useRenderForm } from '@/hooks/useRenderForm';
 import { NewRenderSidebar } from './NewRenderSidebar';
 import { Scene } from './Scene';
-import type { RenderConfig } from '@/utils/render/config';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { useSelector } from '@tanstack/react-store';
 
 export function NewRenderPage() {
   const { user } = useAuth();
   const location = useLocation();
-  const importedConfig = location.state?.importedConfig as RenderConfig | undefined;
+  const importedConfig = location.state?.importedConfig as NormalizedRenderConfig | undefined;
 
   // canvas container sizing
   const containerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Problem

When copying a render config from an existing render's API response and pasting it into the new render form, two things go wrong:

1. **Zod validation rejects `null`**: Rust's serde serializes `Option::None` as JSON `null` by default. The `GeometricData` enum had no `#[serde(skip_serializing_if)]` on any `Option<T>` fields, so absent optional fields appeared as `"field": null` in API responses. The frontend Zod schemas used `.optional()` which only accepts `undefined` (missing), not `null`.

2. **Inline data isn't normalized on import**: The import modal called `normalizeRenderConfig` which only handled the top-level `active_scene` — it didn't recursively extract inline geometrics/materials/textures into named references. A config copied from the API could have inline data that made it through to the form.

## Changes

### Backend (`src/deserialization/geometrics.rs`)
Added `#[serde(skip_serializing_if = "Option::is_none")]` to all 13 `Option<T>` fields in the `GeometricData` enum:
`is_culled` (box, parallelogram, triangle), `a/b/c_normal` (triangle), `use_bvh` (list, obj_model), `origin`, `scale`, `recalculate_normals` (obj_model), `around` (rotate_x/y/z).

### Frontend — Zod validation (`ui/src/utils/render/geometric.ts`)
- Changed `.optional()` → `.nullish()` on all matching Zod fields (accepts `null` as well as `undefined`)
- Added missing `around` field to rotate_x/y/z Zod schemas (was completely absent, silently stripped)

### Frontend — Deep normalization on import (`ui/src/utils/render/config.ts`)
Rewrote `normalizeRenderConfig` to do three passes:
1. Extract inline `active_scene` into the scenes map
2. Recursively normalize all maps (geometrics, materials, textures, scenes) — inline data extracted to named references
3. Prune: remove non-active scenes and unreferenced geometrics/materials/textures/cameras

### Frontend — Type hierarchy cleanup (21 files)
Changed `RenderConfig` from an alias of `NormalizedRenderConfig` to a clean union: `RawRenderConfig | NormalizedRenderConfig`. All normalize functions now accept the union; all consumers use `NormalizedRenderConfig` explicitly.