### PR TITLE
feat: improve landing page, polish navbar, add global gradient background

### DIFF
--- a/ui/src/layouts/Layout/LayoutNavbar/index.tsx
+++ b/ui/src/layouts/Layout/LayoutNavbar/index.tsx
@@ -9,8 +9,11 @@ import {
 import type { DeepPartial } from 'flowbite-react/types';
 import { UserBadge } from './UserBadge';
 import { Link } from 'react-router-dom';
+import { useAuth } from '@/providers/auth';
 
 export function LayoutNavbar() {
+  const { isAuthenticated } = useAuth();
+
   const navbarTheme: DeepPartial<NavbarTheme> = {
     root: {
       base: 'bg-zinc-900 border-b border-zinc-800 px-4 h-16 dark:bg-zinc-900 dark:border-zinc-800',
@@ -22,7 +25,7 @@ export function LayoutNavbar() {
 
   return (
     <Navbar fluid theme={navbarTheme}>
-      <div className="flex items-baseline gap-4">
+      <div className="flex flex-1 items-baseline gap-4">
         {/* @ts-expect-error polymorphic 'as' prop not typed in flowbite-react */}
         <NavbarBrand as={Link} to="/">
           <span className="self-center text-xl font-semibold whitespace-nowrap text-white">
@@ -33,15 +36,17 @@ export function LayoutNavbar() {
           {__APP_VERSION__}
         </span>
       </div>
-      <div className="flex md:order-2">
+      <div className="flex flex-1 justify-end md:order-2">
         <UserBadge />
         <NavbarToggle />
       </div>
       <NavbarCollapse>
-        {/* @ts-expect-error polymorphic 'as' prop not typed in flowbite-react */}
-        <NavbarLink as={Link} to="/renders">
-          Renders
-        </NavbarLink>
+        {isAuthenticated && (
+          // @ts-expect-error polymorphic 'as' prop not typed in flowbite-react
+          <NavbarLink as={Link} to="/renders">
+            Renders
+          </NavbarLink>
+        )}
       </NavbarCollapse>
     </Navbar>
   );

--- a/ui/src/layouts/Layout/index.tsx
+++ b/ui/src/layouts/Layout/index.tsx
@@ -11,8 +11,14 @@ export function Layout() {
   return (
     <div className="flex h-screen flex-col">
       <LayoutNavbar />
-      <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-zinc-950 text-zinc-200">
-        <Outlet />
+      <main className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-zinc-950 text-zinc-200">
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_20%,var(--color-primary-500)_0%,transparent_60%)] opacity-10" />
+          <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_70%_80%,var(--color-secondary-500)_0%,transparent_60%)] opacity-10" />
+        </div>
+        <div className="relative z-10 flex min-h-0 flex-1 flex-col">
+          <Outlet />
+        </div>
       </main>
     </div>
   );

--- a/ui/src/views/index.tsx
+++ b/ui/src/views/index.tsx
@@ -1,15 +1,97 @@
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import { Button } from 'flowbite-react';
+import { motion } from 'framer-motion';
+import { useAuth } from '@/providers/auth';
+import { navigateToAPILogin } from '@/utils/api';
+import type { User } from '@/utils/api';
+import { FaGithub } from 'react-icons/fa';
 
 export function HomePage() {
+  const { isAuthenticated, user } = useAuth();
+
   return (
-    <div className="flex flex-1 items-center justify-center">
-      <h1 className="text-2xl">
-        Perhaps you're looking for the{' '}
-        <Link to="/renders" className="text-blue-500 hover:underline">
-          renders page
-        </Link>
-        ?
-      </h1>
+    <div className="relative flex flex-1 items-center justify-center">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_20%,var(--color-primary-500)_0%,transparent_60%)] opacity-50" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_70%_80%,var(--color-secondary-500)_0%,transparent_60%)] opacity-50" />
+      </div>
+      {isAuthenticated && user ? <AuthenticatedWelcome user={user} /> : <LandingHero />}
+    </div>
+  );
+}
+
+function LandingHero() {
+  return (
+    <div className="relative z-10 flex flex-col items-center gap-6 text-center">
+      <motion.h1
+        className="from-primary-400 to-secondary-400 bg-linear-to-r bg-clip-text text-6xl font-bold text-transparent"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1, duration: 0.5 }}
+      >
+        Luxide
+      </motion.h1>
+      <motion.p
+        className="text-lg text-white"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.5 }}
+      >
+        Path Tracing Render Manager
+      </motion.p>
+      <motion.p
+        className="max-w-md text-white"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3, duration: 0.5 }}
+      >
+        Create, monitor, and manage path-traced renders with a powerful multi-tenant platform.
+      </motion.p>
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.5, duration: 0.5 }}
+      >
+        <Button color="default" onClick={() => navigateToAPILogin().catch(console.error)}>
+          <FaGithub className="mr-2 h-5 w-5" />
+          Log in with GitHub
+        </Button>
+      </motion.div>
+    </div>
+  );
+}
+
+function AuthenticatedWelcome({ user }: { user: User }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="relative z-10 flex flex-col items-center gap-6 text-center">
+      <motion.img
+        src={user.avatar_url}
+        alt={`${user.username}'s avatar`}
+        className="h-20 w-20 rounded-full border-2 border-zinc-700"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1, duration: 0.5 }}
+      />
+      <motion.h1
+        className="text-3xl font-bold text-white"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.5 }}
+      >
+        Welcome back, {user.username}
+      </motion.h1>
+      <motion.div
+        className="flex gap-4"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3, duration: 0.5 }}
+      >
+        <Button color="default" onClick={() => navigate('/renders')}>
+          View Renders
+        </Button>
+      </motion.div>
     </div>
   );
 }

--- a/ui/src/views/index.tsx
+++ b/ui/src/views/index.tsx
@@ -54,7 +54,7 @@ function LandingHero() {
       >
         <Button color="default" onClick={() => navigateToAPILogin().catch(console.error)}>
           <FaGithub className="mr-2 h-5 w-5" />
-          Log in with GitHub
+          Sign in with GitHub
         </Button>
       </motion.div>
     </div>


### PR DESCRIPTION
### Landing Page (`ui/src/views/index.tsx`)
- Replaced the bare redirect hint with an auth-aware landing page
- **Visitors** see a hero section with "Luxide" in gradient text, tagline, description, and "Sign in with GitHub" button — with framer-motion fade-in animations and a two-tone sky-blue + pink radial glow
- **Logged-in users** see a personalized welcome with avatar, username, and a "View Renders" button

### Navbar (`ui/src/layouts/Layout/LayoutNavbar/index.tsx`)
- "Renders" link hidden when not authenticated
- "Renders" link centered dead-center on the page using `flex-1` on both side groups (was offset right due to wider brand text)

### Layout (`ui/src/layouts/Layout/index.tsx`)
- Extremely muted two-tone gradient background added to all pages via the Layout's `<main>` element (`opacity-10` sky-blue + pink radials, behind all page content)