### PR TITLE
fix: prevent progress bar from animating backwards on new checkpoint

### DIFF
--- a/ui/src/views/renders/RenderPreviewCard.tsx
+++ b/ui/src/views/renders/RenderPreviewCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Card, Progress, Spinner, type CardTheme } from 'flowbite-react';
 import { Link } from 'react-router-dom';
 import type { DeepPartial } from 'flowbite-react/types';
@@ -26,6 +27,16 @@ export function RenderPreviewCard(props: RenderPreviewCardProps) {
     : pausing
       ? state.pausing.progress_info.progress
       : 0;
+
+  // disable the CSS width transition when progress decreases
+  // (new checkpoint started), so the bar snaps instead of animating backwards.
+  // a 2-element array preserves history so the re-render after setState still
+  // sees the previous value and can compute the correct direction.
+  const [stack, setStack] = useState([progress, progress]);
+  const increasing = stack[1] >= stack[0];
+  if (stack[1] !== progress) {
+    setStack([stack[1], progress]);
+  }
 
   const cardTheme: DeepPartial<CardTheme> = {
     root: {
@@ -83,7 +94,9 @@ export function RenderPreviewCard(props: RenderPreviewCardProps) {
               size="sm"
               theme={{
                 base: 'rounded-none',
-                bar: 'rounded-none transition-[width] duration-1000 ease-linear',
+                bar: increasing
+                  ? 'rounded-none transition-[width] duration-1000 ease-linear'
+                  : 'rounded-none',
               }}
             />
           )}

--- a/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/ProgressState.tsx
+++ b/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/ProgressState.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Progress, type ProgressTheme } from 'flowbite-react';
 import type { DeepPartial } from 'flowbite-react/types';
 
@@ -9,8 +10,18 @@ export type ProgressStateProps = {
 export function ProgressState(props: ProgressStateProps) {
   const { progress, color } = props;
 
+  // disable the CSS width transition when progress decreases
+  // (new checkpoint started), so the bar snaps instead of animating backwards.
+  // a 2-element array preserves history so the re-render after setState still
+  // sees the previous value and can compute the correct direction.
+  const [stack, setStack] = useState([progress, progress]);
+  const increasing = stack[1] >= stack[0];
+  if (stack[1] !== progress) {
+    setStack([stack[1], progress]);
+  }
+
   const progressTheme: DeepPartial<ProgressTheme> = {
-    bar: 'transition-[width] duration-1000 ease-linear',
+    bar: increasing ? 'transition-[width] duration-1000 ease-linear' : '',
   };
 
   return (


### PR DESCRIPTION
When a checkpoint finishes and a new one starts, the per-checkpoint progress resets from ~1.0 to 0.0. The CSS `transition-[width] duration-1000` on the bar would animate this width drop over 1 second, making it look like the bar was going backwards.

**Fix:** Use a 2-element `useState` array as a mini history queue — comparing `stack[0]` (old progress) against `stack[1]` (current progress) to detect direction during rendering. When progress decreases, the transition class is stripped so the bar snaps instantly instead of animating. The array preserves history so the `setState`-triggered re-render can still compute the correct direction.

**Files:**
- `ui/src/views/renders/[id]/RenderDisplay/RenderProgress/ProgressState.tsx` — labeled progress bar on render detail page
- `ui/src/views/renders/RenderPreviewCard.tsx` — slim progress bar on render preview cards