### PR TITLE
feat: geometric sampling primitives for importance sampling (Step 2)

### DIFF
--- a/src/geometry/compounds/axis_aligned_pbox.rs
+++ b/src/geometry/compounds/axis_aligned_pbox.rs
@@ -86,4 +86,12 @@ impl Geometric for AxisAlignedPBox {
     fn bounding_box(&self) -> Aabb {
         self.0.bounding_box()
     }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        self.0.sample_direction_from(origin)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        self.0.direction_pdf(origin, dir)
+    }
 }

--- a/src/geometry/compounds/axis_aligned_pbox.rs
+++ b/src/geometry/compounds/axis_aligned_pbox.rs
@@ -78,6 +78,11 @@ impl Geometric for AxisAlignedPBox {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
         self.0.intersect(ray, ray_t)
     }
+
+    fn surface_area(&self) -> f64 {
+        self.0.surface_area()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.0.bounding_box()
     }

--- a/src/geometry/compounds/bvh.rs
+++ b/src/geometry/compounds/bvh.rs
@@ -113,6 +113,14 @@ impl Geometric for Bvh {
         }
     }
 
+    fn surface_area(&self) -> f64 {
+        match &self.tree {
+            BvhNode::Branch { left, right } => left.surface_area() + right.surface_area(),
+            BvhNode::Leaf(item) => item.surface_area(),
+            BvhNode::Empty => 0.0,
+        }
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/compounds/bvh.rs
+++ b/src/geometry/compounds/bvh.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, sync::Arc};
 
 use crate::{
-    geometry::{Aabb, Geometric, Ray, RayHit},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
     utils::Interval,
 };
 
@@ -123,5 +123,41 @@ impl Geometric for Bvh {
 
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        match &self.tree {
+            BvhNode::Branch { left, right } => {
+                let left_area = left.surface_area();
+                let right_area = right.surface_area();
+                let total = left_area + right_area;
+                if total <= 0.0 {
+                    return Vector::random_unit();
+                }
+                if rand::random::<f64>() * total <= left_area {
+                    left.sample_direction_from(origin)
+                } else {
+                    right.sample_direction_from(origin)
+                }
+            }
+            BvhNode::Leaf(item) => item.sample_direction_from(origin),
+            BvhNode::Empty => Vector::random_unit(),
+        }
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        match &self.tree {
+            BvhNode::Branch { left, right } => {
+                let total = left.surface_area() + right.surface_area();
+                if total <= 0.0 {
+                    return 0.0;
+                }
+                (left.surface_area() * left.direction_pdf(origin, dir)
+                    + right.surface_area() * right.direction_pdf(origin, dir))
+                    / total
+            }
+            BvhNode::Leaf(item) => item.direction_pdf(origin, dir),
+            BvhNode::Empty => 0.0,
+        }
     }
 }

--- a/src/geometry/compounds/list.rs
+++ b/src/geometry/compounds/list.rs
@@ -84,6 +84,10 @@ impl Geometric for List {
         closest_hit_record
     }
 
+    fn surface_area(&self) -> f64 {
+        self.items.iter().map(|item| item.surface_area()).sum()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/compounds/list.rs
+++ b/src/geometry/compounds/list.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Ray, RayHit},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
     utils::Interval,
 };
 
@@ -90,5 +90,33 @@ impl Geometric for List {
 
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        let total_area = self.surface_area();
+        if total_area <= 0.0 {
+            return Vector::random_unit();
+        }
+        let mut threshold: f64 = rand::random::<f64>() * total_area;
+        for item in &self.items {
+            let area = item.surface_area();
+            if threshold <= area {
+                return item.sample_direction_from(origin);
+            }
+            threshold -= area;
+        }
+        // fallback (floating-point edge case)
+        self.items.last().unwrap().sample_direction_from(origin)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        let total_area = self.surface_area();
+        if total_area <= 0.0 {
+            return 0.0;
+        }
+        self.items
+            .iter()
+            .map(|item| (item.surface_area() / total_area) * item.direction_pdf(origin, dir))
+            .sum()
     }
 }

