### PR TITLE
fix: handle missing checkpoint image gracefully instead of showing 404 error (#107)

### DIFF
--- a/ui/src/hooks/useLatestCheckpointImage.ts
+++ b/ui/src/hooks/useLatestCheckpointImage.ts
@@ -5,31 +5,36 @@ import { useAuth } from '../providers/auth';
 
 export type UseLatestCheckpointImageOptions = {
   renderID: number;
+  enabled?: boolean;
 };
 
 export function useLatestCheckpointImage(options: UseLatestCheckpointImageOptions) {
-  const { renderID } = options;
+  const { renderID, enabled } = options;
 
   const { mustGetToken } = useAuth();
   const token = mustGetToken();
 
-  const query = useQuery({
+  const { data: checkpointData, ...queryRest } = useQuery({
     queryKey: ['checkpointImage', renderID, token],
     queryFn: async () => {
       const blob = await getLatestCheckpointImage(token, renderID);
+      if (blob === null) {
+        return null;
+      }
       return URL.createObjectURL(blob);
     },
     refetchInterval: 1000,
+    enabled: enabled ?? true,
   });
 
-  // revoke the previous blob URL when query.data changes or on unmount
+  // revoke the previous blob URL when checkpointData changes or on unmount
   useEffect(() => {
     return () => {
-      if (query.data) {
-        URL.revokeObjectURL(query.data);
+      if (checkpointData) {
+        URL.revokeObjectURL(checkpointData);
       }
     };
-  }, [query.data]);
+  }, [checkpointData]);
 
-  return query;
+  return { data: checkpointData, ...queryRest };
 }

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -303,10 +303,17 @@ export async function getRenderStats(token: string, renderID: number): Promise<R
   return (await response.json()) as RenderStats;
 }
 
-export async function getLatestCheckpointImage(token: string, renderID: number): Promise<Blob> {
-  const response = await fetch(`${getAPIURL()}/renders/${renderID}/checkpoint/earliest`, {
+export async function getLatestCheckpointImage(
+  token: string,
+  renderID: number,
+): Promise<Blob | null> {
+  const response = await fetch(`${getAPIURL()}/renders/${renderID}/checkpoint/latest`, {
     headers: { Authorization: `Bearer ${token}` },
   });
+
+  if (response.status === 404) {
+    return null;
+  }
 
   if (!response.ok) {
     const body = await response.text();

--- a/ui/src/views/renders/RenderPreviewCard.tsx
+++ b/ui/src/views/renders/RenderPreviewCard.tsx
@@ -10,7 +10,12 @@ export type RenderPreviewCardProps = {
 
 export function RenderPreviewCard(props: RenderPreviewCardProps) {
   const { render } = props;
-  const checkpointImageQuery = useLatestCheckpointImage({ renderID: render.id });
+  const {
+    data: checkpointImage,
+    isPending: isCheckpointImagePending,
+    isError: isCheckpointImageError,
+    isSuccess: isCheckpointImageSuccess,
+  } = useLatestCheckpointImage({ renderID: render.id });
   const renderSize = render.config.parameters.image_dimensions;
   const state = render.state;
   const running = isRenderStateRunning(state);
@@ -36,22 +41,28 @@ export function RenderPreviewCard(props: RenderPreviewCardProps) {
         theme={cardTheme}
         renderImage={() => (
           <div className="flex aspect-video items-center justify-center overflow-hidden bg-zinc-900">
-            {checkpointImageQuery.isPending && (
+            {isCheckpointImagePending && (
               <div className="flex flex-col items-center justify-center">
                 <Spinner size="xl" color="info" />
                 <span className="mt-2 text-sm">loading preview...</span>
               </div>
             )}
-            {checkpointImageQuery.isError && (
+            {isCheckpointImageError && (
               <img
                 src={`https://placehold.co/${renderSize[0]}x${renderSize[1]}?text=Error`}
                 alt="Render Error"
                 className="h-full w-full object-contain"
               />
             )}
-            {checkpointImageQuery.isSuccess && (
+            {isCheckpointImageSuccess && checkpointImage === null && (
+              <div className="flex flex-col items-center justify-center">
+                <Spinner size="xl" color="info" />
+                <span className="mt-2 text-sm">Rendering initial checkpoint...</span>
+              </div>
+            )}
+            {isCheckpointImageSuccess && checkpointImage !== null && (
               <img
-                src={checkpointImageQuery.data}
+                src={checkpointImage}
                 alt="Render Preview"
                 className="h-full w-full object-contain"
               />

--- a/ui/src/views/renders/[id]/RenderDisplay/RenderPreview.tsx
+++ b/ui/src/views/renders/[id]/RenderDisplay/RenderPreview.tsx
@@ -1,4 +1,6 @@
 import { useLatestCheckpointImage } from '@/hooks/useLatestCheckpointImage';
+import { useRender } from '@/hooks/useRender';
+import { isRenderStateCreated } from '@/utils/api';
 import { Spinner } from 'flowbite-react';
 
 export type RenderPreviewProps = {
@@ -8,6 +10,11 @@ export type RenderPreviewProps = {
 export function RenderPreview(props: RenderPreviewProps) {
   const { renderID } = props;
 
+  const { data: render } = useRender({ renderID });
+  const renderState = render?.state;
+
+  const checkpointEnabled = renderState ? !isRenderStateCreated(renderState) : true;
+
   const {
     data: checkpointImage,
     isPending: isCheckpointImagePending,
@@ -15,11 +22,18 @@ export function RenderPreview(props: RenderPreviewProps) {
     error: checkpointImageError,
   } = useLatestCheckpointImage({
     renderID,
+    enabled: checkpointEnabled,
   });
 
   return (
     <div className="flex min-h-0 flex-1 items-center justify-center p-4">
       {isCheckpointImagePending && <Spinner size="xl" color="info" />}
+      {!isCheckpointImagePending && !isCheckpointImageError && checkpointImage === null && (
+        <div className="flex flex-col items-center justify-center gap-2">
+          <Spinner size="xl" color="info" />
+          <p className="text-sm text-zinc-400">Rendering — no checkpoint image yet</p>
+        </div>
+      )}
       {isCheckpointImageError && (
         <p className="text-sm text-zinc-500">
           Error loading checkpoint image: {checkpointImageError?.message}

--- a/ui/src/views/renders/[id]/RenderDisplay/RenderTitleBar/RenderTitleBar.tsx
+++ b/ui/src/views/renders/[id]/RenderDisplay/RenderTitleBar/RenderTitleBar.tsx
@@ -25,6 +25,9 @@ export function RenderTitleBar(props: RenderTitleBarProps) {
     const [width, height] = render.config.parameters.image_dimensions;
     const filename = `${render.config.name}-checkpoint-${width}x${height}.png`;
     const blob = await getLatestCheckpointImage(token, renderID);
+    if (blob === null) {
+      return;
+    }
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;


### PR DESCRIPTION
Closes #107.

## Problem
When viewing a render on `/renders/:id` and no checkpoint image exists yet, the preview showed a hard _"Error loading checkpoint image: (404: )"_ message. This is misleading — a 404 is an expected transient state meaning "no checkpoint yet," not an error.

## Root causes fixed
1. **Wrong endpoint URL**: `getLatestCheckpointImage` was calling `/checkpoint/earliest` instead of `/checkpoint/latest`
2. **404 treated as error**: The API function threw on any non-ok response, including 404. TanStack Query would then surface it as `isError: true`
3. **No null-data handling**: The UI had no concept of "query succeeded but no data yet"

## Changes
- **`api.ts`**: Fixed `/checkpoint/earliest` → `/checkpoint/latest`. Now returns `null` on 404 instead of throwing. Return type: `Promise<Blob>` → `Promise<Blob | null>`
- **`useLatestCheckpointImage`**: Handles `null` blob from API. Added optional `enabled` parameter. Fixed hook destructuring convention
- **`RenderPreview`**: Shows "Rendering — no checkpoint image yet" with spinner when no checkpoint exists. Disables checkpoint polling when render is in `"created"` state (avoids guaranteed-404 requests during setup)
- **`RenderPreviewCard`**: Renders list page cards now show a processing spinner instead of `<img src="null">` when no checkpoint exists. Fixed hook destructuring convention