### PR TITLE
fix: ensure default resources present in cloned/imported render configs

### DIFF
--- a/ui/src/hooks/useRenderForm.ts
+++ b/ui/src/hooks/useRenderForm.ts
@@ -46,7 +46,9 @@ export function useRenderForm(options: UseRenderFormOptions) {
     .refine(
       ({ parameters }) => {
         const cfg = parameters.importance_sampling;
+
         return (
+          !cfg ||
           cfg.emissive_weight + cfg.transmissive_weight + cfg.specular_weight + cfg.brdf_weight > 0
         );
       },

--- a/ui/src/utils/render/parameters.ts
+++ b/ui/src/utils/render/parameters.ts
@@ -20,7 +20,7 @@ export const RenderParametersSchema = z
     saved_checkpoint_limit: z.number().int().min(0).max(1000).optional(),
     max_bounces: z.number().int().min(1).max(200),
     use_scaling_truncation: z.boolean(),
-    importance_sampling: ImportanceSamplingConfigSchema,
+    importance_sampling: ImportanceSamplingConfigSchema.optional(),
   })
   .refine((params) => params.tile_dimensions[0] <= params.image_dimensions[0], {
     message: 'Cannot be larger than image dimensions',

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -191,10 +191,12 @@ export function getCornellBoxGlassSpheresRenderConfig(): NormalizedRenderConfig 
     name: 'Cornell Box — Glass Spheres',
     parameters: {
       ...base.parameters,
-      importance_sampling: {
-        ...base.parameters.importance_sampling,
-        emissive_weight: 1.0,
-      },
+      importance_sampling: base.parameters.importance_sampling
+        ? {
+            ...base.parameters.importance_sampling,
+            emissive_weight: 1.0,
+          }
+        : undefined,
     },
     scenes: {
       ...scenes,
@@ -382,7 +384,7 @@ export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
   });
 }
 