--- a/src/geometry/compounds/model_obj.rs
+++ b/src/geometry/compounds/model_obj.rs
@@ -137,6 +137,10 @@ impl Geometric for ModelObj {
         self.geometric.intersect(ray, ray_t)
     }
 
+    fn surface_area(&self) -> f64 {
+        self.geometric.surface_area()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.geometric.bounding_box()
     }
@@ -152,6 +156,13 @@ impl Geometric for ListOrBvh {
         match self {
             ListOrBvh::List(list) => list.intersect(ray, ray_t),
             ListOrBvh::Bvh(bvh) => bvh.intersect(ray, ray_t),
+        }
+    }
+
+    fn surface_area(&self) -> f64 {
+        match self {
+            ListOrBvh::List(list) => list.surface_area(),
+            ListOrBvh::Bvh(bvh) => bvh.surface_area(),
         }
     }
 

--- a/src/geometry/compounds/model_obj.rs
+++ b/src/geometry/compounds/model_obj.rs
@@ -144,6 +144,14 @@ impl Geometric for ModelObj {
     fn bounding_box(&self) -> Aabb {
         self.geometric.bounding_box()
     }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        self.geometric.sample_direction_from(origin)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        self.geometric.direction_pdf(origin, dir)
+    }
 }
 
 enum ListOrBvh {
@@ -170,6 +178,20 @@ impl Geometric for ListOrBvh {
         match self {
             ListOrBvh::List(list) => list.bounding_box(),
             ListOrBvh::Bvh(bvh) => bvh.bounding_box(),
+        }
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        match self {
+            ListOrBvh::List(list) => list.sample_direction_from(origin),
+            ListOrBvh::Bvh(bvh) => bvh.sample_direction_from(origin),
+        }
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        match self {
+            ListOrBvh::List(list) => list.direction_pdf(origin, dir),
+            ListOrBvh::Bvh(bvh) => bvh.direction_pdf(origin, dir),
         }
     }
 }

--- a/src/geometry/geometric.rs
+++ b/src/geometry/geometric.rs
@@ -1,4 +1,7 @@
-use crate::utils::Interval;
+use crate::{
+    geometry::{Point, Vector},
+    utils::Interval,
+};
 
 use super::{Aabb, Ray, RayHit};
 
@@ -6,4 +9,22 @@ pub trait Geometric: Sync + Send {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit>;
     fn surface_area(&self) -> f64;
     fn bounding_box(&self) -> Aabb;
+
+    /// Sample a random direction from `origin` toward a point on this object's
+    /// surface, chosen uniformly by area. The returned direction is a unit vector.
+    fn sample_direction_from(&self, origin: Point) -> Vector;
+    /// The solid-angle probability density that [`sample_direction_from`] would
+    /// assign to `dir`. Returns 0.0 if `dir` does not intersect this object.
+    ///
+    /// Internally, this shoots `Ray(origin, dir)` and converts the uniform
+    /// area density to solid-angle density using the Jacobian:
+    ///
+    /// ```text
+    /// p_solid_angle = distance² / (|cos(θ_light)| × area)
+    /// ```
+    ///
+    /// where `distance` is the ray parameter at the hit point, `cos(θ_light)`
+    /// is the absolute cosine between the direction and the surface normal at
+    /// the hit, and `area` is the total surface area.
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64;
 }

--- a/src/geometry/geometric.rs
+++ b/src/geometry/geometric.rs
@@ -4,5 +4,6 @@ use super::{Aabb, Ray, RayHit};
 
 pub trait Geometric: Sync + Send {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit>;
+    fn surface_area(&self) -> f64;
     fn bounding_box(&self) -> Aabb;
 }

--- a/src/geometry/instances/rotate_x_axis.rs
+++ b/src/geometry/instances/rotate_x_axis.rs
@@ -97,6 +97,10 @@ impl Geometric for RotateXAxis {
         Some(rayhit)
     }
 
