### PR TITLE
fix: resolve dropdown z-index conflict with layout content wrapper

### DIFF
--- a/ui/src/layouts/Layout/index.tsx
+++ b/ui/src/layouts/Layout/index.tsx
@@ -16,7 +16,7 @@ export function Layout() {
           <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_20%,var(--color-primary-500)_0%,transparent_60%)] opacity-10" />
           <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_70%_80%,var(--color-secondary-500)_0%,transparent_60%)] opacity-10" />
         </div>
-        <div className="relative z-10 flex min-h-0 flex-1 flex-col">
+        <div className="relative z-0 flex min-h-0 flex-1 flex-col">
           <Outlet />
         </div>
       </main>


### PR DESCRIPTION
## Summary

The user profile dropdown in the navbar was rendering **behind** page content (e.g., render cards on `/renders`), making it appear non-functional.

## Root Cause

PR #100 introduced a `z-10` on the Layout content wrapper to layer it above the new gradient background. However, the Dropdown's floating menu also uses `z-10` (from the Flowbite theme). Both at the same z-index level in the same stacking context, the **later-in-DOM** content wrapper painted **on top** of the **earlier-in-DOM** dropdown.

## Fix

Changed `z-10` → `z-0` on the content wrapper div in `ui/src/layouts/Layout/index.tsx`. This:

- Keeps the stacking context boundary (important for any absolute-positioned children in page content)
- Lowers the wrapper to level 0 so the dropdown at `z-10` renders above
- The gradient stays behind content because both are at `auto/0` level and content comes later in DOM order

## Files Changed

- `ui/src/layouts/Layout/index.tsx` — one character: `z-10` → `z-0`