-function withDefaultResources(config: NormalizedRenderConfig): NormalizedRenderConfig {
+export function withDefaultResources(config: NormalizedRenderConfig): NormalizedRenderConfig {
   return {
     ...config,
     geometrics: {

--- a/ui/src/views/renders/CreateRenderModal/ExistingRenderPicker.tsx
+++ b/ui/src/views/renders/CreateRenderModal/ExistingRenderPicker.tsx
@@ -3,6 +3,7 @@ import { Button, ModalHeader, ModalBody, ModalFooter, Spinner, Alert } from 'flo
 import { HiArrowLeft } from 'react-icons/hi2';
 import { useRenders } from '@/hooks/useRenders';
 import { normalizeRenderConfig, type NormalizedRenderConfig } from '@/utils/render/config';
+import { withDefaultResources } from '@/utils/render/templates';
 import {
   isRenderStateCreated,
   isRenderStateRunning,
@@ -38,7 +39,10 @@ export function ExistingRenderPicker(props: ExistingRenderPickerProps) {
   const handleUseConfig = () => {
     if (!selectedRender) return;
     const normalizedConfig = normalizeRenderConfig(selectedRender.config);
-    onSelect(normalizedConfig);
+    const configWithDefaults = withDefaultResources(normalizedConfig);
+
+    // ensure default resources are present so new materials referencing __white/__black work correctly
+    onSelect(configWithDefaults);
   };
 
   const getStateBadgeClasses = (state: RenderState): string => {
@@ -65,9 +69,7 @@ export function ExistingRenderPicker(props: ExistingRenderPickerProps) {
             <Spinner />
           </div>
         )}
-        {isError && (
-          <Alert color="failure">Failed to load renders. Please try again.</Alert>
-        )}
+        {isError && <Alert color="failure">Failed to load renders. Please try again.</Alert>}
         {!isLoading && !isError && renders && renders.length === 0 && (
           <p className="py-8 text-center text-zinc-400">No existing renders to clone.</p>
         )}

--- a/ui/src/views/renders/CreateRenderModal/ImportConfigModal/ImportConfigBody.tsx
+++ b/ui/src/views/renders/CreateRenderModal/ImportConfigModal/ImportConfigBody.tsx
@@ -3,6 +3,7 @@ import { Button, ModalHeader, ModalBody, ModalFooter } from 'flowbite-react';
 import { HiFolderOpen } from 'react-icons/hi2';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { RenderConfigSchema, normalizeRenderConfig } from '@/utils/render/config';
+import { withDefaultResources } from '@/utils/render/templates';
 import { RenderConfigEditor } from './RenderConfigEditor';
 
 export type ImportConfigBodyProps = {
@@ -40,7 +41,11 @@ export function ImportConfigBody(props: ImportConfigBodyProps) {
     try {
       const parsed = JSON.parse(jsonText);
       const normalized = normalizeRenderConfig(parsed);
-      const result = RenderConfigSchema.safeParse(normalized);
+
+      // ensure default resources are present so new materials referencing __white/__black work correctly
+      const configWithDefaults = withDefaultResources(normalized);
+
+      const result = RenderConfigSchema.safeParse(configWithDefaults);
       if (!result.success) {
         setError('Configuration has validation errors — see inline markers above.');
         return;

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardParameters.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardParameters.tsx
@@ -10,6 +10,14 @@ import { useState } from 'react';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
 
+const DEFAULT_IMPORTANCE_SAMPLING = {
+  emissive_weight: 1.0,
+  transmissive_weight: 0.0,
+  specular_weight: 0.0,
+  brdf_weight: 1.0,
+  use_multiple_importance_sampling: true,
+};
+
 interface ControlsCardParametersProps {
   form: RenderForm;
 }
@@ -34,6 +42,23 @@ export function ControlsCardParameters(props: ControlsCardParametersProps) {
     } else {
       setSavedCheckpointLimitLocal(savedCheckpointLimit);
       form.setFieldValue('parameters.saved_checkpoint_limit', undefined);
+    }
+  }
+
+  const [importanceSamplingLocal, setImportanceSamplingLocal] = useState(
+    parameters.importance_sampling ?? DEFAULT_IMPORTANCE_SAMPLING,
+  );
+
+  const isImportanceSamplingEnabled = parameters.importance_sampling !== undefined;
+
+  function handleImportanceSamplingToggle(checked: boolean) {
+    if (checked) {
+      form.setFieldValue('parameters.importance_sampling', importanceSamplingLocal);
+    } else {
+      setImportanceSamplingLocal(
+        parameters.importance_sampling ?? DEFAULT_IMPORTANCE_SAMPLING,
+      );
+      form.setFieldValue('parameters.importance_sampling', undefined);
     }
   }
 
@@ -208,6 +233,95 @@ export function ControlsCardParameters(props: ControlsCardParametersProps) {
         <form.AppField name="parameters.use_scaling_truncation">
           {(field) => <field.ToggleControl label="Use Scaling Truncation" labelSuffix={<WarningIconAdvancedProperty />} />}
         </form.AppField>
+        {/* Importance Sampling toggle + animated section */}
+        <div className="h-px">
+          <AnimatePresence>
+            {isImportanceSamplingEnabled && (
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <Separator />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+        <div className="flex w-full items-center justify-between py-2">
+          <h6 className="overflow-hidden font-normal">
+            <span className="flex items-center gap-2">
+              Use Importance Sampling?
+              <WarningIconAdvancedProperty />
+            </span>
+          </h6>
+          <ToggleSwitch
+            checked={isImportanceSamplingEnabled}
+            onChange={handleImportanceSamplingToggle}
+          />
+        </div>
+        <AnimatePresence initial={false}>
+          {isImportanceSamplingEnabled && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.3, ease: 'easeInOut' }}
+              className="overflow-hidden"
+              onAnimationStart={() => {
+                form.validate('change');
+              }}
+            >
+              <div className="py-2">
+                <TextInputControl
+                  form={form}
+                  fieldName="parameters.importance_sampling.emissive_weight"
+                  label="Emissive Weight"
+                  labelSpacePercentage={70}
+                  valueLabel="weight"
+                  type="number"
+                  labelSuffix={<WarningIconAdvancedProperty />}
+                />
+                <TextInputControl
+                  form={form}
+                  fieldName="parameters.importance_sampling.transmissive_weight"
+                  label="Transmissive Weight"
+                  labelSpacePercentage={70}
+                  valueLabel="weight"
+                  type="number"
+                  labelSuffix={<WarningIconAdvancedProperty />}
+                />
+                <TextInputControl
+                  form={form}
+                  fieldName="parameters.importance_sampling.specular_weight"
+                  label="Specular Weight"
+                  labelSpacePercentage={70}
+                  valueLabel="weight"
+                  type="number"
+                  labelSuffix={<WarningIconAdvancedProperty />}
+                />
+                <TextInputControl
+                  form={form}
+                  fieldName="parameters.importance_sampling.brdf_weight"
+                  label="BRDF Weight"
+                  labelSpacePercentage={70}
+                  valueLabel="weight"
+                  type="number"
+                  labelSuffix={<WarningIconAdvancedProperty />}
+                />
+                <form.AppField name="parameters.importance_sampling.use_multiple_importance_sampling">
+                  {(field) => (
+                    <field.ToggleControl
+                      label="Use Multiple Importance Sampling"
+                      labelSuffix={<WarningIconAdvancedProperty />}
+                    />
+                  )}
+                </form.AppField>
+              </div>
+              <Separator />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     </ControlsCard>
   );


### PR DESCRIPTION
Cloned and imported render configs were missing `__white`/`__black` default textures, causing broken material references and UI glitches.

### Changes

**Default resources in cloned/imported configs**
- Export `withDefaultResources` as the public API for merging `__white`, `__black`, `__lambertian_white`, `__lambertian_black`, and `__unit_box` into a config
- Call `withDefaultResources(normalizedConfig)` after `normalizeRenderConfig` in `ExistingRenderPicker` (clone flow) and `ImportConfigBody` (import flow)
- User-defined resources take precedence; defaults only fill in what's missing

**Template fixes**
- Fix pre-existing TS error in `getCornellBoxGlassSpheresRenderConfig` where spreading the optional `importance_sampling` produced `number | undefined` fields — replaced with a ternary guard

**API cleanup**
- Unexport `getDefaultTextures`, `getDefaultMaterials`, `getDefaultGeometrics` — no external callers remain; `withDefaultResources` is the single public entry point

### Related
- Bug: `__MISSING__` labels on texture dropdowns when adding new materials to cloned/imported configs
- Bug: flowbite `<Select>` dropdowns collapsing on poll-triggered re-renders (inconsistent state when `value` had no matching `<option>`)