+    fn surface_area(&self) -> f64 {
+        self.geometric.surface_area()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/rotate_x_axis.rs
+++ b/src/geometry/instances/rotate_x_axis.rs
@@ -104,4 +104,17 @@ impl Geometric for RotateXAxis {
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        let local_origin = self.world_to_local_point(origin);
+        let local_dir = self.geometric.sample_direction_from(local_origin);
+        self.local_to_world_vector(local_dir)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        let local_origin = self.world_to_local_point(origin);
+        let local_dir = self.world_to_local_vector(dir);
+        // PDF is invariant under rigid transforms
+        self.geometric.direction_pdf(local_origin, local_dir)
+    }
 }

--- a/src/geometry/instances/rotate_y_axis.rs
+++ b/src/geometry/instances/rotate_y_axis.rs
@@ -97,6 +97,10 @@ impl Geometric for RotateYAxis {
         Some(rayhit)
     }
 
+    fn surface_area(&self) -> f64 {
+        self.geometric.surface_area()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/rotate_y_axis.rs
+++ b/src/geometry/instances/rotate_y_axis.rs
@@ -104,4 +104,17 @@ impl Geometric for RotateYAxis {
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        let local_origin = self.world_to_local_point(origin);
+        let local_dir = self.geometric.sample_direction_from(local_origin);
+        self.local_to_world_vector(local_dir)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        let local_origin = self.world_to_local_point(origin);
+        let local_dir = self.world_to_local_vector(dir);
+        // PDF is invariant under rigid transforms
+        self.geometric.direction_pdf(local_origin, local_dir)
+    }
 }

--- a/src/geometry/instances/rotate_z_axis.rs
+++ b/src/geometry/instances/rotate_z_axis.rs
@@ -97,6 +97,10 @@ impl Geometric for RotateZAxis {
         Some(rayhit)
     }
 
+    fn surface_area(&self) -> f64 {
+        self.geometric.surface_area()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/rotate_z_axis.rs
+++ b/src/geometry/instances/rotate_z_axis.rs
@@ -104,4 +104,17 @@ impl Geometric for RotateZAxis {
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        let local_origin = self.world_to_local_point(origin);
+        let local_dir = self.geometric.sample_direction_from(local_origin);
+        self.local_to_world_vector(local_dir)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        let local_origin = self.world_to_local_point(origin);
+        let local_dir = self.world_to_local_vector(dir);
+        // PDF is invariant under rigid transforms
+        self.geometric.direction_pdf(local_origin, local_dir)
+    }
 }

--- a/src/geometry/instances/translate.rs
+++ b/src/geometry/instances/translate.rs
@@ -43,6 +43,10 @@ impl Geometric for Translate {
         })
     }
 
+    fn surface_area(&self) -> f64 {
+        self.geometric.surface_area()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/translate.rs
+++ b/src/geometry/instances/translate.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
     utils::Interval,
 };
 
@@ -49,5 +49,17 @@ impl Geometric for Translate {
 
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        let local_origin = Point::from_vector(self.world_to_local(origin.0));
+        // direction is invariant under translation
+        self.geometric.sample_direction_from(local_origin)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        let local_origin = Point::from_vector(self.world_to_local(origin.0));
+        // direction is invariant under translation; PDF is invariant
+        self.geometric.direction_pdf(local_origin, dir)
     }
 }

--- a/src/geometry/primitives/parallelogram.rs
+++ b/src/geometry/primitives/parallelogram.rs
@@ -105,6 +105,10 @@ impl Geometric for Parallelogram {
         })
     }
 
