### PR TITLE
feat: configurable importance sampling with mixture PDFs

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,6 +25,10 @@ run-postgres:
     docker compose up -d postgres
     sqlx migrate run
 
+[group('run')]
+view-logs:
+    docker compose logs -f luxide
+
 [group('build')]
 build: build-api-cli
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -16,7 +16,7 @@ use luxide::{
         materials::{Dielectric, Lambertian, Material, Specular},
         textures::{Checker, Image8Bit, Noise, SolidColor},
     },
-    tracing::{FileStorage, RenderManager, RenderState, RenderStorage, Scene, User},
+    tracing::{FileStorage, RenderManager, RenderState, RenderStorage, Scene, SceneWorld, User},
     utils::Angle,
 };
 use noise::{Perlin, Turbulence};
@@ -319,7 +319,7 @@ fn final_scene() -> Scene {
     Scene {
         // name: "final_scene".to_string(),
         camera,
-        world,
+        world: SceneWorld::from_world_without_importance_sampling(world),
         background_color: Color::BLACK,
     }
 }
@@ -469,7 +469,7 @@ fn cornell_box() -> Scene {
     Scene {
         // name: "cornell_box".to_string(),
         camera,
-        world: Arc::new(world),
+        world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
         background_color: Color::BLACK,
     }
 }
@@ -552,7 +552,7 @@ fn simple_light() -> Scene {
     Scene {
         // name: "simple_light".to_string(),
         camera,
-        world: Arc::new(world),
+        world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
         background_color: Color::BLACK,
     }
 }
@@ -649,7 +649,7 @@ fn quads() -> Scene {
     Scene {
         // name: "quads".to_string(),
         camera,
-        world: Arc::new(world),
+        world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
         background_color: Color::new(0.7, 0.8, 1.0),
     }
 }
@@ -715,7 +715,7 @@ fn two_perlin_spheres() -> Scene {
     Scene {
         // name: "two_perlin_spheres".to_string(),
         camera,
-        world: Arc::new(world),
+        world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
         background_color: Color::new(0.7, 0.8, 1.0),
     }
 }
@@ -793,7 +793,7 @@ fn earth() -> Scene {
     Scene {
         // name: "earth".to_string(),
         camera,
-        world: Arc::new(world),
+        world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
         background_color: Color::new(0.7, 0.8, 1.0),
     }
 }
