### PR TITLE
feat: introduce BRDF and PDF infrastructure (Step 0–1 of importance sampling)

### DIFF
--- a/.opencode/brdf-importance-sampling.md
+++ b/.opencode/brdf-importance-sampling.md
@@ -1,0 +1,154 @@
+# BRDF / Importance Sampling Plan
+
+## What We Built (Current State)
+
+**This is a fresh start.** The previous `feat/brdfs-and-pdfs` branch was discarded. All code from that effort (ScatterRecord, ONB, `random_cosine_direction`, `scattering_pdf`, `skip_pdf`, explicit PDF division in `ray_color`) is gone.
+
+We are working on branch `feat/brdfs-and-pdfs-2`, based off `main`, with the original Peter Shirley Book 1/2 code as the baseline:
+
+- `Material::scatter(&self, ray, ray_hit) -> Option<Ray>` — returns a scattered ray directly, no PDF attached
+- `Camera::ray_color()` — recursive/loop integrator with emittance + reflectance accumulation, no explicit PDF denominator
+- Lambertian scatter: `normal + random_unit_vector()` (cosine-weighted via normalization of random hemisphere direction, but *not* expressed as a PDF)
+- Isotropic scatter: `random_unit_vector()` (uniform sphere direction)
+- `Geometric` trait only has `intersect` / `bounding_box` — no sampling methods
+
+---
+
+## Key Concepts
+
+### BRDF (Bidirectional Reflectance Distribution Function)
+
+The BRDF describes how light reflects off a surface. Given incoming and outgoing directions, it returns the ratio of reflected radiance to incoming irradiance.
+
+**Lambertian BRDF** = `albedo / π` (constant, energy-conserving).
+
+In code: currently `ray_color` multiplies the reflectance color into `attentuation_strength`. When we introduce `brdf()`, the material will return this value directly.
+
+### Importance Sampling
+
+Instead of shooting rays uniformly and hoping they hit lights, we sample directions *proportional to how much they contribute* to the final color. This dramatically reduces noise.
+
+**Key formula:** Monte Carlo estimator with importance sampling
+
+```
+L ≈ (brdf * emission * cos_theta) / pdf
+```
+
+When `pdf ≈ brdf * cos_theta` (i.e., the PDF matches the integrand shape), variance drops sharply.
+
+### ONB (Orthonormal Basis)
+
+A local coordinate frame `(u, v, w)` built from the surface normal. Used to sample directions relative to the surface (e.g., cosine-weighted hemisphere sampling).
+
+The ONB class converts between local coordinates (where `w` is the "up" axis aligned with the normal) and world coordinates.
+
+### Mixture PDF
+
+When a scene has multiple lights (especially small lights), no single PDF works well everywhere. A `MixturePdf` combines several PDFs (e.g., cosine hemisphere + light sampling) so rays are likely to hit both diffuse surfaces *and* lights.
+
+---
+
+## Books Referenced
+
+**Peter Shirley, Ray Tracing in One Weekend Series (Books 1–3)**
+
+- **Book 1** — Basic ray tracing: camera, spheres, Lambertian/Metal/Dielectric materials, antialiasing, defocus blur.
+- **Book 2** — BVH, textures, perlin noise, quads, volumes (constant density), scene description.
+- **Book 3** — BRDF models, PDF-based sampling, cosine hemisphere sampling, mixture PDFs, light sampling via `GeometricPdf`, explicit PDF denominator in the integrator.
+
+Our baseline (currently on `main`) covers Books 1 and 2 fully. The `feat/brdfs-and-pdfs-2` branch will implement Book 3 step by step.
+
+---
+
+## What Remains (Future Work)
+
+All steps below are derived from Peter Shirley's *Ray Tracing: The Rest of Your Life* (Book 3).
+
+### Step 0 — `brdf()`, ONB, ScatterRecord, `random_cosine_direction()`, migrate integrator
+
+Introduce the core building blocks without yet changing *what* is sampled:
+
+- Add `ONB` struct with `build_from_w(normal)` and `local(u, v, w) -> Vector` methods
+- Add `Vector::random_cosine_direction()` that returns a cosine-weighted random direction on the hemisphere (z-up in local space, then transformed via ONB)
+- Add `ScatterRecord` struct holding the scattered ray, attenuation color, and (later) a PDF pointer
+- Add `brdf()` method to the `Material` trait — Lambertian returns `albedo / π`, others return zero (or their proper BRDF if specular/dielectric)
+- Refactor `Material::scatter()` to return `ScatterRecord` instead of `Option<Ray>`
+- Refactor `Camera::ray_color()` to use the explicit Monte Carlo formula:
+
+```
+L = emitted + brdf * cos_theta * ray_color(scattered) / pdf
+```
+
+Initially `pdf` is hardcoded to the cosine-hemisphere PDF value (`cos_theta / π`), so the numerator and denominator cancel exactly and the image looks identical to before. This is the "trust nothing, verify everything" checkpoint.
+
+**Files affected:** `src/camera.rs`, `src/shading/materials.rs`, `src/shading/materials/lambertian.rs`, `src/shading/materials/isotropic.rs`, `src/shading/materials/specular.rs`, `src/shading/materials/dielectric.rs`, new file for `ONB` and `ScatterRecord` (likely `src/shading/onb.rs` or similar).
+
+### Step 1 — `Pdf` trait + `CosineHemispherePdf` + `UniformSpherePdf`
+
+Extract PDF calculation into its own abstraction:
+
+- Define a `Pdf` trait: `fn sample(&self) -> Vector` and `fn density(&self, dir: Vector) -> f64`
+- `CosineHemispherePdf` — samples a cosine-weighted hemisphere via `random_cosine_direction()`, density = `cos_theta / π`
+- `UniformSpherePdf` — samples uniformly on the unit sphere, density = `1 / (4π)`
+- Refactor Lambertian to use `CosineHemispherePdf` internally
+- Refactor Isotropic to use `UniformSpherePdf` internally
+
+At this point the image should still be identical to baseline (Step 0).
+
+### Step 2 — Geometric sampling primitives
+
+Add direction sampling to the `Geometric` trait so geometry can serve as a light-sampling target:
+
+- `fn sample_direction_from(&self, origin: Point) -> Vector`
+- `fn direction_pdf(&self, origin: Point, dir: Vector) -> f64`
+- Implement for sphere, parallelogram, BVH, constant-volume wrapper, transform wrappers
+- Compute the Jacobian from area PDF to solid-angle PDF: `pdf_direction = pdf_area * distance² / |cos_alpha|`
+
+This is purely additive — nothing consumes these yet.
+
+### Step 3 — `GeometricPdf` + `MixturePdf` + separate lights list
+
+The actual importance sampling step where the PDF ratio stops being 1.0:
+
+- `GeometricPdf` wraps a `&dyn Geometric` (a light) and implements `Pdf` via `sample_direction_from` / `direction_pdf`
+- `MixturePdf` holds two `Arc<dyn Pdf>` and randomly delegates to one, averaging their densities
+- Add a `lights` list to the scene (separate from `world`) — a list of geometric objects that emit light
+- In `ray_color`, build a `MixturePdf` from the surface's own PDF (cosine hemisphere) and a `GeometricPdf` over the lights
+- Pass this mixture PDF into `ScatterRecord` so the integrator uses it
+
+The PDF ratio is no longer 1.0, so the image will change (less noise around light sources).
+
+### Step 4 — Validate on small-light scene
+
+Test with the classic Book 3 scene: a large diffuse box with a tiny emissive sphere/quad. Without importance sampling, this scene is extremely noisy. With `GeometricPdf` + `MixturePdf`, it should converge cleanly.
+
+---
+
+## Naming Conventions
+
+The user has specified exact naming. Deviations must be caught in review:
+
+| Concept | Name | Notes |
+|---|---|---|
+| PDF trait | `Pdf` | methods: `sample(&self) -> Vector`, `density(&self, dir: Vector) -> f64` |
+| Cosine hemisphere PDF | `CosineHemispherePdf` | not `CosinePdf` |
+| Uniform sphere PDF | `UniformSpherePdf` | not `SpherePdf` |
+| Geometry-targeting PDF | `GeometricPdf` | not `HittablePdf` |
+| Mixture PDF | `MixturePdf` | |
+| Geometric sampling methods | `sample_direction_from(&self, origin: Point) -> Vector` | on the `Geometric` trait |
+| | `direction_pdf(&self, origin: Point, dir: Vector) -> f64` | on the `Geometric` trait |
+
+**Direction vs Point vs Ray conventions:**
+- Direction parameter is always a unit `Vector`
+- Origin parameter is always a `Point`
+- `Ray` is used only for actual ray tracing (intersection queries)
+
+---
+
+## Session Notes
+
+- **Current branch:** `feat/brdfs-and-pdfs-2`
+- **Baseline:** original Book 1/2 code from `main`. The previous `feat/brdfs-and-pdfs` branch was discarded entirely.
+- **Naming conventions** (see table above) are the user's explicit preferences and should be checked on every code review.
+- **Goal:** Implement Book 3 (*The Rest of Your Life*) step by step, with careful verification at each checkpoint to ensure the image doesn't regress.
+- **Key binding:** `ray_color` changes must produce identical output in Steps 0–1 (cosine PDF cancellation). Changes in Step 3 will change the image (that's the point).

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,7 +4,7 @@ use rand::RngExt;
 
 use crate::{
     geometry::{Geometric, Point, Ray, Vector},
-    shading::Color,
+    shading::{Color, materials::ScatterRecord},
     tracing::{RenderParameters, Scene},
     utils::{Angle, Interval},
 };
@@ -145,29 +145,55 @@ impl Camera {
             // update our accumulated color
             accumulated_color += attentuation_strength * emittance;
 
-            let reflectance = ray_hit
-                .material
-                .reflectance(ray_hit.u, ray_hit.v, ray_hit.point);
-
-            // if the surface is black, it's not going to let any incoming light contribute to the outgoing color
-            // so we can safely say no light is reflected and simply return the accumulated color so far
-            if bounces >= max_bounces || reflectance == Color::BLACK {
+            if bounces >= max_bounces {
                 return accumulated_color;
             }
 
-            // get scattered ray, if possible
-            match ray_hit.material.scatter(ray, &ray_hit) {
-                Some(scatter) => {
-                    // redirect the ray
-                    ray = scatter;
-                    // update the attenuation by the effect this surface has on the light rays
-                    attentuation_strength *= reflectance;
-                }
-                None => {
-                    // the surface absorbed this ray, so we can return the accumulated color
-                    return accumulated_color;
-                }
+            // early termination: if the surface absorbs all light, skip scatter
+            if ray_hit.material.reflectance(ray_hit.u, ray_hit.v, ray_hit.point) == Color::BLACK {
+                return accumulated_color;
+            }
+
+            let Some(srec) = ray_hit.material.scatter(ray, &ray_hit) else {
+                return accumulated_color;
             };
+
+            // unit vector from surface toward the camera (outgoing direction for BRDF)
+            let outgoing_direction = (-ray.direction).unit_vector();
+            // ray = srec.scattered();
+
+            match srec {
+                ScatterRecord::Delta { scattered } => {
+                    // specular or dielectric materials, which really only have a discrete scatter direction, and not a distribution over 3D space.
+                    //
+                    // essentially, this is a special case that sidesteps the BRDF + PDF evaluation
+                    let reflectance =
+                        ray_hit
+                            .material
+                            .reflectance(ray_hit.u, ray_hit.v, ray_hit.point);
+
+                    attentuation_strength *= reflectance;
+
+                    ray = scattered
+                }
+                ScatterRecord::Pdf { pdf, scattered } => {
+                    // unit vector from surface toward the light source (incident direction for BRDF)
+                    let incident_direction = scattered.direction.unit_vector();
+                    let cos_theta = ray_hit.normal.dot(incident_direction);
+
+                    let brdf_val = ray_hit.material.brdf(
+                        outgoing_direction,
+                        incident_direction,
+                        ray_hit.normal,
+                        ray_hit.u,
+                        ray_hit.v,
+                        ray_hit.point,
+                    );
+                    attentuation_strength *= brdf_val * cos_theta / pdf;
+
+                    ray = scattered
+                }
+            }
 
             bounces += 1;
         }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -9,6 +9,9 @@ pub use aabb::Aabb;
 mod geometric;
 pub use geometric::Geometric;
 
+mod onb;
+pub use onb::Onb;
+
 mod point;
 pub use point::Point;
 

--- a/src/geometry/onb.rs
+++ b/src/geometry/onb.rs
@@ -1,0 +1,51 @@
+use crate::geometry::vector::Vector;
+
+/// An orthonormal basis {u, v, w} for orienting Z-axis-relative
+/// direction vectors to an arbitrary surface normal.
+///
+/// `w` is the surface normal direction. `u` and `v` span the
+/// tangent plane perpendicular to `w`.
+#[derive(Debug, Clone, Copy)]
+pub struct Onb {
+    pub u: Vector,
+    pub v: Vector,
+    pub w: Vector,
+}
+
+impl Onb {
+    /// Build an ONB from a unit surface normal.
+    ///
+    /// Picks an auxiliary vector that is not parallel to `normal`,
+    /// then builds `u`, `v` via cross products so that `{u, v, w}`
+    /// forms a right-handed orthonormal basis.
+    pub fn from_normal(normal: Vector) -> Self {
+        let w = normal.unit_vector();
+        let a = if w.x.abs() > 0.9 {
+            // normal is nearly parallel to +X — use +Y as auxiliary
+            Vector {
+                x: 0.0,
+                y: 1.0,
+                z: 0.0,
+            }
+        } else {
+            Vector {
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            }
+        };
+        let v = w.cross(a).unit_vector();
+        let u = w.cross(v); // automatically unit-length since w ⊥ v
+        Self { u, v, w }
+    }
+
+    /// Transform a direction from the ONB's local frame to world space.
+    ///
+    /// In the local frame, +Z corresponds to the surface normal (`w`).
+    /// For example, feeding this a cosine-weighted direction (biased
+    /// toward +Z) produces a direction biased toward the surface normal
+    /// in world space.
+    pub fn to_world(&self, v: Vector) -> Vector {
+        v.x * self.u + v.y * self.v + v.z * self.w
+    }
+}

--- a/src/geometry/onb.rs
+++ b/src/geometry/onb.rs
@@ -18,7 +18,7 @@ impl Onb {
     /// Picks an auxiliary vector that is not parallel to `normal`,
     /// then builds `u`, `v` via cross products so that `{u, v, w}`
     /// forms a right-handed orthonormal basis.
-    pub fn from_normal(normal: Vector) -> Self {
+    pub fn from_w(normal: Vector) -> Self {
         let w = normal.unit_vector();
         let a = if w.x.abs() > 0.9 {
             // normal is nearly parallel to +X — use +Y as auxiliary

--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -127,7 +127,7 @@ impl Vector {
     ///
     /// implemented via malley's method: uniformly sample the unit disk and
     /// project onto the hemisphere.
-    pub fn random_cosine_direction() -> Self {
+    pub fn random_cosine_weighted_direction() -> Self {
         let r1 = rand::random::<f64>();
         let r2 = rand::random::<f64>();
         let phi = 2.0 * std::f64::consts::PI * r1;

--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -120,6 +120,25 @@ impl Vector {
         }
     }
 
+    /// generates a random unit direction on the +Z hemisphere with a
+    /// cosine-weighted distribution.  the direction is relative to +Z
+    /// (`z > 0` by construction), not world-space.  use an `Onb` to orient
+    /// the result to an arbitrary surface normal.
+    ///
+    /// implemented via malley's method: uniformly sample the unit disk and
+    /// project onto the hemisphere.
+    pub fn random_cosine_direction() -> Self {
+        let r1 = rand::random::<f64>();
+        let r2 = rand::random::<f64>();
+        let phi = 2.0 * std::f64::consts::PI * r1;
+        let sqrt_r2 = r2.sqrt();
+        Self {
+            x: phi.cos() * sqrt_r2,
+            y: phi.sin() * sqrt_r2,
+            z: (1.0 - r2).sqrt(),
+        }
+    }
+
     pub fn length(&self) -> f64 {
         self.squared_length().sqrt()
     }

--- a/src/shading.rs
+++ b/src/shading.rs
@@ -2,6 +2,6 @@ mod color;
 pub use color::Color;
 
 pub mod materials;
-
+pub mod pdf;
 pub mod textures;
 pub use textures::Texture;

--- a/src/shading/materials.rs
+++ b/src/shading/materials.rs
@@ -13,6 +13,25 @@ pub use lambertian::Lambertian;
 mod specular;
 pub use specular::Specular;
 
+/// The result of a material scatter operation.
+///
+/// `Pdf` carries a sampling probability density for diffuse materials
+/// (Lambertian). `Delta` is for specular/dielectric materials that have
+/// a deterministic (delta-function) bounce — no finite PDF exists.
+#[derive(Debug, Clone)]
+pub enum ScatterRecord {
+    Pdf {
+        /// The scattered ray to continue tracing.
+        scattered: Ray,
+        /// The solid-angle probability density of the chosen scatter direction.
+        pdf: f64,
+    },
+    Delta {
+        /// The scattered ray to continue tracing.
+        scattered: Ray,
+    },
+}
+
 pub trait Material: std::fmt::Debug + Sync + Send {
     fn reflectance(&self, u: f64, v: f64, p: Point) -> Color;
     fn emittance(&self, u: f64, v: f64, p: Point) -> Color;

--- a/src/shading/materials.rs
+++ b/src/shading/materials.rs
@@ -35,5 +35,5 @@ pub enum ScatterRecord {
 pub trait Material: std::fmt::Debug + Sync + Send {
     fn reflectance(&self, u: f64, v: f64, p: Point) -> Color;
     fn emittance(&self, u: f64, v: f64, p: Point) -> Color;
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<Ray>;
+    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord>;
 }

--- a/src/shading/materials.rs
+++ b/src/shading/materials.rs
@@ -1,5 +1,5 @@
 use super::Color;
-use crate::geometry::{Point, Ray, RayHit};
+use crate::geometry::{Point, Ray, RayHit, Vector};
 
 mod dielectric;
 pub use dielectric::Dielectric;
@@ -13,12 +13,51 @@ pub use lambertian::Lambertian;
 mod specular;
 pub use specular::Specular;
 
+pub trait Material: std::fmt::Debug + Sync + Send {
+    fn emittance(&self, u: f64, v: f64, p: Point) -> Color;
+
+    /// The raw albedo (reflectance color) of this material at a surface point.
+    ///
+    /// For `Delta`-variant materials (Specular, Dielectric, Isotropic), this
+    /// value is used directly in the integrator as the attenuation factor.
+    ///
+    /// For `Pdf`-variant materials (Lambertian), the actual contribution comes
+    /// from `brdf()`, but `reflectance()` is still called for early-termination:
+    /// if the surface absorbs all light (returns `Color::BLACK`), the integrator
+    /// skips scattering entirely.
+    fn reflectance(&self, u: f64, v: f64, p: Point) -> Color;
+
+    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord>;
+
+    /// Evaluate the BRDF (Bidirectional Reflectance Distribution Function).
+    ///
+    /// Returns the fraction of light arriving from `incident_direction` that
+    /// is reflected toward `outgoing_direction`. This is a pure BRDF value —
+    /// no cosine factor, no sampling probability.
+    ///
+    /// `outgoing_direction` — unit vector toward the camera (outgoing).
+    /// `incident_direction` — unit vector toward the light source (incident).
+    /// `normal` — the surface normal at the hit point.
+    ///
+    /// For delta-function materials (Specular, Dielectric), this method is
+    /// never called — they bypass the BRDF path via `ScatterRecord::Delta`.
+    fn brdf(
+        &self,
+        outgoing_direction: Vector,
+        incident_direction: Vector,
+        normal: Vector,
+        u: f64,
+        v: f64,
+        p: Point,
+    ) -> Color;
+}
+
 /// The result of a material scatter operation.
 ///
 /// `Pdf` carries a sampling probability density for diffuse materials
 /// (Lambertian). `Delta` is for specular/dielectric materials that have
 /// a deterministic (delta-function) bounce — no finite PDF exists.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ScatterRecord {
     Pdf {
         /// The scattered ray to continue tracing.
@@ -30,10 +69,4 @@ pub enum ScatterRecord {
         /// The scattered ray to continue tracing.
         scattered: Ray,
     },
-}
-
-pub trait Material: std::fmt::Debug + Sync + Send {
-    fn reflectance(&self, u: f64, v: f64, p: Point) -> Color;
-    fn emittance(&self, u: f64, v: f64, p: Point) -> Color;
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord>;
 }

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Ray, RayHit},
+    geometry::{Point, Ray, RayHit, Vector},
     shading::{Color, Texture},
 };
 
@@ -35,12 +35,25 @@ impl Dielectric {
 }
 
 impl Material for Dielectric {
-    fn reflectance(&self, u: f64, v: f64, p: crate::geometry::Point) -> Color {
+    fn emittance(&self, u: f64, v: f64, p: crate::geometry::Point) -> Color {
+        self.emittance_texture.value(u, v, p)
+    }
+
+    fn reflectance(&self, u: f64, v: f64, p: Point) -> Color {
         self.reflectance_texture.value(u, v, p)
     }
 
-    fn emittance(&self, u: f64, v: f64, p: crate::geometry::Point) -> Color {
-        self.emittance_texture.value(u, v, p)
+    fn brdf(
+        &self,
+        _outgoing_direction: Vector,
+        _incident_direction: Vector,
+        _normal: Vector,
+        _u: f64,
+        _v: f64,
+        _p: Point,
+    ) -> Color {
+        // delta-function BRDF — never called, bypassed via ScatterRecord::Delta
+        Color::BLACK
     }
 
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
@@ -66,6 +79,8 @@ impl Material for Dielectric {
         };
 
         let scattered = Ray::new(ray_hit.point, refracted, ray.time);
-        Some(ScatterRecord::Delta { scattered })
+        Some(ScatterRecord::Delta {
+            scattered,
+        })
     }
 }

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -5,7 +5,7 @@ use crate::{
     shading::{Color, Texture},
 };
 
-use super::Material;
+use super::{Material, ScatterRecord};
 
 #[derive(Debug, Clone)]
 pub struct Dielectric {
@@ -43,7 +43,7 @@ impl Material for Dielectric {
         self.emittance_texture.value(u, v, p)
     }
 
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<Ray> {
+    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         let (refractive_normal, refraction_ratio) = if ray.direction.dot(ray_hit.normal) < 0.0 {
             (ray_hit.normal, 1.0 / self.index_of_refraction)
         } else {
@@ -66,6 +66,6 @@ impl Material for Dielectric {
         };
 
         let scattered = Ray::new(ray_hit.point, refracted, ray.time);
-        Some(scattered)
+        Some(ScatterRecord::Delta { scattered })
     }
 }

--- a/src/shading/materials/isotropic.rs
+++ b/src/shading/materials/isotropic.rs
@@ -5,7 +5,7 @@ use crate::{
     shading::{Color, Texture},
 };
 
-use super::Material;
+use super::{Material, ScatterRecord};
 
 #[derive(Debug, Clone)]
 pub struct Isotropic {
@@ -31,8 +31,10 @@ impl Material for Isotropic {
         self.emittance_texture.value(u, v, p)
     }
 
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<Ray> {
+    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         // always scatter, and always scatter in a random direction
-        Some(Ray::new(ray_hit.point, Vector::random_unit(), ray.time))
+        Some(ScatterRecord::Delta {
+            scattered: Ray::new(ray_hit.point, Vector::random_unit(), ray.time),
+        })
     }
 }

--- a/src/shading/materials/isotropic.rs
+++ b/src/shading/materials/isotropic.rs
@@ -37,4 +37,17 @@ impl Material for Isotropic {
             scattered: Ray::new(ray_hit.point, Vector::random_unit(), ray.time),
         })
     }
+
+    fn brdf(
+        &self,
+        _outgoing_direction: Vector,
+        _incident_direction: Vector,
+        _normal: Vector,
+        u: f64,
+        v: f64,
+        p: Point,
+    ) -> Color {
+        let albedo = self.reflectance_texture.value(u, v, p);
+        albedo / (4.0 * std::f64::consts::PI)
+    }
 }

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Point, Ray, RayHit, Vector},
+    geometry::{Onb, Point, Ray, RayHit, Vector},
     shading::{Color, Texture, textures::SolidColor},
 };
 
-use super::Material;
+use super::{Material, ScatterRecord};
 
 #[derive(Debug, Clone)]
 pub struct Lambertian {
@@ -47,18 +47,17 @@ impl Material for Lambertian {
         self.emittance_texture.value(u, v, p)
     }
 
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<Ray> {
-        let direction = ray_hit.normal + Vector::random_unit();
-
-        // prevent degenerate rays from being generated
-        let direction = if direction.is_near_zero() {
-            ray_hit.normal
-        } else {
-            direction
-        };
-
-        let scattered = Ray::new(ray_hit.point, direction, ray.time);
-
-        Some(scattered)
+    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
+        let onb = Onb::from_w(ray_hit.normal);
+        let direction = onb.to_world(Vector::random_cosine_weighted_direction());
+        let cos_theta = ray_hit.normal.dot(direction);
+        Some(ScatterRecord::Pdf {
+            scattered: Ray::new(ray_hit.point, direction, ray.time),
+            pdf: if cos_theta < 0.0 {
+                0.0
+            } else {
+                cos_theta / std::f64::consts::PI
+            },
+        })
     }
 }

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -64,4 +64,17 @@ impl Material for Lambertian {
             pdf,
         })
     }
+
+    fn brdf(
+        &self,
+        _outgoing_direction: Vector,
+        _incident_direction: Vector,
+        _normal: Vector,
+        u: f64,
+        v: f64,
+        p: Point,
+    ) -> Color {
+        let albedo = self.reflectance_texture.value(u, v, p);
+        albedo / std::f64::consts::PI
+    }
 }

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
+use crate::shading::pdf::{CosineHemispherePdf, Pdf};
 use crate::{
-    geometry::{Onb, Point, Ray, RayHit, Vector},
+    geometry::{Point, Ray, RayHit, Vector},
     shading::{Color, Texture, textures::SolidColor},
 };
 
@@ -48,20 +49,12 @@ impl Material for Lambertian {
     }
 
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
-        let onb = Onb::from_w(ray_hit.normal);
-        let direction = onb.to_world(Vector::random_cosine_weighted_direction());
-
-        let cos_theta = ray_hit.normal.dot(direction);
-        let pdf = if cos_theta < 0.0 {
-            // for rare degenerate floating-point related cases... this really should only happen incredibly rarely, if at all.
-            0.0
-        } else {
-            cos_theta / std::f64::consts::PI
-        };
+        let pdf = CosineHemispherePdf::new(ray_hit.normal);
+        let direction = pdf.sample();
 
         Some(ScatterRecord::Pdf {
             scattered: Ray::new(ray_hit.point, direction, ray.time),
-            pdf,
+            pdf: pdf.density(direction),
         })
     }
 

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -50,14 +50,18 @@ impl Material for Lambertian {
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         let onb = Onb::from_w(ray_hit.normal);
         let direction = onb.to_world(Vector::random_cosine_weighted_direction());
+
         let cos_theta = ray_hit.normal.dot(direction);
+        let pdf = if cos_theta < 0.0 {
+            // for rare degenerate floating-point related cases... this really should only happen incredibly rarely, if at all.
+            0.0
+        } else {
+            cos_theta / std::f64::consts::PI
+        };
+
         Some(ScatterRecord::Pdf {
             scattered: Ray::new(ray_hit.point, direction, ray.time),
-            pdf: if cos_theta < 0.0 {
-                0.0
-            } else {
-                cos_theta / std::f64::consts::PI
-            },
+            pdf,
         })
     }
 }

--- a/src/shading/materials/specular.rs
+++ b/src/shading/materials/specular.rs
@@ -5,7 +5,7 @@ use crate::{
     shading::{Color, Texture},
 };
 
-use super::Material;
+use super::{Material, ScatterRecord};
 
 #[derive(Debug, Clone)]
 pub struct Specular {
@@ -37,7 +37,7 @@ impl Material for Specular {
         self.emittance_texture.value(u, v, p)
     }
 
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<Ray> {
+    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         let reflected = ray.direction.unit_vector().reflect_around(ray_hit.normal);
 
         let scattered = Ray::new(
@@ -47,7 +47,7 @@ impl Material for Specular {
         );
 
         if scattered.direction.dot(ray_hit.normal) > 0.0 {
-            Some(scattered)
+            Some(ScatterRecord::Delta { scattered })
         } else {
             None
         }

--- a/src/shading/materials/specular.rs
+++ b/src/shading/materials/specular.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Ray, RayHit, Vector},
+    geometry::{Point, Ray, RayHit, Vector},
     shading::{Color, Texture},
 };
 
@@ -29,12 +29,25 @@ impl Specular {
 }
 
 impl Material for Specular {
-    fn reflectance(&self, u: f64, v: f64, p: crate::geometry::Point) -> Color {
+    fn reflectance(&self, u: f64, v: f64, p: Point) -> Color {
         self.reflectance_texture.value(u, v, p)
     }
 
-    fn emittance(&self, u: f64, v: f64, p: crate::geometry::Point) -> Color {
+    fn emittance(&self, u: f64, v: f64, p: Point) -> Color {
         self.emittance_texture.value(u, v, p)
+    }
+
+    fn brdf(
+        &self,
+        _outgoing_direction: Vector,
+        _incident_direction: Vector,
+        _normal: Vector,
+        _u: f64,
+        _v: f64,
+        _p: Point,
+    ) -> Color {
+        // delta-function BRDF — never called, bypassed via ScatterRecord::Delta
+        Color::BLACK
     }
 
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {

--- a/src/shading/pdf.rs
+++ b/src/shading/pdf.rs
@@ -1,0 +1,70 @@
+use crate::geometry::{Onb, Vector};
+
+/// A probability density function over solid angle (directions on the unit
+/// sphere or hemisphere).
+///
+/// The two methods form a matched pair:
+/// - `sample()` draws a random direction distributed according to this PDF.
+/// - `density(dir)` returns the probability density that `sample()` would
+///   have assigned to the given direction.
+pub trait Pdf {
+    /// Draw a random unit direction distributed according to this PDF.
+    fn sample(&self) -> Vector;
+
+    /// The solid-angle probability density at `dir`.
+    fn density(&self, dir: Vector) -> f64;
+}
+
+/// Cosine-weighted probability density over the hemisphere centered on a
+/// surface normal.
+///
+/// `density(dir)` returns `max(0, cos(θ)) / π`, where `cos(θ)` is the
+/// dot product of the direction with the stored normal.
+///
+/// Internally uses [`Vector::random_cosine_weighted_direction`] and [`Onb`] to
+/// generate directions (Malley's method: uniform disk sample projected
+/// onto the hemisphere).
+pub struct CosineHemispherePdf {
+    onb: Onb,
+}
+
+impl CosineHemispherePdf {
+    /// Create a cosine-weighted PDF centered on `normal` (the surface normal).
+    pub fn new(normal: Vector) -> Self {
+        Self {
+            onb: Onb::from_w(normal),
+        }
+    }
+}
+
+impl Pdf for CosineHemispherePdf {
+    fn sample(&self) -> Vector {
+        self.onb
+            .to_world(Vector::random_cosine_weighted_direction())
+    }
+
+    fn density(&self, dir: Vector) -> f64 {
+        let cos_theta = self.onb.w.dot(dir);
+        if cos_theta <= 0.0 {
+            0.0
+        } else {
+            cos_theta / std::f64::consts::PI
+        }
+    }
+}
+
+/// Uniform probability density over the full sphere.
+///
+/// `density(dir)` always returns `1 / (4π)`. Used for isotropic volume
+/// scattering materials.
+pub struct UniformSpherePdf;
+
+impl Pdf for UniformSpherePdf {
+    fn sample(&self) -> Vector {
+        Vector::random_unit()
+    }
+
+    fn density(&self, _dir: Vector) -> f64 {
+        1.0 / (4.0 * std::f64::consts::PI)
+    }
+}


### PR DESCRIPTION
## Summary

This is Steps 0 and 1 of the importance sampling refactor (Issue #28). No visual change — this is purely architectural refactoring that makes future light-sampling / mixture-PDF work possible.

## What changed

### New types
- **`Onb`** (`src/geometry/onb.rs`) — orthonormal basis for orienting Z-axis-relative directions to surface normals
- **`Vector::random_cosine_weighted_direction()`** — Malley's method cosine-weighted hemisphere sampling
- **`ScatterRecord`** enum (`src/shading/materials.rs`) — `Pdf { scattered, pdf }` and `Delta { scattered }` variants replace the old `Option<Ray>` return
- **`Pdf` trait + `CosineHemispherePdf` + `UniformSpherePdf`** (`src/shading/pdf.rs`) — probability density abstraction

### Material trait changes
- Added `brdf(w_out, w_in, normal, u, v, p) -> Color` — pure BRDF evaluation, folds in albedo
- `scatter()` returns `Option<ScatterRecord>` instead of `Option<Ray>`
- `reflectance()` kept for `Delta`-variant materials and early-termination

### Integrator change (`camera.rs`)
- `Delta` path: `attenuation *= reflectance()` (specular/dielectric/isotropic — unchanged behavior)
- `Pdf` path: `attenuation *= brdf * cos(θ) / pdf` (Lambertian — same result, new formula)

### Equivalence
The `brdf * cos(θ) / pdf` ratio simplifies to `albedo` for Lambertian because `brdf = albedo/π`, `cos(θ)/π` (sampling), and the `π` and `cos(θ)` cancel. Rendered output is byte-identical to main.

## Related
- Issue #28 (Importance Sampling)
- Issue #8 (Techniques from Ray Tracing: The Rest of Your Life)