### PR TITLE
feat: environment map, shadows, emissive lighting, and Scene settings UI

### DIFF
--- a/ui-svelte/src/lib/utils/render/templates.ts
+++ b/ui-svelte/src/lib/utils/render/templates.ts
@@ -4,274 +4,274 @@ import type { MaterialData } from './material';
 import type { TextureData } from './texture';
 
 export function getDefaultRenderConfig(): RenderConfig {
-	return getCornellBoxRenderConfig();
+  return getCornellBoxRenderConfig();
 }
 
 export function getEmptyRenderConfig(): RenderConfig {
-	return withDefaultResources({
-		name: 'Empty',
-		parameters: {
-			image_dimensions: [500, 500],
-			tile_dimensions: [1, 1],
-			gamma_correction: 2.0,
-			samples_per_checkpoint: 10,
-			total_checkpoints: 100,
-			saved_checkpoint_limit: 1,
-			max_bounces: 50,
-			use_scaling_truncation: true
-		},
-		active_scene: 'Scene 1',
-		scenes: {
-			'Scene 1': {
-				geometrics: [],
-				use_bvh: true,
-				camera: 'Camera 1',
-				background_color: [0.0, 0.0, 0.0]
-			}
-		},
-		cameras: {
-			'Camera 1': {
-				vertical_field_of_view_degrees: 40.0,
-				eye_location: [0.0, 0.0, -10.0],
-				target_location: [0.0, 0.0, 0.0],
-				view_up: [0.0, 1.0, 0.0],
-				defocus_angle_degrees: 0.0,
-				focus_distance: 'eye_to_target'
-			}
-		},
-		geometrics: {},
-		materials: {},
-		textures: {}
-	});
+  return withDefaultResources({
+    name: 'Empty',
+    parameters: {
+      image_dimensions: [500, 500],
+      tile_dimensions: [1, 1],
+      gamma_correction: 2.0,
+      samples_per_checkpoint: 10,
+      total_checkpoints: 100,
+      saved_checkpoint_limit: 1,
+      max_bounces: 50,
+      use_scaling_truncation: true,
+    },
+    active_scene: 'Main',
+    scenes: {
+      Main: {
+        geometrics: [],
+        use_bvh: true,
+        camera: 'Main Camera',
+        background_color: [0.0, 0.0, 0.0],
+      },
+    },
+    cameras: {
+      'Main Camera': {
+        vertical_field_of_view_degrees: 40.0,
+        eye_location: [0.0, 0.0, -10.0],
+        target_location: [0.0, 0.0, 0.0],
+        view_up: [0.0, 1.0, 0.0],
+        defocus_angle_degrees: 0.0,
+        focus_distance: 'eye_to_target',
+      },
+    },
+    geometrics: {},
+    materials: {},
+    textures: {},
+  });
 }
 
 export function getCornellBoxRenderConfig(): RenderConfig {
-	return withDefaultResources({
-		name: 'Cornell Box',
-		parameters: {
-			image_dimensions: [500, 500],
-			tile_dimensions: [1, 1],
-			gamma_correction: 2.0,
-			samples_per_checkpoint: 10,
-			total_checkpoints: 100,
-			saved_checkpoint_limit: 1,
-			max_bounces: 50,
-			use_scaling_truncation: true
-		},
-		active_scene: 'Cornell Box',
-		scenes: {
-			'Cornell Box': {
-				geometrics: [
-					'Far Left Box',
-					'Near Right Box',
-					'Left Wall',
-					'Right Wall',
-					'Floor',
-					'Ceiling',
-					'Ceiling Light',
-					'Far Wall',
-					'Near Wall'
-				],
-				use_bvh: true,
-				camera: 'Camera 1',
-				background_color: [0.0, 0.0, 0.0]
-			}
-		},
-		cameras: {
-			'Camera 1': {
-				vertical_field_of_view_degrees: 40.0,
-				eye_location: [5.0, 5.0, 14.4144],
-				target_location: [5.0, 5.0, 0.0],
-				view_up: [0.0, 1.0, 0.0],
-				defocus_angle_degrees: 0.0,
-				focus_distance: 'eye_to_target'
-			}
-		},
-		geometrics: {
-			'Left Wall': {
-				type: 'parallelogram',
-				lower_left: [0.0, 0.0, 0.0],
-				u: [0.0, 0.0, -10.0],
-				v: [0.0, 10.0, 0.0],
-				is_culled: false,
-				material: 'Green'
-			},
-			'Right Wall': {
-				type: 'parallelogram',
-				lower_left: [10.0, 0.0, -10.0],
-				u: [0.0, 0.0, 10.0],
-				v: [0.0, 10.0, 0.0],
-				is_culled: false,
-				material: 'Red'
-			},
-			Floor: {
-				type: 'parallelogram',
-				lower_left: [0.0, 0.0, 0.0],
-				u: [10.0, 0.0, 0.0],
-				v: [0.0, 0.0, -10.0],
-				is_culled: false,
-				material: 'White'
-			},
-			Ceiling: {
-				type: 'parallelogram',
-				lower_left: [0.0, 10.0, -10.0],
-				u: [10.0, 0.0, 0.0],
-				v: [0.0, 0.0, 10.0],
-				is_culled: false,
-				material: 'White'
-			},
-			'Far Wall': {
-				type: 'parallelogram',
-				lower_left: [0.0, 0.0, -10.0],
-				u: [10.0, 0.0, 0.0],
-				v: [0.0, 10.0, 0.0],
-				is_culled: false,
-				material: 'White'
-			},
-			'Near Wall': {
-				type: 'parallelogram',
-				lower_left: [10.0, 0.0, 0.0],
-				u: [-10.0, 0.0, 0.0],
-				v: [0.0, 10.0, 0.0],
-				is_culled: true,
-				material: 'White'
-			},
-			'Ceiling Light': {
-				type: 'parallelogram',
-				lower_left: [3.5, 9.99, -6.5],
-				u: [3.0, 0.0, 0.0],
-				v: [0.0, 0.0, 3.0],
-				is_culled: false,
-				material: 'White Light'
-			},
-			'Far Left Box': {
-				type: 'rotate_y',
-				geometric: 'Far Left Box - Unrotated',
-				degrees: 15.0,
-				around: [3.5, 0.0, -6.5]
-			},
-			'Far Left Box - Unrotated': {
-				type: 'box',
-				a: [2.0, 0.0, -5.0],
-				b: [5.0, 6.0, -8.0],
-				is_culled: false,
-				material: 'White'
-			},
-			'Near Right Box': {
-				type: 'rotate_y',
-				geometric: 'Near Right Box - Unrotated',
-				degrees: 342.0,
-				around: [6.5, 0.0, -3.5]
-			},
-			'Near Right Box - Unrotated': {
-				type: 'box',
-				a: [5.0, 0.0, -2.0],
-				b: [8.0, 3.0, -5.0],
-				is_culled: false,
-				material: 'White'
-			}
-		},
-		materials: {
-			White: {
-				type: 'lambertian',
-				reflectance_texture: 'White',
-				emittance_texture: 'Black'
-			},
-			'White Light': {
-				type: 'lambertian',
-				reflectance_texture: 'Black',
-				emittance_texture: 'White Light'
-			},
-			Red: {
-				type: 'lambertian',
-				reflectance_texture: 'Red',
-				emittance_texture: 'Black'
-			},
-			Green: {
-				type: 'lambertian',
-				reflectance_texture: 'Green',
-				emittance_texture: 'Black'
-			}
-		},
-		textures: {
-			Black: {
-				type: 'color',
-				color: [0.0, 0.0, 0.0]
-			},
-			White: {
-				type: 'color',
-				color: [0.73, 0.73, 0.73]
-			},
-			'White Light': {
-				type: 'color',
-				color: [7.0, 7.0, 7.0]
-			},
-			Red: {
-				type: 'color',
-				color: [0.65, 0.05, 0.05]
-			},
-			Green: {
-				type: 'color',
-				color: [0.12, 0.45, 0.15]
-			}
-		}
-	});
+  return withDefaultResources({
+    name: 'Cornell Box',
+    parameters: {
+      image_dimensions: [500, 500],
+      tile_dimensions: [1, 1],
+      gamma_correction: 2.0,
+      samples_per_checkpoint: 10,
+      total_checkpoints: 100,
+      saved_checkpoint_limit: 1,
+      max_bounces: 50,
+      use_scaling_truncation: true,
+    },
+    active_scene: 'Cornell Box',
+    scenes: {
+      'Cornell Box': {
+        geometrics: [
+          'Far Left Box',
+          'Near Right Box',
+          'Left Wall',
+          'Right Wall',
+          'Floor',
+          'Ceiling',
+          'Ceiling Light',
+          'Far Wall',
+          'Near Wall',
+        ],
+        use_bvh: true,
+        camera: 'Main Camera',
+        background_color: [0.0, 0.0, 0.0],
+      },
+    },
+    cameras: {
+      'Main Camera': {
+        vertical_field_of_view_degrees: 40.0,
+        eye_location: [5.0, 5.0, 14.4144],
+        target_location: [5.0, 5.0, 0.0],
+        view_up: [0.0, 1.0, 0.0],
+        defocus_angle_degrees: 0.0,
+        focus_distance: 'eye_to_target',
+      },
+    },
+    geometrics: {
+      'Left Wall': {
+        type: 'parallelogram',
+        lower_left: [0.0, 0.0, 0.0],
+        u: [0.0, 0.0, -10.0],
+        v: [0.0, 10.0, 0.0],
+        is_culled: false,
+        material: 'Green',
+      },
+      'Right Wall': {
+        type: 'parallelogram',
+        lower_left: [10.0, 0.0, -10.0],
+        u: [0.0, 0.0, 10.0],
+        v: [0.0, 10.0, 0.0],
+        is_culled: false,
+        material: 'Red',
+      },
+      Floor: {
+        type: 'parallelogram',
+        lower_left: [0.0, 0.0, 0.0],
+        u: [10.0, 0.0, 0.0],
+        v: [0.0, 0.0, -10.0],
+        is_culled: false,
+        material: 'White',
+      },
+      Ceiling: {
+        type: 'parallelogram',
+        lower_left: [0.0, 10.0, -10.0],
+        u: [10.0, 0.0, 0.0],
+        v: [0.0, 0.0, 10.0],
+        is_culled: false,
+        material: 'White',
+      },
+      'Far Wall': {
+        type: 'parallelogram',
+        lower_left: [0.0, 0.0, -10.0],
+        u: [10.0, 0.0, 0.0],
+        v: [0.0, 10.0, 0.0],
+        is_culled: false,
+        material: 'White',
+      },
+      'Near Wall': {
+        type: 'parallelogram',
+        lower_left: [10.0, 0.0, 0.0],
+        u: [-10.0, 0.0, 0.0],
+        v: [0.0, 10.0, 0.0],
+        is_culled: true,
+        material: 'White',
+      },
+      'Ceiling Light': {
+        type: 'parallelogram',
+        lower_left: [3.5, 9.99, -6.5],
+        u: [3.0, 0.0, 0.0],
+        v: [0.0, 0.0, 3.0],
+        is_culled: false,
+        material: 'White Light',
+      },
+      'Far Left Box': {
+        type: 'rotate_y',
+        geometric: 'Far Left Box - Unrotated',
+        degrees: 15.0,
+        around: [3.5, 0.0, -6.5],
+      },
+      'Far Left Box - Unrotated': {
+        type: 'box',
+        a: [2.0, 0.0, -5.0],
+        b: [5.0, 6.0, -8.0],
+        is_culled: false,
+        material: 'White',
+      },
+      'Near Right Box': {
+        type: 'rotate_y',
+        geometric: 'Near Right Box - Unrotated',
+        degrees: 342.0,
+        around: [6.5, 0.0, -3.5],
+      },
+      'Near Right Box - Unrotated': {
+        type: 'box',
+        a: [5.0, 0.0, -2.0],
+        b: [8.0, 3.0, -5.0],
+        is_culled: false,
+        material: 'White',
+      },
+    },
+    materials: {
+      White: {
+        type: 'lambertian',
+        reflectance_texture: 'White',
+        emittance_texture: 'Black',
+      },
+      'White Light': {
+        type: 'lambertian',
+        reflectance_texture: 'Black',
+        emittance_texture: 'White Light',
+      },
+      Red: {
+        type: 'lambertian',
+        reflectance_texture: 'Red',
+        emittance_texture: 'Black',
+      },
+      Green: {
+        type: 'lambertian',
+        reflectance_texture: 'Green',
+        emittance_texture: 'Black',
+      },
+    },
+    textures: {
+      Black: {
+        type: 'color',
+        color: [0.0, 0.0, 0.0],
+      },
+      White: {
+        type: 'color',
+        color: [0.73, 0.73, 0.73],
+      },
+      'White Light': {
+        type: 'color',
+        color: [7.0, 7.0, 7.0],
+      },
+      Red: {
+        type: 'color',
+        color: [0.65, 0.05, 0.05],
+      },
+      Green: {
+        type: 'color',
+        color: [0.12, 0.45, 0.15],
+      },
+    },
+  });
 }
 
 function withDefaultResources(config: RenderConfig): RenderConfig {
-	return {
-		...config,
-		geometrics: {
-			...config.geometrics,
-			...getDefaultGeometrics()
-		},
-		materials: {
-			...config.materials,
-			...getDefaultMaterials()
-		},
-		textures: {
-			...config.textures,
-			...getDefaultTextures()
-		}
-	};
+  return {
+    ...config,
+    geometrics: {
+      ...config.geometrics,
+      ...getDefaultGeometrics(),
+    },
+    materials: {
+      ...config.materials,
+      ...getDefaultMaterials(),
+    },
+    textures: {
+      ...config.textures,
+      ...getDefaultTextures(),
+    },
+  };
 }
 
 function getDefaultGeometrics(): Record<string, GeometricData> {
-	return {
-		__unit_box: {
-			type: 'box',
-			a: [-0.5, 0.0, 0.5],
-			b: [0.5, 1.0, -0.5],
-			is_culled: false,
-			material: '__lambertian_white'
-		}
-	};
+  return {
+    __unit_box: {
+      type: 'box',
+      a: [-0.5, 0.0, 0.5],
+      b: [0.5, 1.0, -0.5],
+      is_culled: false,
+      material: '__lambertian_white',
+    },
+  };
 }
 
 function getDefaultMaterials(): Record<string, MaterialData> {
-	return {
-		__lambertian_white: {
-			type: 'lambertian',
-			reflectance_texture: '__white',
-			emittance_texture: '__black'
-		},
-		__lambertian_black: {
-			type: 'lambertian',
-			reflectance_texture: '__black',
-			emittance_texture: '__black'
-		}
-	};
+  return {
+    __lambertian_white: {
+      type: 'lambertian',
+      reflectance_texture: '__white',
+      emittance_texture: '__black',
+    },
+    __lambertian_black: {
+      type: 'lambertian',
+      reflectance_texture: '__black',
+      emittance_texture: '__black',
+    },
+  };
 }
 
 function getDefaultTextures(): Record<string, TextureData> {
-	return {
-		__white: {
-			type: 'color',
-			color: [1.0, 1.0, 1.0]
-		},
-		__black: {
-			type: 'color',
-			color: [0.0, 0.0, 0.0]
-		}
-	};
+  return {
+    __white: {
+      type: 'color',
+      color: [1.0, 1.0, 1.0],
+    },
+    __black: {
+      type: 'color',
+      color: [0.0, 0.0, 0.0],
+    },
+  };
 }

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -150,10 +150,18 @@ export function getCenterPoint(
     case 'rotate_x':
     case 'rotate_y':
     case 'rotate_z':
-    case 'translate':
     case 'constant_volume': {
       const { data: subData } = getGeometricDataSafe(config, data.geometric);
       return getCenterPoint(config, subData);
+    }
+    case 'translate': {
+      const { data: subData } = getGeometricDataSafe(config, data.geometric);
+      const childCenter = getCenterPoint(config, subData);
+      return [
+        childCenter[0] + data.translation[0],
+        childCenter[1] + data.translation[1],
+        childCenter[2] + data.translation[2],
+      ];
     }
     case 'parallelogram':
       return [

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -1,7 +1,7 @@
 import type { NormalizedRenderConfig, RenderConfig } from './config';
 import { normalizeMaterialData, type RawMaterialData } from './material';
 import { normalizeTextureData, type RawTextureData } from './texture';
-import { AngleSchema, capitalize, getNextUniqueName, isTypedObject, type Angle } from './utils';
+import { AngleSchema, capitalize, getNextUniqueName, isTypedObject, toRadians, type Angle } from './utils';
 import { z } from 'zod';
 
 // geometric types
@@ -123,6 +123,49 @@ export function getReferencedMaterialNames(
   return [...new Set(materials)];
 }
 
+// rotate a point around a pivot by angleRad radians on the given axis.
+// matches the Rust backend's RotateXAxis / RotateYAxis / RotateZAxis conventions.
+function rotatePoint(
+  point: [number, number, number],
+  axis: 'rotate_x' | 'rotate_y' | 'rotate_z',
+  angleRad: number,
+  pivot: [number, number, number],
+): [number, number, number] {
+  const [px, py, pz] = pivot;
+  const vx = point[0] - px;
+  const vy = point[1] - py;
+  const vz = point[2] - pz;
+  const cosA = Math.cos(angleRad);
+  const sinA = Math.sin(angleRad);
+
+  let rx: number;
+  let ry: number;
+  let rz: number;
+
+  switch (axis) {
+    case 'rotate_x':
+      // rotation in YZ plane: y' = y*cos - z*sin, z' = y*sin + z*cos
+      rx = vx;
+      ry = vy * cosA - vz * sinA;
+      rz = vy * sinA + vz * cosA;
+      break;
+    case 'rotate_y':
+      // rotation in XZ plane: x' = x*cos + z*sin, z' = -x*sin + z*cos
+      rx = vx * cosA + vz * sinA;
+      ry = vy;
+      rz = -vx * sinA + vz * cosA;
+      break;
+    case 'rotate_z':
+      // rotation in XY plane: x' = x*cos - y*sin, y' = x*sin + y*cos
+      rx = vx * cosA - vy * sinA;
+      ry = vx * sinA + vy * cosA;
+      rz = vz;
+      break;
+  }
+
+  return [rx + px, ry + py, rz + pz];
+}
+
 export function getCenterPoint(
   config: NormalizedRenderConfig,
   data: GeometricData,
@@ -149,7 +192,15 @@ export function getCenterPoint(
       return data.origin ?? [0, 0, 0];
     case 'rotate_x':
     case 'rotate_y':
-    case 'rotate_z':
+    case 'rotate_z': {
+      const { data: subData } = getGeometricDataSafe(config, data.geometric);
+      const childCenter = getCenterPoint(config, subData);
+      const angleRad = toRadians(data);
+      // default to origin if around pivot is not specified,
+      // matching Rust backend: around.unwrap_or([0.0, 0.0, 0.0])
+      const pivot = data.around ?? [0, 0, 0];
+      return rotatePoint(childCenter, data.type, angleRad, pivot);
+    }
     case 'constant_volume': {
       const { data: subData } = getGeometricDataSafe(config, data.geometric);
       return getCenterPoint(config, subData);

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -73,17 +73,17 @@ export function getEmptyRenderConfig(): NormalizedRenderConfig {
         use_multiple_importance_sampling: false,
       },
     },
-    active_scene: 'Scene 1',
+    active_scene: 'Main',
     scenes: {
-      'Scene 1': {
+      Main: {
         geometrics: [],
         use_bvh: true,
-        camera: 'Camera 1',
+        camera: 'Main Camera',
         background_color: [0.0, 0.0, 0.0],
       },
     },
     cameras: {
-      'Camera 1': {
+      'Main Camera': {
         vertical_field_of_view_degrees: 40.0,
         eye_location: [0.0, 0.0, -10.0],
         target_location: [0.0, 0.0, 0.0],
@@ -265,12 +265,12 @@ export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
           'Near Wall',
         ],
         use_bvh: true,
-        camera: 'Camera 1',
+        camera: 'Main Camera',
         background_color: [0.0, 0.0, 0.0],
       },
     },
     cameras: {
-      'Camera 1': {
+      'Main Camera': {
         vertical_field_of_view_degrees: 40.0,
         eye_location: [5.0, 5.0, 14.4144],
         target_location: [5.0, 5.0, 0.0],

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardScene.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardScene.tsx
@@ -1,0 +1,47 @@
+import { ControlsCard } from './ControlsCard';
+import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
+import type { RenderForm, RenderFormPath } from '@/hooks/useRenderForm';
+import type { DeepKeys } from '@tanstack/react-form';
+import type { NormalizedRenderConfig } from '@/utils/render/config';
+import { InfoIconAdditionalInfo } from '@/views/renders/new/Controls/icons/InfoIconAdditionalInfo';
+import { useSelector } from '@tanstack/react-store';
+
+export type ControlsCardSceneProps = {
+  form: RenderForm;
+};
+
+export function ControlsCardScene(props: ControlsCardSceneProps) {
+  const { form } = props;
+
+  const renderConfig = useSelector(form.store, (state) => state.values);
+  const activeSceneName = renderConfig.active_scene;
+
+  const formPath: RenderFormPath = `scenes.${activeSceneName}`;
+
+  return (
+    <ControlsCard leftLabel="scene" leftLabelStyle="light" startExpanded>
+      <div className="flex flex-col gap-2 p-4">
+        <form.AppField name={`${formPath}.use_bvh`}>
+          {(field) => <field.ToggleControl label="Use BVH" />}
+        </form.AppField>
+        <TextArrayInputControl
+          form={form}
+          fieldName={`${formPath}.background_color` as DeepKeys<NormalizedRenderConfig>}
+          label="Background Color"
+          valueLabels={['red', 'green', 'blue']}
+          type="number"
+          unenforcedStep={0.01}
+          labelSuffix={
+            <InfoIconAdditionalInfo
+              info={[
+                'Color values are typically between 0 and 1. For example, pure white would be [1, 1, 1].',
+                'Values can be set outside of this range, and will be affected by the "Use Scaling Truncation" parameter.',
+                'This color is only visible in areas where no geometry is present behind the transparent background.',
+              ]}
+            />
+          }
+        />
+      </div>
+    </ControlsCard>
+  );
+}

--- a/ui/src/views/renders/new/Controls/index.tsx
+++ b/ui/src/views/renders/new/Controls/index.tsx
@@ -5,6 +5,7 @@ import { ControlsCardParameters } from './cards/ControlsCardParameters';
 import { ControlsCardGeometric } from './cards/ControlsCardGeometric';
 import { ControlsCardMaterial } from './cards/ControlsCardMaterial';
 import { ControlsCardTexture } from './cards/ControlsCardTexture';
+import { ControlsCardScene } from './cards/ControlsCardScene';
 import { AddEntityDropdown } from './AddEntityDropdown';
 import { defaultGeometricForType, type GeometricData } from '@/utils/render/geometric';
 import { defaultMaterialForType, type MaterialData } from '@/utils/render/material';
@@ -76,8 +77,9 @@ export function Controls(props: ControlsProps) {
         </div>
       </TabItem>
 
-      <TabItem title="Camera">
+      <TabItem title="Scene">
         <div className="flex flex-col items-stretch gap-4 p-2">
+          <ControlsCardScene form={form} />
           <ControlsCardCamera form={form} cameraName={activeScene.camera} />
         </div>
       </TabItem>

--- a/ui/src/views/renders/new/Scene/CameraUpdater.tsx
+++ b/ui/src/views/renders/new/Scene/CameraUpdater.tsx
@@ -1,0 +1,33 @@
+import { PerspectiveCamera } from '@react-three/drei';
+import { useRef, useEffect } from 'react';
+import * as THREE from 'three';
+import type { RawCameraData } from '@/utils/render/camera';
+
+export type CameraUpdaterProps = {
+  cameraData: RawCameraData;
+};
+
+export function CameraUpdater(props: CameraUpdaterProps) {
+  const { cameraData } = props;
+
+  const cameraRef = useRef<THREE.PerspectiveCamera>(null);
+
+  // imperative: lookAt is a method, not a reactive prop
+  useEffect(() => {
+    cameraRef.current?.lookAt(
+      cameraData.target_location[0],
+      cameraData.target_location[1],
+      cameraData.target_location[2],
+    );
+  }, [cameraData]);
+
+  return (
+    <PerspectiveCamera
+      ref={cameraRef}
+      makeDefault
+      fov={cameraData.vertical_field_of_view_degrees}
+      position={cameraData.eye_location}
+      up={cameraData.view_up}
+    />
+  );
+}

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -84,7 +84,17 @@ export function MaterialResolver(props: MaterialResolverProps) {
     if (!emissiveColor) return null;
 
     const { data: geometricData } = getGeometricDataSafe(config, geometricName);
-    if (isComposite(geometricData) || geometricData.type === 'constant_volume') return null;
+    if (geometricData.type === 'constant_volume') {
+      return null;
+    }
+    // allow list and translate composites through
+    if (
+      isComposite(geometricData) &&
+      geometricData.type !== 'list' &&
+      geometricData.type !== 'translate'
+    ) {
+      return null;
+    }
 
     const center = getCenterPoint(config, geometricData);
     const intensity = Math.max(...emissiveColor);

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import * as THREE from 'three';
 import { getMaterialDataSafe } from '@/utils/render/material';
 import { getTextureDataSafe } from '@/utils/render/texture';
-import { isComposite, getCenterPoint } from '@/utils/render/geometric';
+import { getCenterPoint } from '@/utils/render/geometric';
 import { getGeometricDataSafe } from '@/utils/render/geometric';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 
@@ -85,14 +85,6 @@ export function MaterialResolver(props: MaterialResolverProps) {
 
     const { data: geometricData } = getGeometricDataSafe(config, geometricName);
     if (geometricData.type === 'constant_volume') {
-      return null;
-    }
-    // allow list and translate composites through
-    if (
-      isComposite(geometricData) &&
-      geometricData.type !== 'list' &&
-      geometricData.type !== 'translate'
-    ) {
       return null;
     }
 

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -87,7 +87,7 @@ export function MaterialResolver(props: MaterialResolverProps) {
     if (isComposite(geometricData) || geometricData.type === 'constant_volume') return null;
 
     const center = getCenterPoint(config, geometricData);
-    const intensity = emissiveColor.reduce((a, b) => a + b, 0) / 3;
+    const intensity = Math.max(...emissiveColor);
 
     return (
       <pointLight

--- a/ui/src/views/renders/new/Scene/SceneBackground.tsx
+++ b/ui/src/views/renders/new/Scene/SceneBackground.tsx
@@ -11,6 +11,7 @@ export function SceneBackground(props: SceneBackgroundProps) {
 
   const { scene } = useThree();
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/immutability -- scene mutation is the standard R3F pattern
     scene.background = new THREE.Color(...color);
   }, [scene, color]);
   return null;

--- a/ui/src/views/renders/new/Scene/SceneBackground.tsx
+++ b/ui/src/views/renders/new/Scene/SceneBackground.tsx
@@ -1,0 +1,17 @@
+import { useThree } from '@react-three/fiber';
+import { useEffect } from 'react';
+import * as THREE from 'three';
+
+export type SceneBackgroundProps = {
+  color: [number, number, number];
+};
+
+export function SceneBackground(props: SceneBackgroundProps) {
+  const { color } = props;
+
+  const { scene } = useThree();
+  useEffect(() => {
+    scene.background = new THREE.Color(...color);
+  }, [scene, color]);
+  return null;
+}

--- a/ui/src/views/renders/new/Scene/index.tsx
+++ b/ui/src/views/renders/new/Scene/index.tsx
@@ -43,7 +43,7 @@ export function Scene(props: SceneProps) {
   const { data: cameraData } = getCameraData(renderConfig, activeScene.camera);
 
   return (
-    <Canvas shadows>
+    <Canvas shadows="soft">
       <CameraUpdater cameraData={cameraData} />
       <Environment preset="lobby" environmentIntensity={0.05} />
       {activeScene.geometrics.map((geoName: string) => (

--- a/ui/src/views/renders/new/Scene/index.tsx
+++ b/ui/src/views/renders/new/Scene/index.tsx
@@ -1,6 +1,6 @@
 import { Canvas } from '@react-three/fiber';
 import { Environment, PerspectiveCamera } from '@react-three/drei';
-import { useRef, useEffect } from 'react';
+import { useMemo, useRef, useEffect } from 'react';
 import { useSelector } from '@tanstack/react-store';
 import * as THREE from 'three';
 import { GeometricRenderer } from './GeometricRenderer';
@@ -42,8 +42,13 @@ export function Scene(props: SceneProps) {
   const activeScene = getSceneData(renderConfig, renderConfig.active_scene);
   const { data: cameraData } = getCameraData(renderConfig, activeScene.camera);
 
+  const sceneProps = useMemo(
+    () => ({ background: new THREE.Color(...activeScene.background_color) }),
+    [activeScene.background_color],
+  );
+
   return (
-    <Canvas shadows="soft">
+    <Canvas shadows="soft" scene={sceneProps}>
       <CameraUpdater cameraData={cameraData} />
       <Environment preset="lobby" environmentIntensity={0.05} />
       {activeScene.geometrics.map((geoName: string) => (

--- a/ui/src/views/renders/new/Scene/index.tsx
+++ b/ui/src/views/renders/new/Scene/index.tsx
@@ -43,7 +43,7 @@ export function Scene(props: SceneProps) {
   const { data: cameraData } = getCameraData(renderConfig, activeScene.camera);
 
   return (
-    <Canvas>
+    <Canvas shadows>
       <CameraUpdater cameraData={cameraData} />
       <Environment preset="lobby" environmentIntensity={0.05} />
       {activeScene.geometrics.map((geoName: string) => (

--- a/ui/src/views/renders/new/Scene/index.tsx
+++ b/ui/src/views/renders/new/Scene/index.tsx
@@ -1,5 +1,5 @@
 import { Canvas } from '@react-three/fiber';
-import { PerspectiveCamera } from '@react-three/drei';
+import { Environment, PerspectiveCamera } from '@react-three/drei';
 import { useRef, useEffect } from 'react';
 import { useSelector } from '@tanstack/react-store';
 import * as THREE from 'three';
@@ -45,7 +45,7 @@ export function Scene(props: SceneProps) {
   return (
     <Canvas>
       <CameraUpdater cameraData={cameraData} />
-      <ambientLight intensity={0.05} />
+      <Environment preset="lobby" environmentIntensity={0.05} />
       {activeScene.geometrics.map((geoName: string) => (
         <GeometricRenderer key={geoName} config={renderConfig} name={geoName} />
       ))}

--- a/ui/src/views/renders/new/Scene/index.tsx
+++ b/ui/src/views/renders/new/Scene/index.tsx
@@ -1,39 +1,16 @@
 import { Canvas } from '@react-three/fiber';
-import { Environment, PerspectiveCamera } from '@react-three/drei';
-import { useMemo, useRef, useEffect } from 'react';
+import { Environment } from '@react-three/drei';
 import { useSelector } from '@tanstack/react-store';
-import * as THREE from 'three';
 import { GeometricRenderer } from './GeometricRenderer';
+import { CameraUpdater } from './CameraUpdater';
+import { SceneBackground } from './SceneBackground';
 import { getSceneData } from '@/utils/render/scene';
-import { getCameraData, type RawCameraData } from '@/utils/render/camera';
+import { getCameraData } from '@/utils/render/camera';
 import type { RenderForm } from '@/hooks/useRenderForm';
 
-interface SceneProps {
+export type SceneProps = {
   form: RenderForm;
-}
-
-function CameraUpdater({ cameraData }: { cameraData: RawCameraData }) {
-  const cameraRef = useRef<THREE.PerspectiveCamera>(null);
-
-  // imperative: lookAt is a method, not a reactive prop
-  useEffect(() => {
-    cameraRef.current?.lookAt(
-      cameraData.target_location[0],
-      cameraData.target_location[1],
-      cameraData.target_location[2],
-    );
-  }, [cameraData]);
-
-  return (
-    <PerspectiveCamera
-      ref={cameraRef}
-      makeDefault
-      fov={cameraData.vertical_field_of_view_degrees}
-      position={cameraData.eye_location}
-      up={cameraData.view_up}
-    />
-  );
-}
+};
 
 export function Scene(props: SceneProps) {
   const { form } = props;
@@ -42,13 +19,9 @@ export function Scene(props: SceneProps) {
   const activeScene = getSceneData(renderConfig, renderConfig.active_scene);
   const { data: cameraData } = getCameraData(renderConfig, activeScene.camera);
 
-  const sceneProps = useMemo(
-    () => ({ background: new THREE.Color(...activeScene.background_color) }),
-    [activeScene.background_color],
-  );
-
   return (
-    <Canvas shadows="soft" scene={sceneProps}>
+    <Canvas shadows="soft">
+      <SceneBackground color={activeScene.background_color} />
       <CameraUpdater cameraData={cameraData} />
       <Environment preset="lobby" environmentIntensity={0.05} />
       {activeScene.geometrics.map((geoName: string) => (


### PR DESCRIPTION
## Summary

Overhauls the React Three Fiber 3D scene preview with lighting, shadows, emissive support, and new UI controls. Closes #110.

## Changes

### 3D Preview (R3F)
- **Environment map** — Added `Environment` from drei with lobby preset and low intensity (0.05). Gives specular/metal materials something to reflect instead of rendering black.
- **Shadow maps** — Enabled `shadows` on Canvas. Existing `castShadow`/`receiveShadow` props on meshes and point lights now actually work.
- **Emissive intensity** — Switched from average-based `(R+G+B)/3` to `max(R,G,B)`. Colored lights no longer unfairly dimmed.
- **Emissive lights for composites** — `list`, `translate`, `rotate_x`, `rotate_y`, `rotate_z` composites can now emit point lights for their emissive children.
- **Background color** — Config's `background_color` now reactively sets the canvas background via `useThree`.
- **Center point fixes** — `getCenterPoint` now correctly handles `translate` (adds offset) and `rotate_*` (rotates around pivot via new `rotatePoint` helper matching Rust backend conventions).

### UI Controls
- **Scene tab** — Renamed Camera tab to Scene. Added `ControlsCardScene` with:
  - **Use BVH** toggle
  - **Background Color** editor (RGB, modeled after color texture controls with tooltip)

### Code Quality
- Extracted `CameraUpdater` and `SceneBackground` into separate files following the one-component-per-file convention
- Fixed `interface` → `export type` and inline-destructure → props-parameter convention violations
- Removed unused `isComposite` import
- Template scene/camera names updated (`Scene 1` → `Main`, `Camera 1` → `Main Camera`)

## Files Changed

| File | Change |
|------|--------|
| `Scene/index.tsx` | Environment, shadows, background, extracted sub-components |
| `Scene/SceneBackground.tsx` | New — reactive background color component |
| `Scene/CameraUpdater.tsx` | New — extracted camera updater |
| `Scene/MaterialResolver.tsx` | Emissive intensity, composite light support |
| `utils/render/geometric.ts` | `rotatePoint` helper, center point fixes |
| `Controls/index.tsx` | Camera → Scene tab, add ControlsCardScene |
| `Controls/cards/ControlsCardScene.tsx` | New — scene settings card |
| `utils/render/templates.ts` | Template name updates |

## How to Test

1. Select **Cornell Box — Mirror Spheres** template — specular spheres should show reflections, not black voids
2. Toggle **Use BVH** in Scene tab — config updates
3. Change **Background Color** — canvas background updates immediately
4. Shadow-casting emissive lights should cast visible shadows on nearby geometry