@@ -845,7 +845,7 @@ fn two_spheres() -> Scene {
 
     Scene {
         // name: "two_spheres".to_string(),
-        world: Arc::new(world),
+        world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
         camera,
         background_color: Color::new(0.7, 0.8, 1.0),
     }
@@ -982,7 +982,7 @@ fn random_spheres() -> Scene {
 
     Scene {
         // name: "random_spheres".to_string(),
-        world,
+        world: SceneWorld::from_world_without_importance_sampling(world),
         camera,
         background_color: Color::new(0.7, 0.8, 1.0),
     }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,4 +1,4 @@
-use std::f64::consts::PI;
+use std::{f64::consts::PI, sync::Arc};
 
 use rand::RngExt;
 
@@ -9,7 +9,7 @@ use crate::{
         materials::ScatterRecord,
         pdf::{GeometricPdf, MixturePdf, Pdf},
     },
-    tracing::{RenderParameters, Scene, SceneWorld},
+    tracing::{ImportanceSamplingConfig, RenderParameters, Scene, SceneWorld},
     utils::{Angle, Interval},
 };
 
@@ -28,6 +28,7 @@ pub struct Camera {
     background_color: Color,
     image_height: u32,
     center: Point,
+    importance_sampling: ImportanceSamplingConfig,
     pixel_00_location: Point,
     pixel_delta_u: Vector,
     pixel_delta_v: Vector,
@@ -61,6 +62,7 @@ impl Camera {
     pub fn initialize(&mut self, parameters: &RenderParameters, scene: &Scene) {
         self.center = self.eye_location;
         self.background_color = scene.background_color;
+        self.importance_sampling = parameters.importance_sampling;
 
         let (width, height) = parameters.image_dimensions;
 
@@ -131,9 +133,7 @@ impl Camera {
         x_offset + y_offset
     }
 
-    pub fn ray_color(&self, mut ray: Ray, world: &SceneWorld, max_bounces: u32) -> Color {
-        let SceneWorld { world, emissives } = world;
-
+    pub fn ray_color(&self, mut ray: Ray, scene_world: &SceneWorld, max_bounces: u32) -> Color {
         // accumulated color contributions of each geometric we intersect along the rays' paths.
         let mut accumulated_color = Color::BLACK;
         // accumulated attentuation (color) of surfaces we encounter.
@@ -143,7 +143,10 @@ impl Camera {
 
         // iterate over geometrics until we fail to intersect, reach max bounces, or find a non-reflective surface
         let mut bounces = 0;
-        while let Some(ray_hit) = world.intersect(ray, Interval::new(0.001, f64::INFINITY)) {
+        while let Some(ray_hit) = scene_world
+            .world
+            .intersect(ray, Interval::new(0.001, f64::INFINITY))
+        {
             let emittance = ray_hit
                 .material
                 .emittance(ray_hit.u, ray_hit.v, ray_hit.point);
@@ -170,7 +173,6 @@ impl Camera {
 
             // unit vector from surface toward the camera (outgoing direction for BRDF)
             let outgoing_direction = (-ray.direction).unit_vector();
-            // ray = srec.scattered();
 
             match srec {
                 ScatterRecord::Delta { scattered } => {
@@ -187,15 +189,12 @@ impl Camera {
                     ray = scattered
                 }
                 ScatterRecord::Pdf { pdf: scatter_pdf } => {
-                    let emissives_pdf = &emissives
-                        .iter()
-                        .map(|e| GeometricPdf::new(e.to_owned(), ray_hit.point))
-                        .collect::<Vec<_>>()[0];
-
-                    let pdf =
-                        MixturePdf::new(scatter_pdf, 0.5, Box::new(emissives_pdf.to_owned()), 0.5);
-
-                    // let pdf = scatter_pdf;
+                    let pdf = build_mixture_pdf(
+                        scatter_pdf,
+                        &self.importance_sampling,
+                        scene_world,
+                        ray_hit.point,
+                    );
 
                     let incident_direction = pdf.sample();
                     let cos_theta = ray_hit.normal.dot(incident_direction);
@@ -232,4 +231,55 @@ impl Camera {
         // then, we can finally return the accumulated color
         accumulated_color
     }
+}
+
+/// Build a mixture PDF from the BRDF scatter PDF and any enabled importance
+/// sampling categories. Skips categories with zero weight or no objects.
+fn build_mixture_pdf(
+    scatter_pdf: Box<dyn Pdf>,
+    config: &ImportanceSamplingConfig,
+    scene_world: &SceneWorld,
+    hit_point: Point,
+) -> Box<dyn Pdf> {
+    let mut entries: Vec<(Box<dyn Pdf>, f64)> = Vec::with_capacity(4);
+
+    // material-provided BRDF category
+    if config.brdf_weight > 0.0 {
+        entries.push((scatter_pdf, config.brdf_weight));
+    }
+
+    // emissive category
+    if config.emissive_weight > 0.0 && !scene_world.emissive_list.is_empty() {
+        entries.push((
+            Box::new(GeometricPdf::new(
+                Arc::clone(&scene_world.emissive_list),
+                hit_point,
+            )),
+            config.emissive_weight,
+        ));
+    }
+
+    // transmissive category
+    if config.transmissive_weight > 0.0 && !scene_world.transmissive_list.is_empty() {
+        entries.push((
+            Box::new(GeometricPdf::new(
+                Arc::clone(&scene_world.transmissive_list),
+                hit_point,
+            )),
+            config.transmissive_weight,
+        ));
+    }
+
+    // specular category
+    if config.specular_weight > 0.0 && !scene_world.specular_list.is_empty() {
+        entries.push((
+            Box::new(GeometricPdf::new(
+                Arc::clone(&scene_world.specular_list),
+                hit_point,
+            )),
+            config.specular_weight,
+        ));
+    }
+
+    Box::new(MixturePdf::new(entries))
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -3,9 +3,13 @@ use std::f64::consts::PI;
 use rand::RngExt;
 
 use crate::{
-    geometry::{Geometric, Point, Ray, Vector},
-    shading::{Color, materials::ScatterRecord},
-    tracing::{RenderParameters, Scene},
+    geometry::{Point, Ray, Vector},
+    shading::{
+        Color,
+        materials::ScatterRecord,
+        pdf::{GeometricPdf, MixturePdf, Pdf},
+    },
+    tracing::{RenderParameters, Scene, SceneWorld},
     utils::{Angle, Interval},
 };
 
@@ -127,7 +131,9 @@ impl Camera {
         x_offset + y_offset
     }
 
-    pub fn ray_color(&self, mut ray: Ray, geometric: &dyn Geometric, max_bounces: u32) -> Color {
+    pub fn ray_color(&self, mut ray: Ray, world: &SceneWorld, max_bounces: u32) -> Color {
+        let SceneWorld { world, emissives } = world;
+
         // accumulated color contributions of each geometric we intersect along the rays' paths.
         let mut accumulated_color = Color::BLACK;
         // accumulated attentuation (color) of surfaces we encounter.
@@ -137,7 +143,7 @@ impl Camera {
 
         // iterate over geometrics until we fail to intersect, reach max bounces, or find a non-reflective surface
         let mut bounces = 0;
-        while let Some(ray_hit) = geometric.intersect(ray, Interval::new(0.001, f64::INFINITY)) {
+        while let Some(ray_hit) = world.intersect(ray, Interval::new(0.001, f64::INFINITY)) {
             let emittance = ray_hit
                 .material
                 .emittance(ray_hit.u, ray_hit.v, ray_hit.point);
@@ -180,7 +186,15 @@ impl Camera {
 
                     ray = scattered
                 }
-                ScatterRecord::Pdf { pdf } => {
+                ScatterRecord::Pdf { pdf: scatter_pdf } => {
+                    let emissives_pdf = &emissives
+                        .iter()
+                        .map(|e| GeometricPdf::new(e.to_owned(), ray_hit.point))
+                        .collect::<Vec<_>>()[0];
+
+                    let pdf =
+                        MixturePdf::new(scatter_pdf, 0.5, Box::new(emissives_pdf.to_owned()), 0.5);
+
                     let incident_direction = pdf.sample();
                     let cos_theta = ray_hit.normal.dot(incident_direction);
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -195,6 +195,8 @@ impl Camera {
                     let pdf =
                         MixturePdf::new(scatter_pdf, 0.5, Box::new(emissives_pdf.to_owned()), 0.5);
 
+                    // let pdf = scatter_pdf;
+
                     let incident_direction = pdf.sample();
                     let cos_theta = ray_hit.normal.dot(incident_direction);
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -243,10 +243,10 @@ fn build_mixture_pdf(
 ) -> Box<dyn Pdf> {
     let mut entries: Vec<(Box<dyn Pdf>, f64)> = Vec::with_capacity(4);
 
-    // material-provided BRDF category
-    if config.brdf_weight > 0.0 {
-        entries.push((scatter_pdf, config.brdf_weight));
-    }
+    // material-provided BRDF category — always included as fallback;
+    // zero weight means it won't be sampled unless all other
+    // categories are also empty
+    entries.push((scatter_pdf, config.brdf_weight));
 
     // emissive category
     if config.emissive_weight > 0.0 && !scene_world.emissive_list.is_empty() {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -150,7 +150,11 @@ impl Camera {
             }
 
             // early termination: if the surface absorbs all light, skip scatter
-            if ray_hit.material.reflectance(ray_hit.u, ray_hit.v, ray_hit.point) == Color::BLACK {
+            if ray_hit
+                .material
+                .reflectance(ray_hit.u, ray_hit.v, ray_hit.point)
+                == Color::BLACK
+            {
                 return accumulated_color;
             }
 
@@ -176,9 +180,8 @@ impl Camera {
 
                     ray = scattered
                 }
-                ScatterRecord::Pdf { pdf, scattered } => {
-                    // unit vector from surface toward the light source (incident direction for BRDF)
-                    let incident_direction = scattered.direction.unit_vector();
+                ScatterRecord::Pdf { pdf } => {
+                    let incident_direction = pdf.sample();
                     let cos_theta = ray_hit.normal.dot(incident_direction);
 
                     let brdf_val = ray_hit.material.brdf(
@@ -189,9 +192,10 @@ impl Camera {
                         ray_hit.v,
                         ray_hit.point,
                     );
-                    attentuation_strength *= brdf_val * cos_theta / pdf;
+                    let pdf_val = pdf.density(incident_direction);
+                    attentuation_strength *= brdf_val * cos_theta / pdf_val;
 
-                    ray = scattered
+                    ray = Ray::new(ray_hit.point, incident_direction, ray.time)
                 }
             }
 

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -113,8 +113,11 @@ impl RenderConfig {
 
         let active_scene = self.active_scene.build(&builts)?;
 
+        let mut parameters = self.parameters;
+        parameters.importance_sampling.normalize();
+
         Ok(RenderData {
-            parameters: self.parameters,
+            parameters,
             scene: active_scene,
         })
     }

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -102,8 +102,6 @@ impl RenderConfig {
     pub fn compile(&self) -> Result<RenderData, String> {
         let mut builts = Builts::new();
 
-        self.validate()?;
-
         // setup named properties
         build_textures(&self.textures, &mut builts)?;
         build_materials(&self.materials, &mut builts)?;
@@ -112,6 +110,8 @@ impl RenderConfig {
         build_scenes(&self.scenes, &mut builts)?;
 
         let active_scene = self.active_scene.build(&builts)?;
+
+        self.validate(&active_scene)?;
 
         let mut parameters = self.parameters;
         parameters.importance_sampling.normalize();
@@ -123,8 +123,10 @@ impl RenderConfig {
     }
 
     // mostly for handling validation that isn't covered by the `build` functions above
-    pub fn validate(&self) -> Result<(), String> {
-        self.parameters.importance_sampling.validate()?;
+    pub fn validate(&self, active_scene: &Scene) -> Result<(), String> {
+        self.parameters
+            .importance_sampling
+            .validate(&active_scene.world)?;
 
         Ok(())
     }

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -102,6 +102,8 @@ impl RenderConfig {
     pub fn compile(&self) -> Result<RenderData, String> {
         let mut builts = Builts::new();
 
+        self.validate()?;
+
         // setup named properties
         build_textures(&self.textures, &mut builts)?;
         build_materials(&self.materials, &mut builts)?;
@@ -115,6 +117,13 @@ impl RenderConfig {
             parameters: self.parameters,
             scene: active_scene,
         })
+    }
+
+    // mostly for handling validation that isn't covered by the `build` functions above
+    pub fn validate(&self) -> Result<(), String> {
+        self.parameters.importance_sampling.validate()?;
+
+        Ok(())
     }
 }
 

--- a/src/deserialization/scenes.rs
+++ b/src/deserialization/scenes.rs
@@ -1,11 +1,6 @@
-use std::sync::Arc;
-
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    geometry::compounds::{Bvh, List},
-    tracing::Scene,
-};
+use crate::tracing::{Scene, SceneWorld};
 
 use super::{Build, Builts, cameras::CameraRefOrInline, geometrics::GeometricRefOrInline};
 
@@ -45,7 +40,7 @@ pub struct SceneData {
 
 impl Build<Scene> for SceneData {
     fn build(&self, builts: &Builts) -> Result<Scene, String> {
-        let mut world = List::new();
+        let mut world = Vec::new();
 
         for geometric in &self.geometrics {
             let geometric = geometric.build(builts)?;
@@ -53,11 +48,7 @@ impl Build<Scene> for SceneData {
         }
         let camera = self.camera.build(builts)?;
         let scene = Scene {
-            world: if self.use_bvh {
-                Arc::new(Bvh::from_list(world))
-            } else {
-                Arc::new(world)
-            },
+            world: SceneWorld::from_geometrics(&world, self.use_bvh),
             camera,
             background_color: self.background_color.into(),
         };

--- a/src/deserialization/scenes.rs
+++ b/src/deserialization/scenes.rs
@@ -46,6 +46,7 @@ pub struct SceneData {
 impl Build<Scene> for SceneData {
     fn build(&self, builts: &Builts) -> Result<Scene, String> {
         let mut world = List::new();
+
         for geometric in &self.geometrics {
             let geometric = geometric.build(builts)?;
             world.push(geometric);

--- a/src/geometry/compounds/axis_aligned_pbox.rs
+++ b/src/geometry/compounds/axis_aligned_pbox.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::List;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AxisAlignedPBox(List);
 
 impl AxisAlignedPBox {

--- a/src/geometry/compounds/axis_aligned_pbox.rs
+++ b/src/geometry/compounds/axis_aligned_pbox.rs
@@ -87,6 +87,18 @@ impl Geometric for AxisAlignedPBox {
         self.0.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.0.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.0.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.0.bounding_box()
     }

--- a/src/geometry/compounds/axis_aligned_pbox.rs
+++ b/src/geometry/compounds/axis_aligned_pbox.rs
@@ -83,6 +83,10 @@ impl Geometric for AxisAlignedPBox {
         self.0.surface_area()
     }
 
+    fn is_emissive(&self) -> bool {
+        self.0.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.0.bounding_box()
     }

--- a/src/geometry/compounds/bvh.rs
+++ b/src/geometry/compounds/bvh.rs
@@ -7,14 +7,14 @@ use crate::{
 
 use super::List;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum BvhNode {
     Branch { left: Arc<Bvh>, right: Arc<Bvh> },
     Leaf(Arc<dyn Geometric>),
     Empty,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Bvh {
     tree: BvhNode,
     bounding_box: Aabb,

--- a/src/geometry/compounds/bvh.rs
+++ b/src/geometry/compounds/bvh.rs
@@ -129,6 +129,30 @@ impl Geometric for Bvh {
         }
     }
 
+    fn is_transmissive(&self) -> bool {
+        match &self.tree {
+            BvhNode::Branch { left, right } => left.is_transmissive() || right.is_transmissive(),
+            BvhNode::Leaf(item) => item.is_transmissive(),
+            BvhNode::Empty => false,
+        }
+    }
+
+    fn is_specular(&self) -> bool {
+        match &self.tree {
+            BvhNode::Branch { left, right } => left.is_specular() || right.is_specular(),
+            BvhNode::Leaf(item) => item.is_specular(),
+            BvhNode::Empty => false,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match &self.tree {
+            BvhNode::Branch { left, right } => left.is_empty() && right.is_empty(),
+            BvhNode::Leaf(item) => item.is_empty(),
+            BvhNode::Empty => true,
+        }
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/compounds/bvh.rs
+++ b/src/geometry/compounds/bvh.rs
@@ -121,6 +121,14 @@ impl Geometric for Bvh {
         }
     }
 
+    fn is_emissive(&self) -> bool {
+        match &self.tree {
+            BvhNode::Branch { left, right } => left.is_emissive() || right.is_emissive(),
+            BvhNode::Leaf(item) => item.is_emissive(),
+            BvhNode::Empty => false,
+        }
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/compounds/list.rs
+++ b/src/geometry/compounds/list.rs
@@ -59,13 +59,11 @@ impl List {
     pub fn take_items(self) -> Vec<Arc<dyn Geometric>> {
         self.items
     }
+}
 
-    pub fn len(&self) -> usize {
-        self.items.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.items.is_empty()
+impl From<Vec<Arc<dyn Geometric>>> for List {
+    fn from(geometrics: Vec<Arc<dyn Geometric>>) -> Self {
+        Self::from_vec(geometrics)
     }
 }
 
@@ -90,6 +88,18 @@ impl Geometric for List {
 
     fn is_emissive(&self) -> bool {
         self.items.iter().any(|item| item.is_emissive())
+    }
+
+    fn is_transmissive(&self) -> bool {
+        self.items.iter().any(|item| item.is_transmissive())
+    }
+
+    fn is_specular(&self) -> bool {
+        self.items.iter().any(|item| item.is_specular())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.items.is_empty()
     }
 
     fn bounding_box(&self) -> Aabb {

--- a/src/geometry/compounds/list.rs
+++ b/src/geometry/compounds/list.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::Interval,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct List {
     pub items: Vec<Arc<dyn Geometric>>,
     bounding_box: Aabb,

--- a/src/geometry/compounds/list.rs
+++ b/src/geometry/compounds/list.rs
@@ -88,6 +88,10 @@ impl Geometric for List {
         self.items.iter().map(|item| item.surface_area()).sum()
     }
 
+    fn is_emissive(&self) -> bool {
+        self.items.iter().any(|item| item.is_emissive())
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/compounds/model_obj.rs
+++ b/src/geometry/compounds/model_obj.rs
@@ -146,6 +146,18 @@ impl Geometric for ModelObj {
         self.geometric.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.geometric.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.geometric.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.geometric.is_empty()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.geometric.bounding_box()
     }
@@ -184,6 +196,27 @@ impl Geometric for ListOrBvh {
         match self {
             ListOrBvh::List(list) => list.is_emissive(),
             ListOrBvh::Bvh(bvh) => bvh.is_emissive(),
+        }
+    }
+
+    fn is_transmissive(&self) -> bool {
+        match self {
+            ListOrBvh::List(list) => list.is_transmissive(),
+            ListOrBvh::Bvh(bvh) => bvh.is_transmissive(),
+        }
+    }
+
+    fn is_specular(&self) -> bool {
+        match self {
+            ListOrBvh::List(list) => list.is_specular(),
+            ListOrBvh::Bvh(bvh) => bvh.is_specular(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            ListOrBvh::List(list) => list.is_empty(),
+            ListOrBvh::Bvh(bvh) => bvh.is_empty(),
         }
     }
 

--- a/src/geometry/compounds/model_obj.rs
+++ b/src/geometry/compounds/model_obj.rs
@@ -142,6 +142,10 @@ impl Geometric for ModelObj {
         self.geometric.surface_area()
     }
 
+    fn is_emissive(&self) -> bool {
+        self.geometric.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.geometric.bounding_box()
     }
@@ -173,6 +177,13 @@ impl Geometric for ListOrBvh {
         match self {
             ListOrBvh::List(list) => list.surface_area(),
             ListOrBvh::Bvh(bvh) => bvh.surface_area(),
+        }
+    }
+
+    fn is_emissive(&self) -> bool {
+        match self {
+            ListOrBvh::List(list) => list.is_emissive(),
+            ListOrBvh::Bvh(bvh) => bvh.is_emissive(),
         }
     }
 

--- a/src/geometry/compounds/model_obj.rs
+++ b/src/geometry/compounds/model_obj.rs
@@ -8,6 +8,7 @@ use crate::{
 
 use super::{Bvh, List};
 
+#[derive(Clone, Debug)]
 pub struct ModelObj {
     geometric: ListOrBvh,
 }
@@ -154,6 +155,7 @@ impl Geometric for ModelObj {
     }
 }
 
+#[derive(Clone, Debug)]
 enum ListOrBvh {
     List(List),
     Bvh(Bvh),

--- a/src/geometry/geometric.rs
+++ b/src/geometry/geometric.rs
@@ -10,6 +10,17 @@ pub trait Geometric: std::fmt::Debug + Sync + Send {
     /// Whether any point on this geometric object emits light.
     /// Delegates to the material for primitives, OR of children for compounds.
     fn is_emissive(&self) -> bool;
+
+    /// Whether this geometric object transmits light (glass / dielectric).
+    fn is_transmissive(&self) -> bool;
+
+    /// Whether this geometric object reflects specularly (mirror / metal).
+    fn is_specular(&self) -> bool;
+
+    /// Whether this geometric object contains no primitives.
+    /// Defaults to `false` — overridden by compound types like `List`.
+    fn is_empty(&self) -> bool;
+
     fn surface_area(&self) -> f64;
     fn bounding_box(&self) -> Aabb;
 

--- a/src/geometry/geometric.rs
+++ b/src/geometry/geometric.rs
@@ -7,6 +7,9 @@ use super::{Aabb, Ray, RayHit};
 
 pub trait Geometric: std::fmt::Debug + Sync + Send {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit>;
+    /// Whether any point on this geometric object emits light.
+    /// Delegates to the material for primitives, OR of children for compounds.
+    fn is_emissive(&self) -> bool;
     fn surface_area(&self) -> f64;
     fn bounding_box(&self) -> Aabb;
 

--- a/src/geometry/geometric.rs
+++ b/src/geometry/geometric.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::{Aabb, Ray, RayHit};
 
-pub trait Geometric: Sync + Send {
+pub trait Geometric: std::fmt::Debug + Sync + Send {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit>;
     fn surface_area(&self) -> f64;
     fn bounding_box(&self) -> Aabb;

--- a/src/geometry/instances/rotate_x_axis.rs
+++ b/src/geometry/instances/rotate_x_axis.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::{Angle, Interval},
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RotateXAxis {
     geometric: Arc<dyn Geometric>,
     translation: Vector,

--- a/src/geometry/instances/rotate_x_axis.rs
+++ b/src/geometry/instances/rotate_x_axis.rs
@@ -101,6 +101,10 @@ impl Geometric for RotateXAxis {
         self.geometric.surface_area()
     }
 
+    fn is_emissive(&self) -> bool {
+        self.geometric.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/rotate_x_axis.rs
+++ b/src/geometry/instances/rotate_x_axis.rs
@@ -105,6 +105,18 @@ impl Geometric for RotateXAxis {
         self.geometric.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.geometric.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.geometric.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.geometric.is_empty()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/rotate_y_axis.rs
+++ b/src/geometry/instances/rotate_y_axis.rs
@@ -105,6 +105,18 @@ impl Geometric for RotateYAxis {
         self.geometric.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.geometric.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.geometric.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.geometric.is_empty()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/rotate_y_axis.rs
+++ b/src/geometry/instances/rotate_y_axis.rs
@@ -101,6 +101,10 @@ impl Geometric for RotateYAxis {
         self.geometric.surface_area()
     }
 
+    fn is_emissive(&self) -> bool {
+        self.geometric.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/rotate_y_axis.rs
+++ b/src/geometry/instances/rotate_y_axis.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::{Angle, Interval},
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RotateYAxis {
     geometric: Arc<dyn Geometric>,
     translation: Vector,

--- a/src/geometry/instances/rotate_z_axis.rs
+++ b/src/geometry/instances/rotate_z_axis.rs
@@ -105,6 +105,18 @@ impl Geometric for RotateZAxis {
         self.geometric.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.geometric.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.geometric.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.geometric.is_empty()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/rotate_z_axis.rs
+++ b/src/geometry/instances/rotate_z_axis.rs
@@ -101,6 +101,10 @@ impl Geometric for RotateZAxis {
         self.geometric.surface_area()
     }
 
+    fn is_emissive(&self) -> bool {
+        self.geometric.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/rotate_z_axis.rs
+++ b/src/geometry/instances/rotate_z_axis.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::{Angle, Interval},
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RotateZAxis {
     geometric: Arc<dyn Geometric>,
     translation: Vector,

--- a/src/geometry/instances/translate.rs
+++ b/src/geometry/instances/translate.rs
@@ -47,6 +47,10 @@ impl Geometric for Translate {
         self.geometric.surface_area()
     }
 
+    fn is_emissive(&self) -> bool {
+        self.geometric.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/translate.rs
+++ b/src/geometry/instances/translate.rs
@@ -51,6 +51,18 @@ impl Geometric for Translate {
         self.geometric.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.geometric.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.geometric.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.geometric.is_empty()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/instances/translate.rs
+++ b/src/geometry/instances/translate.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::Interval,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Translate {
     geometric: Arc<dyn Geometric>,
     translation: Vector,

--- a/src/geometry/primitives/parallelogram.rs
+++ b/src/geometry/primitives/parallelogram.rs
@@ -115,6 +115,18 @@ impl Geometric for Parallelogram {
         self.material.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.material.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.material.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.surface_area() <= 0.0
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/primitives/parallelogram.rs
+++ b/src/geometry/primitives/parallelogram.rs
@@ -111,6 +111,10 @@ impl Geometric for Parallelogram {
         self.area
     }
 
+    fn is_emissive(&self) -> bool {
+        self.material.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/primitives/parallelogram.rs
+++ b/src/geometry/primitives/parallelogram.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::Interval,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Parallelogram {
     lower_left: Point,
     u: Vector,

--- a/src/geometry/primitives/sphere.rs
+++ b/src/geometry/primitives/sphere.rs
@@ -134,6 +134,18 @@ impl Geometric for Sphere {
         self.material.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.material.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.material.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.radius <= 0.0
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/primitives/sphere.rs
+++ b/src/geometry/primitives/sphere.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::Interval,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Sphere {
     center_1: Point,
     center_vector: Option<Vector>,

--- a/src/geometry/primitives/sphere.rs
+++ b/src/geometry/primitives/sphere.rs
@@ -130,6 +130,10 @@ impl Geometric for Sphere {
         4.0 * PI * self.radius * self.radius
     }
 
+    fn is_emissive(&self) -> bool {
+        self.material.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/primitives/triangle.rs
+++ b/src/geometry/primitives/triangle.rs
@@ -172,6 +172,18 @@ impl Geometric for Triangle {
         self.material.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.material.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.material.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.surface_area() <= 0.0
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/primitives/triangle.rs
+++ b/src/geometry/primitives/triangle.rs
@@ -168,6 +168,10 @@ impl Geometric for Triangle {
         self.area
     }
 
+    fn is_emissive(&self) -> bool {
+        self.material.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.bounding_box
     }

--- a/src/geometry/primitives/triangle.rs
+++ b/src/geometry/primitives/triangle.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::Interval,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Triangle {
     a: Point,
     b: Point,

--- a/src/geometry/ray_hit.rs
+++ b/src/geometry/ray_hit.rs
@@ -4,7 +4,7 @@ use crate::shading::materials::Material;
 
 use super::{Point, Vector};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RayHit {
     pub t: f64,
     pub point: Point,

--- a/src/geometry/volumes/constant.rs
+++ b/src/geometry/volumes/constant.rs
@@ -88,6 +88,10 @@ impl Geometric for Constant {
         self.geometric.surface_area()
     }
 
+    fn is_emissive(&self) -> bool {
+        self.geometric.is_emissive()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.geometric.bounding_box()
     }

--- a/src/geometry/volumes/constant.rs
+++ b/src/geometry/volumes/constant.rs
@@ -92,6 +92,18 @@ impl Geometric for Constant {
         self.geometric.is_emissive()
     }
 
+    fn is_transmissive(&self) -> bool {
+        self.geometric.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.geometric.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.geometric.is_empty()
+    }
+
     fn bounding_box(&self) -> Aabb {
         self.geometric.bounding_box()
     }

--- a/src/geometry/volumes/constant.rs
+++ b/src/geometry/volumes/constant.rs
@@ -12,7 +12,7 @@ use crate::{
     utils::Interval,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Constant {
     geometric: Arc<dyn Geometric>,
     negative_inverse_density: f64,

--- a/src/shading/materials.rs
+++ b/src/shading/materials.rs
@@ -17,6 +17,10 @@ pub use specular::Specular;
 pub trait Material: std::fmt::Debug + Sync + Send {
     fn emittance(&self, u: f64, v: f64, p: Point) -> Color;
 
+    /// Whether this material emits any light at any point on its surface.
+    /// Used to build the lights list for importance sampling.
+    fn is_emissive(&self) -> bool;
+
     /// The raw albedo (reflectance color) of this material at a surface point.
     ///
     /// For `Delta`-variant materials (Specular, Dielectric, Isotropic), this

--- a/src/shading/materials.rs
+++ b/src/shading/materials.rs
@@ -1,4 +1,5 @@
 use super::Color;
+use super::pdf::Pdf;
 use crate::geometry::{Point, Ray, RayHit, Vector};
 
 mod dielectric;
@@ -57,13 +58,11 @@ pub trait Material: std::fmt::Debug + Sync + Send {
 /// `Pdf` carries a sampling probability density for diffuse materials
 /// (Lambertian). `Delta` is for specular/dielectric materials that have
 /// a deterministic (delta-function) bounce — no finite PDF exists.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub enum ScatterRecord {
     Pdf {
-        /// The scattered ray to continue tracing.
-        scattered: Ray,
-        /// The solid-angle probability density of the chosen scatter direction.
-        pdf: f64,
+        /// The probability density function for the scatter direction.
+        pdf: Box<dyn Pdf>,
     },
     Delta {
         /// The scattered ray to continue tracing.

--- a/src/shading/materials.rs
+++ b/src/shading/materials.rs
@@ -21,6 +21,12 @@ pub trait Material: std::fmt::Debug + Sync + Send {
     /// Used to build the lights list for importance sampling.
     fn is_emissive(&self) -> bool;
 
+    /// Whether this material transmits light (glass / dielectric).
+    fn is_transmissive(&self) -> bool;
+
+    /// Whether this material reflects specularly (mirror / metal).
+    fn is_specular(&self) -> bool;
+
     /// The raw albedo (reflectance color) of this material at a surface point.
     ///
     /// For `Delta`-variant materials (Specular, Dielectric, Isotropic), this

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -43,6 +43,14 @@ impl Material for Dielectric {
         self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
     }
 
+    fn is_transmissive(&self) -> bool {
+        true
+    }
+
+    fn is_specular(&self) -> bool {
+        false
+    }
+
     fn reflectance(&self, u: f64, v: f64, p: Point) -> Color {
         self.reflectance_texture.value(u, v, p)
     }

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -39,6 +39,10 @@ impl Material for Dielectric {
         self.emittance_texture.value(u, v, p)
     }
 
+    fn is_emissive(&self) -> bool {
+        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
+    }
+
     fn reflectance(&self, u: f64, v: f64, p: Point) -> Color {
         self.reflectance_texture.value(u, v, p)
     }
@@ -79,8 +83,6 @@ impl Material for Dielectric {
         };
 
         let scattered = Ray::new(ray_hit.point, refracted, ray.time);
-        Some(ScatterRecord::Delta {
-            scattered,
-        })
+        Some(ScatterRecord::Delta { scattered })
     }
 }

--- a/src/shading/materials/isotropic.rs
+++ b/src/shading/materials/isotropic.rs
@@ -35,6 +35,14 @@ impl Material for Isotropic {
         self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
     }
 
+    fn is_transmissive(&self) -> bool {
+        false
+    }
+
+    fn is_specular(&self) -> bool {
+        false
+    }
+
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         // always scatter, and always scatter in a random direction
         Some(ScatterRecord::Delta {

--- a/src/shading/materials/isotropic.rs
+++ b/src/shading/materials/isotropic.rs
@@ -31,6 +31,10 @@ impl Material for Isotropic {
         self.emittance_texture.value(u, v, p)
     }
 
+    fn is_emissive(&self) -> bool {
+        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
+    }
+
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         // always scatter, and always scatter in a random direction
         Some(ScatterRecord::Delta {

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -52,6 +52,14 @@ impl Material for Lambertian {
         self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
     }
 
+    fn is_transmissive(&self) -> bool {
+        false
+    }
+
+    fn is_specular(&self) -> bool {
+        false
+    }
+
     fn scatter(&self, _ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         Some(ScatterRecord::Pdf {
             pdf: Box::new(CosineHemispherePdf::new(ray_hit.normal)),

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::shading::pdf::{CosineHemispherePdf, Pdf};
+use crate::shading::pdf::CosineHemispherePdf;
 use crate::{
     geometry::{Point, Ray, RayHit, Vector},
     shading::{Color, Texture, textures::SolidColor},
@@ -48,13 +48,9 @@ impl Material for Lambertian {
         self.emittance_texture.value(u, v, p)
     }
 
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
-        let pdf = CosineHemispherePdf::new(ray_hit.normal);
-        let direction = pdf.sample();
-
+    fn scatter(&self, _ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         Some(ScatterRecord::Pdf {
-            scattered: Ray::new(ray_hit.point, direction, ray.time),
-            pdf: pdf.density(direction),
+            pdf: Box::new(CosineHemispherePdf::new(ray_hit.normal)),
         })
     }
 

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -48,6 +48,10 @@ impl Material for Lambertian {
         self.emittance_texture.value(u, v, p)
     }
 
+    fn is_emissive(&self) -> bool {
+        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
+    }
+
     fn scatter(&self, _ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         Some(ScatterRecord::Pdf {
             pdf: Box::new(CosineHemispherePdf::new(ray_hit.normal)),

--- a/src/shading/materials/specular.rs
+++ b/src/shading/materials/specular.rs
@@ -37,6 +37,10 @@ impl Material for Specular {
         self.emittance_texture.value(u, v, p)
     }
 
+    fn is_emissive(&self) -> bool {
+        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
+    }
+
     fn brdf(
         &self,
         _outgoing_direction: Vector,

--- a/src/shading/materials/specular.rs
+++ b/src/shading/materials/specular.rs
@@ -41,6 +41,14 @@ impl Material for Specular {
         self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
     }
 
+    fn is_transmissive(&self) -> bool {
+        false
+    }
+
+    fn is_specular(&self) -> bool {
+        true
+    }
+
     fn brdf(
         &self,
         _outgoing_direction: Vector,

--- a/src/shading/pdf.rs
+++ b/src/shading/pdf.rs
@@ -118,7 +118,7 @@ impl Pdf for UniformSpherePdf {
 /// Stores the geometric object and the origin point so `sample()` and
 /// `density()` can delegate to the object's `sample_direction_from` /
 /// `direction_pdf` methods without needing an explicit origin parameter.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GeometricPdf {
     geometric: Arc<dyn Geometric>,
     origin: Point,

--- a/src/shading/pdf.rs
+++ b/src/shading/pdf.rs
@@ -1,4 +1,6 @@
-use crate::geometry::{Onb, Vector};
+use std::sync::Arc;
+
+use crate::geometry::{Geometric, Onb, Point, Vector};
 
 /// A probability density function over solid angle (directions on the unit
 /// sphere or hemisphere).
@@ -11,8 +13,8 @@ pub trait Pdf {
     /// Draw a random unit direction distributed according to this PDF.
     fn sample(&self) -> Vector;
 
-    /// The solid-angle probability density at `dir`.
-    fn density(&self, dir: Vector) -> f64;
+    /// The solid-angle probability density at `direction`.
+    fn density(&self, direction: Vector) -> f64;
 }
 
 /// Cosine-weighted probability density over the hemisphere centered on a
@@ -43,8 +45,8 @@ impl Pdf for CosineHemispherePdf {
             .to_world(Vector::random_cosine_weighted_direction())
     }
 
-    fn density(&self, dir: Vector) -> f64 {
-        let cos_theta = self.onb.w.dot(dir);
+    fn density(&self, direction: Vector) -> f64 {
+        let cos_theta = self.onb.w.dot(direction);
         if cos_theta <= 0.0 {
             0.0
         } else {
@@ -73,18 +75,18 @@ impl UniformHemispherePdf {
 
 impl Pdf for UniformHemispherePdf {
     fn sample(&self) -> Vector {
-        let mut dir = Vector::random_unit();
+        let mut direction = Vector::random_unit();
         // map lower hemisphere to upper: negate the vector if z < 0.
         // this doubles the density on +Z (from 1/4π to 1/2π) while
         // preserving uniformity across the hemisphere.
-        if dir.z < 0.0 {
-            dir = -dir;
+        if direction.z < 0.0 {
+            direction = -direction;
         }
-        self.onb.to_world(dir)
+        self.onb.to_world(direction)
     }
 
-    fn density(&self, dir: Vector) -> f64 {
-        if self.onb.w.dot(dir) <= 0.0 {
+    fn density(&self, direction: Vector) -> f64 {
+        if self.onb.w.dot(direction) <= 0.0 {
             0.0
         } else {
             1.0 / (2.0 * std::f64::consts::PI)
@@ -105,5 +107,80 @@ impl Pdf for UniformSpherePdf {
 
     fn density(&self, _dir: Vector) -> f64 {
         1.0 / (4.0 * std::f64::consts::PI)
+    }
+}
+
+/// PDF that samples directions toward a piece of geometry (typically a light).
+///
+/// Stores the geometric object and the origin point so `sample()` and
+/// `density()` can delegate to the object's `sample_direction_from` /
+/// `direction_pdf` methods without needing an explicit origin parameter.
+pub struct GeometricPdf {
+    geometric: Arc<dyn Geometric>,
+    origin: Point,
+}
+
+impl GeometricPdf {
+    pub fn new(geometric: Arc<dyn Geometric>, origin: Point) -> Self {
+        Self { geometric, origin }
+    }
+}
+
+impl Pdf for GeometricPdf {
+    fn sample(&self) -> Vector {
+        self.geometric.sample_direction_from(self.origin)
+    }
+
+    fn density(&self, direction: Vector) -> f64 {
+        self.geometric.direction_pdf(self.origin, direction)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MixturePdf
+// ---------------------------------------------------------------------------
+
+/// Blends two PDFs with equal weight (50/50).
+///
+/// `sample()` flips a fair coin to choose which distribution to draw from.
+/// `density()` returns the weighted average of both densities, regardless
+/// of which one was used for sampling. This is correct because every
+/// direction that either PDF could have generated contributes to the
+/// denominator in the Monte Carlo estimator.
+pub struct MixturePdf {
+    a: Box<dyn Pdf>,
+    a_weight: f64,
+    b: Box<dyn Pdf>,
+    b_weight: f64,
+}
+
+impl MixturePdf {
+    pub fn new(a: Box<dyn Pdf>, a_weight: f64, b: Box<dyn Pdf>, b_weight: f64) -> Self {
+        let total = a_weight + b_weight;
+
+        Self {
+            a,
+            a_weight: a_weight / total,
+            b,
+            b_weight: b_weight / total,
+        }
+    }
+
+    pub fn new_equal(a: Box<dyn Pdf>, b: Box<dyn Pdf>) -> Self {
+        Self::new(a, 0.5, b, 0.5)
+    }
+}
+
+impl Pdf for MixturePdf {
+    fn sample(&self) -> Vector {
+        if rand::random::<f64>() < self.a_weight {
+            self.a.sample()
+        } else {
+            self.b.sample()
+        }
+    }
+
+    fn density(&self, direction: Vector) -> f64 {
+        self.a_weight * self.a.density(direction) + self.b_weight * self.b.density(direction)
     }
 }

--- a/src/shading/pdf.rs
+++ b/src/shading/pdf.rs
@@ -9,7 +9,7 @@ use crate::geometry::{Geometric, Onb, Point, Vector};
 /// - `sample()` draws a random direction distributed according to this PDF.
 /// - `density(dir)` returns the probability density that `sample()` would
 ///   have assigned to the given direction.
-pub trait Pdf {
+pub trait Pdf: std::fmt::Debug {
     /// Draw a random unit direction distributed according to this PDF.
     fn sample(&self) -> Vector;
 
@@ -26,6 +26,7 @@ pub trait Pdf {
 /// Internally uses [`Vector::random_cosine_weighted_direction`] and [`Onb`] to
 /// generate directions (Malley's method: uniform disk sample projected
 /// onto the hemisphere).
+#[derive(Debug)]
 pub struct CosineHemispherePdf {
     onb: Onb,
 }
@@ -60,6 +61,7 @@ impl Pdf for CosineHemispherePdf {
 ///
 /// `density(dir)` returns `1 / (2π)` if `dir` points above the hemisphere
 /// (i.e., `dot(dir, normal) > 0`), and `0.0` otherwise.
+#[derive(Debug)]
 pub struct UniformHemispherePdf {
     onb: Onb,
 }
@@ -98,6 +100,7 @@ impl Pdf for UniformHemispherePdf {
 ///
 /// `density(dir)` always returns `1 / (4π)`. Used for isotropic volume
 /// scattering materials.
+#[derive(Debug)]
 pub struct UniformSpherePdf;
 
 impl Pdf for UniformSpherePdf {
@@ -115,6 +118,7 @@ impl Pdf for UniformSpherePdf {
 /// Stores the geometric object and the origin point so `sample()` and
 /// `density()` can delegate to the object's `sample_direction_from` /
 /// `direction_pdf` methods without needing an explicit origin parameter.
+#[derive(Debug)]
 pub struct GeometricPdf {
     geometric: Arc<dyn Geometric>,
     origin: Point,
@@ -147,6 +151,7 @@ impl Pdf for GeometricPdf {
 /// of which one was used for sampling. This is correct because every
 /// direction that either PDF could have generated contributes to the
 /// denominator in the Monte Carlo estimator.
+#[derive(Debug)]
 pub struct MixturePdf {
     a: Box<dyn Pdf>,
     a_weight: f64,

--- a/src/shading/pdf.rs
+++ b/src/shading/pdf.rs
@@ -140,52 +140,49 @@ impl Pdf for GeometricPdf {
     }
 }
 
-// ---------------------------------------------------------------------------
-// MixturePdf
-// ---------------------------------------------------------------------------
-
-/// Blends two PDFs with equal weight (50/50).
+/// Blends any number of PDFs with configurable weights.
 ///
-/// `sample()` flips a fair coin to choose which distribution to draw from.
-/// `density()` returns the weighted average of both densities, regardless
-/// of which one was used for sampling. This is correct because every
-/// direction that either PDF could have generated contributes to the
-/// denominator in the Monte Carlo estimator.
+/// `sample()` picks an entry by its normalized weight (CDF),
+/// then delegates to that PDF.
+/// `density()` returns the weighted sum of all densities, regardless
+/// of which entry was used for sampling — each direction that any
+/// constituent PDF could have generated contributes to the denominator.
 #[derive(Debug)]
 pub struct MixturePdf {
-    a: Box<dyn Pdf>,
-    a_weight: f64,
-    b: Box<dyn Pdf>,
-    b_weight: f64,
+    entries: Vec<(Box<dyn Pdf>, f64)>,
 }
 
 impl MixturePdf {
-    pub fn new(a: Box<dyn Pdf>, a_weight: f64, b: Box<dyn Pdf>, b_weight: f64) -> Self {
-        let total = a_weight + b_weight;
-
-        Self {
-            a,
-            a_weight: a_weight / total,
-            b,
-            b_weight: b_weight / total,
-        }
-    }
-
-    pub fn new_equal(a: Box<dyn Pdf>, b: Box<dyn Pdf>) -> Self {
-        Self::new(a, 0.5, b, 0.5)
+    /// Build a mixture from weighted entries. Weights are normalized
+    /// internally — raw values are fine.
+    pub fn new(entries: Vec<(Box<dyn Pdf>, f64)>) -> Self {
+        let total: f64 = entries.iter().map(|(_, w)| w).sum();
+        let entries = entries
+            .into_iter()
+            .map(|(pdf, w)| (pdf, w / total))
+            .collect();
+        Self { entries }
     }
 }
 
 impl Pdf for MixturePdf {
     fn sample(&self) -> Vector {
-        if rand::random::<f64>() < self.a_weight {
-            self.a.sample()
-        } else {
-            self.b.sample()
+        let threshold: f64 = rand::random();
+        let mut cumulative = 0.0;
+        for (pdf, weight) in &self.entries {
+            cumulative += weight;
+            if threshold <= cumulative {
+                return pdf.sample();
+            }
         }
+        // floating-point fallback
+        self.entries.last().unwrap().0.sample()
     }
 
     fn density(&self, direction: Vector) -> f64 {
-        self.a_weight * self.a.density(direction) + self.b_weight * self.b.density(direction)
+        self.entries
+            .iter()
+            .map(|(pdf, weight)| weight * pdf.density(direction))
+            .sum()
     }
 }

--- a/src/shading/pdf.rs
+++ b/src/shading/pdf.rs
@@ -156,6 +156,10 @@ impl MixturePdf {
     /// Build a mixture from weighted entries. Weights are normalized
     /// internally — raw values are fine.
     pub fn new(entries: Vec<(Box<dyn Pdf>, f64)>) -> Self {
+        assert!(
+            !entries.is_empty(),
+            "MixturePdf requires at least one entry"
+        );
         let total: f64 = entries.iter().map(|(_, w)| w).sum();
         let entries = entries
             .into_iter()

--- a/src/tracing/parameters.rs
+++ b/src/tracing/parameters.rs
@@ -1,3 +1,4 @@
+use crate::tracing::SceneWorld;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Debug, Clone)]
@@ -61,7 +62,7 @@ impl ImportanceSamplingConfig {
         self.emissive_weight + self.transmissive_weight + self.specular_weight + self.brdf_weight
     }
 
-    pub fn validate(&self) -> Result<(), String> {
+    pub fn validate(&self, world: &SceneWorld) -> Result<(), String> {
         if self.emissive_weight < 0.0
             || self.transmissive_weight < 0.0
             || self.specular_weight < 0.0
@@ -76,7 +77,28 @@ impl ImportanceSamplingConfig {
             );
         }
 
+        self.validate_against_world(world)?;
+
         Ok(())
+    }
+
+    /// Validate that at least one non-zero weight category has matching
+    /// geometric objects in the scene.
+    fn validate_against_world(&self, world: &SceneWorld) -> Result<(), String> {
+        if self.emissive_weight > 0.0 && !world.emissive_list.is_empty() {
+            return Ok(());
+        }
+        if self.transmissive_weight > 0.0 && !world.transmissive_list.is_empty() {
+            return Ok(());
+        }
+        if self.specular_weight > 0.0 && !world.specular_list.is_empty() {
+            return Ok(());
+        }
+        // the BRDF always matches — any Lambertian material uses it
+        if self.brdf_weight > 0.0 {
+            return Ok(());
+        }
+        Err("at least one importance sampling category must have a non-zero weight with matching objects in the scene".to_string())
     }
 }
 

--- a/src/tracing/parameters.rs
+++ b/src/tracing/parameters.rs
@@ -8,7 +8,7 @@ pub struct OutputFileParameters {
     pub file_ext: String,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct RenderParameters {
     pub image_dimensions: (u32, u32),
     pub tile_dimensions: (u32, u32),
@@ -19,4 +19,43 @@ pub struct RenderParameters {
     pub saved_checkpoint_limit: Option<u32>,
     pub max_bounces: u32,
     pub use_scaling_truncation: bool,
+    /// Configurable weights for importance sampling categories.
+    /// The integrator normalizes these internally — raw values are fine.
+    #[serde(default)]
+    pub importance_sampling: ImportanceSamplingConfig,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ImportanceSamplingConfig {
+    /// Weight for sampling toward emissive objects (lights).
+    #[serde(default = "default_weight")]
+    pub emissive_weight: f64,
+    /// Weight for sampling toward transmissive objects (dielectric/glass).
+    #[serde(default = "default_zero")]
+    pub transmissive_weight: f64,
+    /// Weight for sampling toward specular objects (metal/mirror).
+    #[serde(default = "default_zero")]
+    pub specular_weight: f64,
+    /// Weight for the material's own BRDF-based PDF (diffuse/Lambertian).
+    #[serde(default = "default_weight")]
+    pub brdf_weight: f64,
+}
+
+impl Default for ImportanceSamplingConfig {
+    fn default() -> Self {
+        Self {
+            emissive_weight: 1.0,
+            transmissive_weight: 0.0,
+            specular_weight: 0.0,
+            brdf_weight: 1.0,
+        }
+    }
+}
+
+fn default_weight() -> f64 {
+    1.0
+}
+
+fn default_zero() -> f64 {
+    0.0
 }

--- a/src/tracing/parameters.rs
+++ b/src/tracing/parameters.rs
@@ -28,34 +28,65 @@ pub struct RenderParameters {
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ImportanceSamplingConfig {
     /// Weight for sampling toward emissive objects (lights).
-    #[serde(default = "default_weight")]
+    #[serde(default)]
     pub emissive_weight: f64,
     /// Weight for sampling toward transmissive objects (dielectric/glass).
-    #[serde(default = "default_zero")]
+    #[serde(default)]
     pub transmissive_weight: f64,
     /// Weight for sampling toward specular objects (metal/mirror).
-    #[serde(default = "default_zero")]
+    #[serde(default)]
     pub specular_weight: f64,
     /// Weight for the material's own BRDF-based PDF (diffuse/Lambertian).
-    #[serde(default = "default_weight")]
+    #[serde(default)]
     pub brdf_weight: f64,
+}
+
+impl ImportanceSamplingConfig {
+    /// Normalize the weights so they sum to 1.0, if they don't already.
+    pub fn normalize(&mut self) {
+        let total = self.emissive_weight
+            + self.transmissive_weight
+            + self.specular_weight
+            + self.brdf_weight;
+
+        if total > 0.0 {
+            self.emissive_weight /= total;
+            self.transmissive_weight /= total;
+            self.specular_weight /= total;
+            self.brdf_weight /= total;
+        }
+    }
+
+    pub fn sum(&self) -> f64 {
+        self.emissive_weight + self.transmissive_weight + self.specular_weight + self.brdf_weight
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.emissive_weight < 0.0
+            || self.transmissive_weight < 0.0
+            || self.specular_weight < 0.0
+            || self.brdf_weight < 0.0
+        {
+            return Err("Importance sampling weights must be non-negative".to_string());
+        }
+
+        if self.sum() == 0.0 {
+            return Err(
+                "At least one importance sampling weight must be non-zero and positive".to_string(),
+            );
+        }
+
+        Ok(())
+    }
 }
 
 impl Default for ImportanceSamplingConfig {
     fn default() -> Self {
         Self {
-            emissive_weight: 1.0,
+            emissive_weight: 0.0,
             transmissive_weight: 0.0,
             specular_weight: 0.0,
             brdf_weight: 1.0,
         }
     }
-}
-
-fn default_weight() -> f64 {
-    1.0
-}
-
-fn default_zero() -> f64 {
-    0.0
 }

--- a/src/tracing/scene.rs
+++ b/src/tracing/scene.rs
@@ -1,10 +1,64 @@
 use std::sync::Arc;
 
-use crate::{camera::Camera, geometry::Geometric, shading::Color};
+use crate::{
+    camera::Camera,
+    geometry::{
+        Geometric,
+        compounds::{Bvh, List},
+    },
+    shading::Color,
+};
 
 #[derive(Clone)]
 pub struct Scene {
     pub world: Arc<dyn Geometric>,
+    pub emissives: Arc<dyn Geometric>,
+    pub transmissives: Arc<dyn Geometric>,
+    pub speculars: Arc<dyn Geometric>,
+
     pub camera: Camera,
     pub background_color: Color,
+}
+
+pub struct SceneWorld {
+    pub world: Arc<dyn Geometric>,
+
+    pub emissives: Arc<dyn Geometric>,
+    pub transmissives: Arc<dyn Geometric>,
+    pub speculars: Arc<dyn Geometric>,
+}
+
+impl SceneWorld {
+    pub fn from_geometrics(geometrics: Vec<Arc<dyn Geometric>>, use_bvh: bool) -> Self {
+        let list = List::from_vec(geometrics);
+        let world: Arc<dyn Geometric> = if use_bvh {
+            Arc::new(Bvh::from_list(list))
+        } else {
+            Arc::new(list)
+        };
+
+        let emissives = Vec::new();
+        let transmissives = Vec::new();
+        let speculars = Vec::new();
+
+        for geometric in geometrics {
+            geometric.
+            if geometric.is_emissive() {
+                emissives.push(geometric.clone());
+            }
+            if geometric.is_transmissive() {
+                transmissives.push(geometric.clone());
+            }
+            if geometric.is_specular() {
+                speculars.push(geometric.clone());
+            }
+        }
+
+        SceneWorld {
+            world,
+            emissives,
+            transmissives,
+            speculars,
+        }
+    }
 }

--- a/src/tracing/scene.rs
+++ b/src/tracing/scene.rs
@@ -11,54 +11,51 @@ use crate::{
 
 #[derive(Clone)]
 pub struct Scene {
-    pub world: Arc<dyn Geometric>,
-    pub emissives: Arc<dyn Geometric>,
-    pub transmissives: Arc<dyn Geometric>,
-    pub speculars: Arc<dyn Geometric>,
+    pub world: SceneWorld,
 
     pub camera: Camera,
     pub background_color: Color,
 }
 
+#[derive(Clone)]
 pub struct SceneWorld {
     pub world: Arc<dyn Geometric>,
 
-    pub emissives: Arc<dyn Geometric>,
-    pub transmissives: Arc<dyn Geometric>,
-    pub speculars: Arc<dyn Geometric>,
+    pub emissives: Vec<Arc<dyn Geometric>>,
+    // pub transmissives: Arc<dyn Geometric>,
+    // pub speculars: Arc<dyn Geometric>,
 }
 
 impl SceneWorld {
-    pub fn from_geometrics(geometrics: Vec<Arc<dyn Geometric>>, use_bvh: bool) -> Self {
-        let list = List::from_vec(geometrics);
+    pub fn from_geometrics(geometrics: &Vec<Arc<dyn Geometric>>, use_bvh: bool) -> Self {
+        let list = List::from_vec(geometrics.clone());
         let world: Arc<dyn Geometric> = if use_bvh {
             Arc::new(Bvh::from_list(list))
         } else {
             Arc::new(list)
         };
 
-        let emissives = Vec::new();
-        let transmissives = Vec::new();
-        let speculars = Vec::new();
+        let mut emissives = Vec::new();
+        // let transmissives = Vec::new();
+        // let speculars = Vec::new();
 
         for geometric in geometrics {
-            geometric.
             if geometric.is_emissive() {
                 emissives.push(geometric.clone());
             }
-            if geometric.is_transmissive() {
-                transmissives.push(geometric.clone());
-            }
-            if geometric.is_specular() {
-                speculars.push(geometric.clone());
-            }
+            // if geometric.is_transmissive() {
+            //     transmissives.push(geometric.clone());
+            // }
+            // if geometric.is_specular() {
+            //     speculars.push(geometric.clone());
+            // }
         }
 
         SceneWorld {
             world,
             emissives,
-            transmissives,
-            speculars,
+            // transmissives,
+            // speculars,
         }
     }
 }

--- a/src/tracing/scene.rs
+++ b/src/tracing/scene.rs
@@ -21,12 +21,23 @@ pub struct Scene {
 pub struct SceneWorld {
     pub world: Arc<dyn Geometric>,
 
-    pub emissives: Vec<Arc<dyn Geometric>>,
-    // pub transmissives: Arc<dyn Geometric>,
-    // pub speculars: Arc<dyn Geometric>,
+    pub emissive_list: Arc<dyn Geometric>,
+    pub transmissive_list: Arc<dyn Geometric>,
+    pub specular_list: Arc<dyn Geometric>,
 }
 
 impl SceneWorld {
+    /// Create a SceneWorld from an already-built world geometry,
+    /// with empty category lists (no importance sampling).
+    pub fn from_world_without_importance_sampling(world: Arc<dyn Geometric>) -> Self {
+        SceneWorld {
+            world,
+            emissive_list: Arc::new(List::from_vec(Vec::new())),
+            transmissive_list: Arc::new(List::from_vec(Vec::new())),
+            specular_list: Arc::new(List::from_vec(Vec::new())),
+        }
+    }
+
     pub fn from_geometrics(geometrics: &Vec<Arc<dyn Geometric>>, use_bvh: bool) -> Self {
         let list = List::from_vec(geometrics.clone());
         let world: Arc<dyn Geometric> = if use_bvh {
@@ -36,26 +47,26 @@ impl SceneWorld {
         };
 
         let mut emissives = Vec::new();
-        // let transmissives = Vec::new();
-        // let speculars = Vec::new();
+        let mut transmissives = Vec::new();
+        let mut speculars = Vec::new();
 
         for geometric in geometrics {
             if geometric.is_emissive() {
                 emissives.push(geometric.clone());
             }
-            // if geometric.is_transmissive() {
-            //     transmissives.push(geometric.clone());
-            // }
-            // if geometric.is_specular() {
-            //     speculars.push(geometric.clone());
-            // }
+            if geometric.is_transmissive() {
+                transmissives.push(geometric.clone());
+            }
+            if geometric.is_specular() {
+                speculars.push(geometric.clone());
+            }
         }
 
         SceneWorld {
             world,
-            emissives,
-            // transmissives,
-            // speculars,
+            emissive_list: Arc::new(List::from_vec(emissives)),
+            transmissive_list: Arc::new(List::from_vec(transmissives)),
+            specular_list: Arc::new(List::from_vec(speculars)),
         }
     }
 }

--- a/src/tracing/tracer.rs
+++ b/src/tracing/tracer.rs
@@ -60,7 +60,6 @@ impl Tracer {
     ) -> PixelData {
         let RenderData { parameters, scene } = render_data;
 
-        let world = &scene.world;
         let mut cam = scene.camera.clone();
 
         cam.initialize(parameters, scene);
@@ -83,7 +82,7 @@ impl Tracer {
                                 |acc, _| {
                                     let ray = cam.get_ray(x, y);
 
-                                    acc + cam.ray_color(ray, world.as_ref(), parameters.max_bounces)
+                                    acc + cam.ray_color(ray, &scene.world, parameters.max_bounces)
                                 },
                             );
                             // done with pixel!

--- a/ui/src/hooks/useRenderForm.ts
+++ b/ui/src/hooks/useRenderForm.ts
@@ -27,21 +27,34 @@ export function useRenderForm(options: UseRenderFormOptions) {
       message: 'Image dimensions are too large',
       path: ['parameters', 'image_dimensions'],
     },
-  ).refine(
-    ({ parameters }) => {
-      if ((user?.max_checkpoints_per_render ?? null) !== null) {
+  )
+    .refine(
+      ({ parameters }) => {
+        if ((user?.max_checkpoints_per_render ?? null) !== null) {
+          return (
+            parameters.saved_checkpoint_limit !== undefined &&
+            parameters.saved_checkpoint_limit <= (user?.max_checkpoints_per_render ?? Infinity)
+          );
+        }
+        return true;
+      },
+      {
+        message: 'Saved checkpoint limit is too large',
+        path: ['parameters', 'saved_checkpoint_limit'],
+      },
+    )
+    .refine(
+      ({ parameters }) => {
+        const cfg = parameters.importance_sampling;
         return (
-          parameters.saved_checkpoint_limit !== undefined &&
-          parameters.saved_checkpoint_limit <= (user?.max_checkpoints_per_render ?? Infinity)
+          cfg.emissive_weight + cfg.transmissive_weight + cfg.specular_weight + cfg.brdf_weight > 0
         );
-      }
-      return true;
-    },
-    {
-      message: 'Saved checkpoint limit is too large',
-      path: ['parameters', 'saved_checkpoint_limit'],
-    },
-  );
+      },
+      {
+        message: 'At least one importance sampling weight must be non-zero',
+        path: ['parameters', 'importance_sampling'],
+      },
+    );
 
   return useAppForm({
     defaultValues: initialValues ?? getDefaultRenderConfig(),

--- a/ui/src/utils/render/parameters.ts
+++ b/ui/src/utils/render/parameters.ts
@@ -1,11 +1,17 @@
 import { z } from 'zod';
 
-export const ImportanceSamplingConfigSchema = z.object({
-  emissive_weight: z.number().min(0).default(1.0),
-  transmissive_weight: z.number().min(0).default(0.0),
-  specular_weight: z.number().min(0).default(0.0),
-  brdf_weight: z.number().min(0).default(1.0),
-});
+export const ImportanceSamplingConfigSchema = z
+  .object({
+    emissive_weight: z.number().min(0).default(1.0),
+    transmissive_weight: z.number().min(0).default(0.0),
+    specular_weight: z.number().min(0).default(0.0),
+    brdf_weight: z.number().min(0).default(1.0),
+  })
+  .refine(
+    (cfg) =>
+      cfg.emissive_weight + cfg.transmissive_weight + cfg.specular_weight + cfg.brdf_weight > 0,
+    { message: 'At least one importance sampling category must have a non-zero weight' },
+  );
 
 export type ImportanceSamplingConfig = z.infer<typeof ImportanceSamplingConfigSchema>;
 
@@ -20,7 +26,7 @@ export const RenderParametersSchema = z
     max_bounces: z.number().int().min(1).max(200),
     use_scaling_truncation: z.boolean(),
     importance_sampling: ImportanceSamplingConfigSchema.default({
-      emissive_weight: 1.0,
+      emissive_weight: 0.0,
       transmissive_weight: 0.0,
       specular_weight: 0.0,
       brdf_weight: 1.0,

--- a/ui/src/utils/render/parameters.ts
+++ b/ui/src/utils/render/parameters.ts
@@ -1,17 +1,11 @@
 import { z } from 'zod';
 
-export const ImportanceSamplingConfigSchema = z
-  .object({
-    emissive_weight: z.number().min(0).default(0.0),
-    transmissive_weight: z.number().min(0).default(0.0),
-    specular_weight: z.number().min(0).default(0.0),
-    brdf_weight: z.number().min(0).default(1.0),
-  })
-  .refine(
-    (cfg) =>
-      cfg.emissive_weight + cfg.transmissive_weight + cfg.specular_weight + cfg.brdf_weight > 0,
-    { message: 'At least one importance sampling category must have a non-zero weight' },
-  );
+export const ImportanceSamplingConfigSchema = z.object({
+  emissive_weight: z.number().min(0),
+  transmissive_weight: z.number().min(0),
+  specular_weight: z.number().min(0),
+  brdf_weight: z.number().min(0),
+});
 
 export type ImportanceSamplingConfig = z.infer<typeof ImportanceSamplingConfigSchema>;
 
@@ -25,12 +19,7 @@ export const RenderParametersSchema = z
     saved_checkpoint_limit: z.number().int().min(0).max(1000).optional(),
     max_bounces: z.number().int().min(1).max(200),
     use_scaling_truncation: z.boolean(),
-    importance_sampling: ImportanceSamplingConfigSchema.default({
-      emissive_weight: 0.0,
-      transmissive_weight: 0.0,
-      specular_weight: 0.0,
-      brdf_weight: 1.0,
-    }),
+    importance_sampling: ImportanceSamplingConfigSchema,
   })
   .refine((params) => params.tile_dimensions[0] <= params.image_dimensions[0], {
     message: 'Cannot be larger than image dimensions',

--- a/ui/src/utils/render/parameters.ts
+++ b/ui/src/utils/render/parameters.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const ImportanceSamplingConfigSchema = z
   .object({
-    emissive_weight: z.number().min(0).default(1.0),
+    emissive_weight: z.number().min(0).default(0.0),
     transmissive_weight: z.number().min(0).default(0.0),
     specular_weight: z.number().min(0).default(0.0),
     brdf_weight: z.number().min(0).default(1.0),

--- a/ui/src/utils/render/parameters.ts
+++ b/ui/src/utils/render/parameters.ts
@@ -1,5 +1,14 @@
 import { z } from 'zod';
 
+export const ImportanceSamplingConfigSchema = z.object({
+  emissive_weight: z.number().min(0).default(1.0),
+  transmissive_weight: z.number().min(0).default(0.0),
+  specular_weight: z.number().min(0).default(0.0),
+  brdf_weight: z.number().min(0).default(1.0),
+});
+
+export type ImportanceSamplingConfig = z.infer<typeof ImportanceSamplingConfigSchema>;
+
 export const RenderParametersSchema = z
   .object({
     image_dimensions: z.tuple([z.number().int().min(1), z.number().int().min(1)]),
@@ -10,6 +19,12 @@ export const RenderParametersSchema = z
     saved_checkpoint_limit: z.number().int().min(0).max(1000).optional(),
     max_bounces: z.number().int().min(1).max(200),
     use_scaling_truncation: z.boolean(),
+    importance_sampling: ImportanceSamplingConfigSchema.default({
+      emissive_weight: 1.0,
+      transmissive_weight: 0.0,
+      specular_weight: 0.0,
+      brdf_weight: 1.0,
+    }),
   })
   .refine((params) => params.tile_dimensions[0] <= params.image_dimensions[0], {
     message: 'Cannot be larger than image dimensions',

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -235,10 +235,10 @@ export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
       max_bounces: 50,
       use_scaling_truncation: true,
       importance_sampling: {
-        emissive_weight: 1.0,
+        emissive_weight: 0.0,
         transmissive_weight: 0.0,
-        specular_weight: 0.0,
-        brdf_weight: 1.0,
+        specular_weight: 1.0,
+        brdf_weight: 0.0,
       },
     },
     active_scene: 'Cornell Box',

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -58,6 +58,12 @@ export function getEmptyRenderConfig(): NormalizedRenderConfig {
       saved_checkpoint_limit: 1,
       max_bounces: 50,
       use_scaling_truncation: true,
+      importance_sampling: {
+        emissive_weight: 1.0,
+        transmissive_weight: 0.0,
+        specular_weight: 0.0,
+        brdf_weight: 1.0,
+      },
     },
     active_scene: 'Scene 1',
     scenes: {
@@ -96,6 +102,12 @@ export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
       saved_checkpoint_limit: 1,
       max_bounces: 50,
       use_scaling_truncation: true,
+      importance_sampling: {
+        emissive_weight: 1.0,
+        transmissive_weight: 0.0,
+        specular_weight: 0.0,
+        brdf_weight: 1.0,
+      },
     },
     active_scene: 'Cornell Box',
     scenes: {

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -187,7 +187,14 @@ export function getCornellBoxGlassSpheresRenderConfig(): NormalizedRenderConfig 
   const scenes = base.scenes!;
   return {
     ...base,
-    name: 'Cornell Box — Mirror Spheres',
+    name: 'Cornell Box — Glass Spheres',
+    parameters: {
+      ...base.parameters,
+      importance_sampling: {
+        ...base.parameters.importance_sampling,
+        emissive_weight: 1.0,
+      },
+    },
     scenes: {
       ...scenes,
       'Cornell Box': {
@@ -235,10 +242,10 @@ export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
       max_bounces: 50,
       use_scaling_truncation: true,
       importance_sampling: {
-        emissive_weight: 0.0,
+        emissive_weight: 1.0,
         transmissive_weight: 0.0,
-        specular_weight: 1.0,
-        brdf_weight: 0.0,
+        specular_weight: 0.0,
+        brdf_weight: 1.0,
       },
     },
     active_scene: 'Cornell Box',

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -35,6 +35,13 @@ export const TEMPLATES: Template[] = [
     config: getCornellBoxMirrorSpheresRenderConfig(),
   },
   {
+    id: 'cornell-box-glass-spheres',
+    name: 'Cornell Box — Glass Spheres',
+    description: 'Cornell Box scene with two dielectroc glass spheres instead of boxes',
+    // thumbnail: '/templates/cornell-box-glass-spheres.png',
+    config: getCornellBoxGlassSpheresRenderConfig(),
+  },
+  {
     id: 'empty',
     name: 'Empty',
     description: 'Blank canvas with default parameters — build your scene from scratch',
@@ -88,6 +95,131 @@ export function getEmptyRenderConfig(): NormalizedRenderConfig {
     materials: {},
     textures: {},
   });
+}
+
+export function getCornellBoxRenderConfig(): NormalizedRenderConfig {
+  const base = getCornellBoxBaseRenderConfig();
+  const scenes = base.scenes!;
+  return {
+    ...base,
+    name: 'Cornell Box',
+    scenes: {
+      ...scenes,
+      'Cornell Box': {
+        ...scenes['Cornell Box'],
+        geometrics: ['Far Left Box', 'Near Right Box', ...scenes['Cornell Box'].geometrics],
+      },
+    },
+    geometrics: {
+      ...base.geometrics,
+      'Far Left Box': {
+        type: 'rotate_y',
+        geometric: 'Far Left Box - Unrotated',
+        degrees: 15.0,
+        around: [3.5, 0.0, -6.5],
+      },
+      'Far Left Box - Unrotated': {
+        type: 'box',
+        a: [2.0, 0.0, -5.0],
+        b: [5.0, 6.0, -8.0],
+        is_culled: false,
+        material: 'White',
+      },
+      'Near Right Box': {
+        type: 'rotate_y',
+        geometric: 'Near Right Box - Unrotated',
+        degrees: 342.0,
+        around: [6.5, 0.0, -3.5],
+      },
+      'Near Right Box - Unrotated': {
+        type: 'box',
+        a: [5.0, 0.0, -2.0],
+        b: [8.0, 3.0, -5.0],
+        is_culled: false,
+        material: 'White',
+      },
+    },
+  };
+}
+
+export function getCornellBoxMirrorSpheresRenderConfig(): NormalizedRenderConfig {
+  const base = getCornellBoxBaseRenderConfig();
+  const scenes = base.scenes!;
+  return {
+    ...base,
+    name: 'Cornell Box — Mirror Spheres',
+    scenes: {
+      ...scenes,
+      'Cornell Box': {
+        ...scenes['Cornell Box'],
+        geometrics: ['Far Left Sphere', 'Near Right Sphere', ...scenes['Cornell Box'].geometrics],
+      },
+    },
+    geometrics: {
+      ...base.geometrics,
+      'Far Left Sphere': {
+        type: 'sphere',
+        center: [3.0, 2.0, -7.0],
+        radius: 2.0,
+        material: 'Mirror',
+      },
+      'Near Right Sphere': {
+        type: 'sphere',
+        center: [7.5, 1.5, -2.5],
+        radius: 1.5,
+        material: 'Mirror',
+      },
+    },
+    materials: {
+      ...base.materials,
+      Mirror: {
+        type: 'specular',
+        reflectance_texture: 'White',
+        emittance_texture: 'Black',
+        roughness: 0,
+      },
+    },
+  };
+}
+
+export function getCornellBoxGlassSpheresRenderConfig(): NormalizedRenderConfig {
+  const base = getCornellBoxBaseRenderConfig();
+  const scenes = base.scenes!;
+  return {
+    ...base,
+    name: 'Cornell Box — Mirror Spheres',
+    scenes: {
+      ...scenes,
+      'Cornell Box': {
+        ...scenes['Cornell Box'],
+        geometrics: ['Far Left Sphere', 'Near Right Sphere', ...scenes['Cornell Box'].geometrics],
+      },
+    },
+    geometrics: {
+      ...base.geometrics,
+      'Far Left Sphere': {
+        type: 'sphere',
+        center: [3.0, 2.0, -7.0],
+        radius: 2.0,
+        material: 'Glass',
+      },
+      'Near Right Sphere': {
+        type: 'sphere',
+        center: [7.5, 1.5, -2.5],
+        radius: 1.5,
+        material: 'Glass',
+      },
+    },
+    materials: {
+      ...base.materials,
+      Glass: {
+        type: 'dielectric',
+        reflectance_texture: 'White',
+        emittance_texture: 'Black',
+        index_of_refraction: 1.5,
+      },
+    },
+  };
 }
 
 export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
@@ -239,91 +371,6 @@ export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
       },
     },
   });
-}
-
-export function getCornellBoxRenderConfig(): NormalizedRenderConfig {
-  const base = getCornellBoxBaseRenderConfig();
-  const scenes = base.scenes!;
-  return {
-    ...base,
-    name: 'Cornell Box',
-    scenes: {
-      ...scenes,
-      'Cornell Box': {
-        ...scenes['Cornell Box'],
-        geometrics: ['Far Left Box', 'Near Right Box', ...scenes['Cornell Box'].geometrics],
-      },
-    },
-    geometrics: {
-      ...base.geometrics,
-      'Far Left Box': {
-        type: 'rotate_y',
-        geometric: 'Far Left Box - Unrotated',
-        degrees: 15.0,
-        around: [3.5, 0.0, -6.5],
-      },
-      'Far Left Box - Unrotated': {
-        type: 'box',
-        a: [2.0, 0.0, -5.0],
-        b: [5.0, 6.0, -8.0],
-        is_culled: false,
-        material: 'White',
-      },
-      'Near Right Box': {
-        type: 'rotate_y',
-        geometric: 'Near Right Box - Unrotated',
-        degrees: 342.0,
-        around: [6.5, 0.0, -3.5],
-      },
-      'Near Right Box - Unrotated': {
-        type: 'box',
-        a: [5.0, 0.0, -2.0],
-        b: [8.0, 3.0, -5.0],
-        is_culled: false,
-        material: 'White',
-      },
-    },
-  };
-}
-
-export function getCornellBoxMirrorSpheresRenderConfig(): NormalizedRenderConfig {
-  const base = getCornellBoxBaseRenderConfig();
-  const scenes = base.scenes!;
-  return {
-    ...base,
-    name: 'Cornell Box — Mirror Spheres',
-    scenes: {
-      ...scenes,
-      'Cornell Box': {
-        ...scenes['Cornell Box'],
-        geometrics: ['Far Left Sphere', 'Near Right Sphere', ...scenes['Cornell Box'].geometrics],
-      },
-    },
-    geometrics: {
-      ...base.geometrics,
-      'Far Left Sphere': {
-        type: 'sphere',
-        center: [3.0, 2.0, -7.0],
-        radius: 2.0,
-        material: 'Mirror',
-      },
-      'Near Right Sphere': {
-        type: 'sphere',
-        center: [7.5, 1.5, -2.5],
-        radius: 1.5,
-        material: 'Mirror',
-      },
-    },
-    materials: {
-      ...base.materials,
-      Mirror: {
-        type: 'specular',
-        reflectance_texture: 'White',
-        emittance_texture: 'Black',
-        roughness: 0,
-      },
-    },
-  };
 }
 
 function withDefaultResources(config: NormalizedRenderConfig): NormalizedRenderConfig {


### PR DESCRIPTION
Full importance sampling implementation with configurable per-category weights. 

### What changed

**Rendering engine**
- `SceneWorld` with `emissive_list`, `transmissive_list`, `specular_list` for category-based light sampling
- `MixturePdf` blends any number of weighted PDFs (CDF selection + weighted density)
- `build_mixture_pdf()` constructs a mixture from BRDF, emissive, transmissive, and specular categories
- `ImportanceSamplingConfig` with 4 weights, normalized on compile, validated for non-negative sum and scene matching
- `is_empty()` on `Geometric` trait

**Material trait additions**
- `is_emissive()`, `is_transmissive()`, `is_specular()` on both `Material` and `Geometric`

**Configurable via `parameters.importance_sampling`**
- `emissive_weight`, `transmissive_weight`, `specular_weight`, `brdf_weight` — all normalized internally
- Default: emissive=0, transmissive=0, specular=0, brdf=1 (BRDF-only, opt-in for light sampling)
- Validated: sum must be non-zero, at least one non-zero weight must match objects in scene

**UI (Zod + TypeScript)**
- `ImportanceSamplingConfigSchema` with per-field min(0) validation
- Sum > 0 validation via `.refine()` on `RenderConfigSchema`
- `importance_sampling` field in all config templates

**Fixes**
- `MixturePdf` empty entries panic → assertion + always-include-BRDF fallback
- Zod type error with `NormalizedRenderConfig` → removed `.default()` wrappers

### Related
- Issue #28 (Importance Sampling)
- PR #116 (Steps 0–1)
- PR #117 (Step 2)