### PR TITLE
feat: add Clone Existing option to new render modal

### DIFF
--- a/ui/src/views/renders/CreateRenderModal/ExistingRenderPicker.tsx
+++ b/ui/src/views/renders/CreateRenderModal/ExistingRenderPicker.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { Button, ModalHeader, ModalBody, ModalFooter, Spinner, Alert } from 'flowbite-react';
+import { HiArrowLeft } from 'react-icons/hi2';
+import { useRenders } from '@/hooks/useRenders';
+import { normalizeRenderConfig, type NormalizedRenderConfig } from '@/utils/render/config';
+import {
+  isRenderStateCreated,
+  isRenderStateRunning,
+  isRenderStatePausing,
+  isRenderStatePaused,
+  isRenderStateFinishedCheckpointIteration,
+  type RenderState,
+} from '@/utils/api';
+
+export type ExistingRenderPickerProps = {
+  onSelect: (config: NormalizedRenderConfig) => void;
+  onBack: () => void;
+};
+
+function getStateLabel(state: RenderState): string {
+  if (isRenderStateCreated(state)) return 'created';
+  if (isRenderStateRunning(state)) return 'running';
+  if (isRenderStatePausing(state)) return 'pausing';
+  if (isRenderStatePaused(state)) return 'paused';
+  if (isRenderStateFinishedCheckpointIteration(state)) return 'finished';
+  return 'unknown';
+}
+
+export function ExistingRenderPicker(props: ExistingRenderPickerProps) {
+  const { onSelect, onBack } = props;
+
+  const { data: renders, isLoading, isError } = useRenders();
+  const [selectedRenderId, setSelectedRenderId] = useState<number | null>(null);
+  const selectedRender = selectedRenderId
+    ? (renders?.find((r) => r.id === selectedRenderId) ?? null)
+    : null;
+
+  const handleUseConfig = () => {
+    if (!selectedRender) return;
+    const normalizedConfig = normalizeRenderConfig(selectedRender.config);
+    onSelect(normalizedConfig);
+  };
+
+  const getStateBadgeClasses = (state: RenderState): string => {
+    const label = getStateLabel(state);
+    const base = 'rounded-full px-2 py-0.5 text-xs';
+    if (label === 'created' || label === 'finished') {
+      return `${base} bg-zinc-600 text-zinc-300`;
+    }
+    if (label === 'running') {
+      return `${base} bg-blue-900 text-blue-300`;
+    }
+    if (label === 'pausing' || label === 'paused') {
+      return `${base} bg-yellow-900 text-yellow-300`;
+    }
+    return `${base} bg-zinc-600 text-zinc-300`;
+  };
+
+  return (
+    <>
+      <ModalHeader>Clone Existing Render</ModalHeader>
+      <ModalBody>
+        {isLoading && (
+          <div className="flex justify-center py-8">
+            <Spinner />
+          </div>
+        )}
+        {isError && (
+          <Alert color="failure">Failed to load renders. Please try again.</Alert>
+        )}
+        {!isLoading && !isError && renders && renders.length === 0 && (
+          <p className="py-8 text-center text-zinc-400">No existing renders to clone.</p>
+        )}
+        {!isLoading && !isError && renders && renders.length > 0 && (
+          <ul className="space-y-1">
+            {renders.map((render) => {
+              const isSelected = selectedRenderId === render.id;
+
+              return (
+                <li key={render.id}>
+                  <button
+                    type="button"
+                    className={`w-full rounded px-3 py-2 text-left ${
+                      isSelected ? 'bg-zinc-700' : 'hover:bg-zinc-800'
+                    }`}
+                    onClick={() => setSelectedRenderId(render.id)}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-zinc-200">{render.config.name}</span>
+                        <span className="text-sm text-zinc-500">#{render.id}</span>
+                      </div>
+                      <span className={getStateBadgeClasses(render.state)}>
+                        {getStateLabel(render.state)}
+                      </span>
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </ModalBody>
+      <ModalFooter className="justify-between">
+        <Button color="gray" onClick={onBack}>
+          <HiArrowLeft className="mr-1 h-4 w-4" />
+          Back
+        </Button>
+        {selectedRender && (
+          <Button color="default" onClick={handleUseConfig}>
+            Use This Config
+          </Button>
+        )}
+      </ModalFooter>
+    </>
+  );
+}

--- a/ui/src/views/renders/CreateRenderModal/SourceChoice.tsx
+++ b/ui/src/views/renders/CreateRenderModal/SourceChoice.tsx
@@ -1,16 +1,17 @@
 import { Card, Button, ModalHeader, ModalBody, ModalFooter } from 'flowbite-react';
-import { HiDocumentText, HiArrowUpTray } from 'react-icons/hi2';
+import { HiDocumentText, HiArrowUpTray, HiDocumentDuplicate } from 'react-icons/hi2';
 import type { DeepPartial } from 'flowbite-react/types';
 import type { CardTheme } from 'flowbite-react';
 
 export type SourceChoiceProps = {
   onSelectTemplate: () => void;
   onSelectImportJSON: () => void;
+  onSelectCloneExisting: () => void;
   onCancel: () => void;
 };
 
 export function SourceChoice(props: SourceChoiceProps) {
-  const { onSelectTemplate, onSelectImportJSON, onCancel } = props;
+  const { onSelectTemplate, onSelectImportJSON, onSelectCloneExisting, onCancel } = props;
 
   const cardTheme: DeepPartial<CardTheme> = {
     root: {
@@ -20,25 +21,32 @@ export function SourceChoice(props: SourceChoiceProps) {
   };
 
   const buttonClassName =
-    'flex h-full w-full flex-col items-center justify-center gap-2 p-6 text-zinc-200 hover:bg-zinc-900 hover:rounded-lg';
+    'flex h-full w-full flex-col items-center justify-center gap-2 p-6 text-center text-wrap text-zinc-200 hover:bg-zinc-900 hover:rounded-lg';
 
   return (
     <>
       <ModalHeader>New Render</ModalHeader>
       <ModalBody>
-        <div className="flex gap-4">
-          <Card theme={cardTheme} className="flex-1">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <Card theme={cardTheme}>
             <button type="button" onClick={onSelectTemplate} className={buttonClassName}>
               <HiDocumentText className="h-8 w-8" />
               <span className="text-base font-normal">Template</span>
               <span className="text-sm text-zinc-400">Start from a built-in template</span>
             </button>
           </Card>
-          <Card theme={cardTheme} className="flex-1">
+          <Card theme={cardTheme}>
             <button type="button" onClick={onSelectImportJSON} className={buttonClassName}>
               <HiArrowUpTray className="h-8 w-8" />
               <span className="text-base font-normal">Import JSON</span>
               <span className="text-sm text-zinc-400">Paste or upload a config file</span>
+            </button>
+          </Card>
+          <Card theme={cardTheme}>
+            <button type="button" onClick={onSelectCloneExisting} className={buttonClassName}>
+              <HiDocumentDuplicate className="h-8 w-8" />
+              <span className="text-base font-normal">Clone Existing</span>
+              <span className="text-sm text-zinc-400">Start from an existing render's config</span>
             </button>
           </Card>
         </div>

--- a/ui/src/views/renders/CreateRenderModal/index.tsx
+++ b/ui/src/views/renders/CreateRenderModal/index.tsx
@@ -4,10 +4,11 @@ import { Modal } from 'flowbite-react';
 import { SourceChoice } from './SourceChoice';
 import { TemplatePicker } from './TemplatePicker';
 import { ImportConfigBody } from './ImportConfigModal/ImportConfigBody';
+import { ExistingRenderPicker } from './ExistingRenderPicker';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import type { Template } from '@/utils/render/templates';
 
-type Stage = 'source-choice' | 'template-picker' | 'import-json';
+type Stage = 'source-choice' | 'template-picker' | 'import-json' | 'render-picker';
 
 export type CreateRenderModalProps = {
   show: boolean;
@@ -36,12 +37,19 @@ export function CreateRenderModal(props: CreateRenderModalProps) {
     onClose();
   };
 
+  const handleExistingRenderSelect = (config: NormalizedRenderConfig) => {
+    const modifiedConfig = { ...config, name: `${config.name} (copy)` };
+    navigate('/renders/new', { state: { importedConfig: modifiedConfig } });
+    onClose();
+  };
+
   return (
     <Modal show={show} onClose={handleClose} size="xl" dismissible>
       {stage === 'source-choice' && (
         <SourceChoice
           onSelectTemplate={() => setStage('template-picker')}
           onSelectImportJSON={() => setStage('import-json')}
+          onSelectCloneExisting={() => setStage('render-picker')}
           onCancel={handleClose}
         />
       )}
@@ -52,6 +60,12 @@ export function CreateRenderModal(props: CreateRenderModalProps) {
         <ImportConfigBody
           onImportSuccess={handleImportSuccess}
           onCancel={() => setStage('source-choice')}
+        />
+      )}
+      {stage === 'render-picker' && (
+        <ExistingRenderPicker
+          onSelect={handleExistingRenderSelect}
+          onBack={() => setStage('source-choice')}
         />
       )}
     </Modal>


### PR DESCRIPTION
Adds a third source choice ("Clone Existing") to the CreateRenderModal that lets users start a new render from an existing render's config. 

**Flow:**
1. Click "New Render" → modal shows three options: Template, Import JSON, **Clone Existing**
2. Selecting "Clone Existing" → shows a list of the user's existing renders (name, #ID, state badge)
3. User clicks a render → clicks "Use This Config"
4. The render's config is normalized, name gets ` (copy)` appended, and the form is pre-filled

**Changes:**
- `SourceChoice.tsx` — added Clone Existing card with `HiDocumentDuplicate` icon, responsive grid layout
- `ExistingRenderPicker.tsx` — new component listing renders with state badges and back/confirm buttons
- `CreateRenderModal/index.tsx` — added `render-picker` stage, handler, and rendering case