+    fn surface_area(&self) -> f64 {
+        self.u.cross(self.v).length()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/primitives/parallelogram.rs
+++ b/src/geometry/primitives/parallelogram.rs
@@ -17,6 +17,7 @@ pub struct Parallelogram {
     w: Vector,
     material: Arc<dyn Material>,
     bounding_box: Aabb,
+    area: f64, // cache this because it's used quite often in sampling
 }
 
 impl Parallelogram {
@@ -39,6 +40,7 @@ impl Parallelogram {
             w: n / n.dot(n),
             material,
             bounding_box: Aabb::from_points(&[lower_left, lower_left + u + v]).pad(0.0001),
+            area: u.cross(v).length(),
         }
     }
 
@@ -106,11 +108,39 @@ impl Geometric for Parallelogram {
     }
 
     fn surface_area(&self) -> f64 {
-        self.u.cross(self.v).length()
+        self.area
     }
 
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        let alpha: f64 = rand::random();
+        let beta: f64 = rand::random();
+        let p = self.lower_left + alpha * self.u + beta * self.v;
+
+        origin.to(p).unit_vector()
+    }
+
+    fn direction_pdf(&self, origin: Point, direction: Vector) -> f64 {
+        // go from the origin to the hit point
+        let ray = Ray::new(origin, direction, 0.0);
+
+        // did we hit? we might not because it's not a guarantee that the direction was generated from our own sampler!
+        let Some(hit) = self.intersect(ray, Interval::new(0.001, f64::INFINITY)) else {
+            return 0.0;
+        };
+
+        // assuming we hit, convert the area density to solid angle density using the Jacobian:
+        let cos_theta = direction.dot(hit.normal).abs();
+        if cos_theta < 1e-8 {
+            return 0.0;
+        }
+
+        let area = self.surface_area();
+
+        (hit.t * hit.t) / (cos_theta * area)
     }
 }
 

--- a/src/geometry/primitives/sphere.rs
+++ b/src/geometry/primitives/sphere.rs
@@ -1,7 +1,7 @@
 use std::{f64::consts::PI, sync::Arc};
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Onb, Point, Ray, RayHit, Vector},
     shading::materials::{Lambertian, Material},
     utils::Interval,
 };
@@ -62,6 +62,19 @@ impl Sphere {
         }
     }
 
+    /// Generate a random direction within the cone that subtends the sphere
+    /// from a point at `distance_squared` away. The result is in the local
+    /// frame where +Z points toward the sphere center.
+    fn random_to_sphere(radius: f64, distance_squared: f64) -> Vector {
+        let r1: f64 = rand::random();
+        let r2: f64 = rand::random();
+        let cos_theta_max = (1.0 - radius * radius / distance_squared).sqrt();
+        let z = 1.0 + r2 * (cos_theta_max - 1.0);
+        let phi = 2.0 * PI * r1;
+        let sin_theta = (1.0 - z * z).sqrt();
+        Vector::new(phi.cos() * sin_theta, phi.sin() * sin_theta, z)
+    }
+
     fn uv(unit_point: Point) -> (f64, f64) {
         let theta = (-unit_point.0.y).acos();
         let phi = (-unit_point.0.z).atan2(unit_point.0.x) + PI;
@@ -119,5 +132,51 @@ impl Geometric for Sphere {
 
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        // sample the sphere as a cone from origin:
+        // build an ONB with w pointing toward the sphere center,
+        // then sample a direction uniformly within the cone subtended
+        // by the sphere's visible disk
+        let center = self.center_1;
+        let to_center = origin.to(center);
+        let distance_squared = to_center.squared_length();
+
+        // degenerate: origin inside the sphere — sample the full sphere
+        if distance_squared <= self.radius * self.radius {
+            return Vector::random_unit();
+        }
+
+        let onb = Onb::from_w(to_center.unit_vector());
+        let local_dir = Self::random_to_sphere(self.radius, distance_squared);
+        onb.to_world(local_dir)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        // go from origin to the hit point
+        let ray = Ray::new(origin, dir, 0.0);
+
+        // did we hit? we might not because it's not a guarantee that the
+        // direction was generated from our own sampler!
+        if self
+            .intersect(ray, Interval::new(0.001, f64::INFINITY))
+            .is_none()
+        {
+            return 0.0;
+        }
+
+        let distance_squared = origin.to(self.center_1).squared_length();
+
+        // if the origin is at or inside the sphere, the full sphere
+        // is visible — solid angle is 4π
+        if distance_squared <= self.radius * self.radius {
+            return 1.0 / (4.0 * PI);
+        }
+
+        // cone half-angle from origin: sin(θ_max) = radius / distance
+        let cos_theta_max = (1.0 - self.radius * self.radius / distance_squared).sqrt();
+        let solid_angle = 2.0 * PI * (1.0 - cos_theta_max);
+        1.0 / solid_angle
     }
 }

--- a/src/geometry/primitives/sphere.rs
+++ b/src/geometry/primitives/sphere.rs
@@ -113,6 +113,10 @@ impl Geometric for Sphere {
         })
     }
 
+    fn surface_area(&self) -> f64 {
+        4.0 * PI * self.radius * self.radius
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/primitives/triangle.rs
+++ b/src/geometry/primitives/triangle.rs
@@ -17,6 +17,7 @@ pub struct Triangle {
     is_culled: bool,
     material: Arc<dyn Material>,
     bounding_box: Aabb,
+    area: f64, // cache this because it's used quite often in sampling
 }
 
 impl Triangle {
@@ -67,6 +68,9 @@ impl Triangle {
         material: Arc<dyn Material>,
     ) -> Self {
         let bounding_box = Aabb::from_points(&[a, b, c]).pad(0.0001);
+        let ab = a.to(b);
+        let ac = a.to(c);
+        let area = 0.5 * ab.cross(ac).length();
 
         Self {
             a,
@@ -78,6 +82,7 @@ impl Triangle {
             is_culled,
             material,
             bounding_box,
+            area,
         }
     }
 
@@ -160,10 +165,44 @@ impl Geometric for Triangle {
     }
 
     fn surface_area(&self) -> f64 {
-        0.5 * (self.b.to(self.a).cross(self.c.to(self.a))).length()
+        self.area
     }
 
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        // uniform sampling on a triangle using barycentric coordinates
+        // with sqrt to correct for area concentration
+        let r1: f64 = rand::random();
+        let r2: f64 = rand::random();
+        let sqrt_r1 = r1.sqrt();
+        let beta = sqrt_r1 * (1.0 - r2);
+        let gamma = sqrt_r1 * r2;
+
+        let to_b = self.a.to(self.b);
+        let to_c = self.a.to(self.c);
+
+        let p = self.a + to_b * beta + to_c * gamma;
+        origin.to(p).unit_vector()
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        // go from the origin to the hit point
+        let ray = Ray::new(origin, dir, 0.0);
+
+        // did we hit? we might not because it's not a guarantee that the direction was generated from our own sampler!
+        let Some(hit) = self.intersect(ray, Interval::new(0.001, f64::INFINITY)) else {
+            return 0.0;
+        };
+
+        // assuming we hit, convert the area density to solid angle density using the Jacobian:
+        let cos_theta = dir.dot(hit.normal).abs();
+        if cos_theta < 1e-8 {
+            return 0.0;
+        }
+
+        (hit.t * hit.t) / (cos_theta * self.area)
     }
 }

--- a/src/geometry/primitives/triangle.rs
+++ b/src/geometry/primitives/triangle.rs
@@ -159,6 +159,10 @@ impl Geometric for Triangle {
         self.intersect_moller_trumbore(ray, ray_t)
     }
 
+    fn surface_area(&self) -> f64 {
+        0.5 * (self.b.to(self.a).cross(self.c.to(self.a))).length()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -1,4 +1,7 @@
-use std::ops::{Index, IndexMut, Neg};
+use std::{
+    f64::consts::PI,
+    ops::{Index, IndexMut, Neg},
+};
 
 use auto_ops::{impl_op_ex, impl_op_ex_commutative};
 use bincode::{Decode, Encode};
@@ -130,7 +133,7 @@ impl Vector {
     pub fn random_cosine_weighted_direction() -> Self {
         let r1 = rand::random::<f64>();
         let r2 = rand::random::<f64>();
-        let phi = 2.0 * std::f64::consts::PI * r1;
+        let phi = 2.0 * PI * r1;
         let sqrt_r2 = r2.sqrt();
         Self {
             x: phi.cos() * sqrt_r2,

--- a/src/geometry/volumes/constant.rs
+++ b/src/geometry/volumes/constant.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rand::RngExt;
 
 use crate::{
-    geometry::{Aabb, Geometric, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
     shading::{
         Texture,
         materials::{Isotropic, Material},
@@ -90,5 +90,13 @@ impl Geometric for Constant {
 
     fn bounding_box(&self) -> Aabb {
         self.geometric.bounding_box()
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector {
+        self.geometric.sample_direction_from(origin)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+        self.geometric.direction_pdf(origin, dir)
     }
 }

--- a/src/geometry/volumes/constant.rs
+++ b/src/geometry/volumes/constant.rs
@@ -66,8 +66,7 @@ impl Geometric for Constant {
 
         let ray_length = ray.direction.length();
         let distance_inside_boundary = (second_hit.t - first_hit.t) * ray_length;
-        let hit_distance: f64 =
-            self.negative_inverse_density * rand::rng().random::<f64>().ln();
+        let hit_distance: f64 = self.negative_inverse_density * rand::rng().random::<f64>().ln();
 
         // check if the ray made it through the volume
         if hit_distance > distance_inside_boundary {
@@ -83,6 +82,10 @@ impl Geometric for Constant {
             u: 0.0, // arbitrary
             v: 0.0, // arbitrary
         })
+    }
+
+    fn surface_area(&self) -> f64 {
+        self.geometric.surface_area()
     }
 
     fn bounding_box(&self) -> Aabb {

--- a/src/shading/pdf.rs
+++ b/src/shading/pdf.rs
@@ -53,6 +53,45 @@ impl Pdf for CosineHemispherePdf {
     }
 }
 
+/// Uniform probability density over the hemisphere centered on a surface
+/// normal.
+///
+/// `density(dir)` returns `1 / (2π)` if `dir` points above the hemisphere
+/// (i.e., `dot(dir, normal) > 0`), and `0.0` otherwise.
+pub struct UniformHemispherePdf {
+    onb: Onb,
+}
+
+impl UniformHemispherePdf {
+    /// Create a uniform-hemisphere PDF centered on `normal` (the surface normal).
+    pub fn new(normal: Vector) -> Self {
+        Self {
+            onb: Onb::from_w(normal),
+        }
+    }
+}
+
+impl Pdf for UniformHemispherePdf {
+    fn sample(&self) -> Vector {
+        let mut dir = Vector::random_unit();
+        // map lower hemisphere to upper: negate the vector if z < 0.
+        // this doubles the density on +Z (from 1/4π to 1/2π) while
+        // preserving uniformity across the hemisphere.
+        if dir.z < 0.0 {
+            dir = -dir;
+        }
+        self.onb.to_world(dir)
+    }
+
+    fn density(&self, dir: Vector) -> f64 {
+        if self.onb.w.dot(dir) <= 0.0 {
+            0.0
+        } else {
+            1.0 / (2.0 * std::f64::consts::PI)
+        }
+    }
+}
+
 /// Uniform probability density over the full sphere.
 ///
 /// `density(dir)` always returns `1 / (4π)`. Used for isotropic volume


### PR DESCRIPTION
Step 2 of the importance sampling refactor (Issue #28). Adds sample_direction_from and direction_pdf to the Geometric trait and implements them on all geometric types.

### Geometric trait additions
- `surface_area() -> f64` — on all 13 types
- `sample_direction_from(origin: Point) -> Vector`
- `direction_pdf(origin: Point, dir: Vector) -> f64`

### Primitives
- Parallelogram: uniform area + Jacobian
- Triangle: barycentric area
- Sphere: cone sampling (Book 3 §12.3)

### PDF additions
- `UniformHemispherePdf`

### Compounds & instances delegate to children