### PR TITLE
fix: move point light out of mesh, prevent self-shadowing on emissive objects

### DIFF
--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -3,12 +3,38 @@ import { toRadians } from '@/utils/render/utils';
 import { createParallelogramGeometry, createTriangleGeometry } from '@/utils/three';
 import { MaterialResolver } from './MaterialResolver';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
+import { getMaterialDataSafe } from '@/utils/render/material';
+import { getTextureDataSafe } from '@/utils/render/texture';
+import { getCenterPoint } from '@/utils/render/geometric';
 
-interface GeometricRendererProps {
+type EmissiveInfo = { color: [number, number, number]; intensity: number };
+
+function getEmissiveInfo(
+  config: NormalizedRenderConfig,
+  materialRef: string,
+): EmissiveInfo | undefined {
+  const { data: matData } = getMaterialDataSafe(config, materialRef);
+  const { data: emitTex } = getTextureDataSafe(config, matData.emittance_texture);
+
+  if (emitTex.type !== 'color') {
+    return undefined;
+  }
+  const sum = emitTex.color.reduce((a: number, b: number) => a + b, 0);
+  if (sum <= 0) {
+    return undefined;
+  }
+
+  return {
+    color: emitTex.color,
+    intensity: Math.max(...emitTex.color),
+  };
+}
+
+export type GeometricRendererProps = {
   config: NormalizedRenderConfig;
   name: string;
   rotation?: [number, number, number];
-}
+};
 
 export function GeometricRenderer(props: GeometricRendererProps) {
   const { config, name, rotation = [0, 0, 0] } = props;
@@ -20,26 +46,49 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       const width = Math.abs(data.a[0] - data.b[0]);
       const height = Math.abs(data.a[1] - data.b[1]);
       const depth = Math.abs(data.a[2] - data.b[2]);
-      const position: [number, number, number] = [
-        (data.a[0] + data.b[0]) / 2,
-        (data.a[1] + data.b[1]) / 2,
-        (data.a[2] + data.b[2]) / 2,
-      ];
+
+      const center = getCenterPoint(config, data);
+
+      const emissiveInfo = getEmissiveInfo(config, data.material);
+
       return (
-        <mesh position={position} rotation={rotation} castShadow receiveShadow>
-          <boxGeometry args={[width, height, depth]} />
-          <MaterialResolver config={config} materialRef={data.material} geometricName={name} />
-        </mesh>
+        <>
+          <mesh position={center} rotation={rotation} castShadow={!emissiveInfo} receiveShadow>
+            <boxGeometry args={[width, height, depth]} />
+            <MaterialResolver config={config} materialName={data.material} />
+          </mesh>
+          {emissiveInfo && (
+            <pointLight
+              color={emissiveInfo.color}
+              intensity={emissiveInfo.intensity}
+              position={center}
+              castShadow
+            />
+          )}
+        </>
       );
     }
 
-    case 'sphere':
+    case 'sphere': {
+      const emissiveInfo = getEmissiveInfo(config, data.material);
+
       return (
-        <mesh position={data.center} rotation={rotation} castShadow receiveShadow>
-          <sphereGeometry args={[data.radius]} />
-          <MaterialResolver config={config} materialRef={data.material} geometricName={name} />
-        </mesh>
+        <>
+          <mesh position={data.center} rotation={rotation} castShadow={!emissiveInfo} receiveShadow>
+            <sphereGeometry args={[data.radius]} />
+            <MaterialResolver config={config} materialName={data.material} />
+          </mesh>
+          {emissiveInfo && (
+            <pointLight
+              color={emissiveInfo.color}
+              intensity={emissiveInfo.intensity}
+              position={getCenterPoint(config, data)}
+              castShadow
+            />
+          )}
+        </>
       );
+    }
 
     case 'list':
       return (
@@ -86,29 +135,55 @@ export function GeometricRenderer(props: GeometricRendererProps) {
 
     case 'parallelogram': {
       const geom = createParallelogramGeometry(data);
+
+      const emissiveInfo = getEmissiveInfo(config, data.material);
+
       return (
-        <mesh rotation={rotation} castShadow receiveShadow>
-          <bufferGeometry>
-            <bufferAttribute attach="attributes-position" args={[geom.vertices, 3]} />
-            <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
-            <bufferAttribute attach="index" args={[geom.indices, 1]} />
-          </bufferGeometry>
-          <MaterialResolver config={config} materialRef={data.material} geometricName={name} />
-        </mesh>
+        <>
+          <mesh rotation={rotation} castShadow={!emissiveInfo} receiveShadow>
+            <bufferGeometry>
+              <bufferAttribute attach="attributes-position" args={[geom.vertices, 3]} />
+              <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
+              <bufferAttribute attach="index" args={[geom.indices, 1]} />
+            </bufferGeometry>
+            <MaterialResolver config={config} materialName={data.material} />
+          </mesh>
+          {emissiveInfo && (
+            <pointLight
+              color={emissiveInfo.color}
+              intensity={emissiveInfo.intensity}
+              position={getCenterPoint(config, data)}
+              castShadow
+            />
+          )}
+        </>
       );
     }
 
     case 'triangle': {
       const geom = createTriangleGeometry(data);
+
+      const emissiveInfo = getEmissiveInfo(config, data.material);
+
       return (
-        <mesh rotation={rotation} castShadow receiveShadow>
-          <bufferGeometry>
-            <bufferAttribute attach="attributes-position" args={[geom.vertices, 3]} />
-            <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
-            <bufferAttribute attach="index" args={[geom.indices, 1]} />
-          </bufferGeometry>
-          <MaterialResolver config={config} materialRef={data.material} geometricName={name} />
-        </mesh>
+        <>
+          <mesh rotation={rotation} castShadow={!emissiveInfo} receiveShadow>
+            <bufferGeometry>
+              <bufferAttribute attach="attributes-position" args={[geom.vertices, 3]} />
+              <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
+              <bufferAttribute attach="index" args={[geom.indices, 1]} />
+            </bufferGeometry>
+            <MaterialResolver config={config} materialName={data.material} />
+          </mesh>
+          {emissiveInfo && (
+            <pointLight
+              color={emissiveInfo.color}
+              intensity={emissiveInfo.intensity}
+              position={getCenterPoint(config, data)}
+              castShadow
+            />
+          )}
+        </>
       );
     }
 

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -1,19 +1,16 @@
 import { getMaterialDataSafe } from '@/utils/render/material';
 import { getTextureDataSafe } from '@/utils/render/texture';
-import { getCenterPoint } from '@/utils/render/geometric';
-import { getGeometricDataSafe } from '@/utils/render/geometric';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 
 export type MaterialResolverProps = {
   config: NormalizedRenderConfig;
-  materialRef: string;
-  geometricName: string;
+  materialName: string;
 };
 
 export function MaterialResolver(props: MaterialResolverProps) {
-  const { config, materialRef, geometricName } = props;
+  const { config, materialName } = props;
 
-  const { data: materialData } = getMaterialDataSafe(config, materialRef);
+  const { data: materialData } = getMaterialDataSafe(config, materialName);
   const { data: reflectanceTexture } = getTextureDataSafe(config, materialData.reflectance_texture);
   const { data: emittanceTexture } = getTextureDataSafe(config, materialData.emittance_texture);
 
@@ -22,43 +19,36 @@ export function MaterialResolver(props: MaterialResolverProps) {
       ? emittanceTexture.color
       : undefined;
 
-  const { data: geometricData } = getGeometricDataSafe(config, geometricName);
-
-  // material
-  let materialElement: React.ReactNode = null;
-
   switch (materialData.type) {
     case 'dielectric': {
       console.warn('Dielectric material not yet supported');
-      break;
+      return null;
     }
     case 'lambertian': {
       switch (reflectanceTexture.type) {
         case 'color': {
-          materialElement = (
+          return (
             <meshLambertMaterial
               attach="material"
               color={reflectanceTexture.color}
               {...(emissiveColor ? { emissive: emissiveColor } : {})}
             />
           );
-          break;
         }
         case 'checker':
         case 'image': {
           console.warn(
             `${reflectanceTexture.type} texture not yet supported for lambertian material`,
           );
-          materialElement = <meshLambertMaterial attach="material" color={[1, 1, 1]} />;
-          break;
+          return <meshLambertMaterial attach="material" color={[1, 1, 1]} />;
         }
       }
-      break;
     }
+    // eslint-disable-next-line no-fallthrough -- all inner branches return, TS confirms exhaustive
     case 'specular': {
       switch (reflectanceTexture.type) {
         case 'color': {
-          materialElement = (
+          return (
             <meshStandardMaterial
               attach="material"
               color={reflectanceTexture.color}
@@ -67,14 +57,13 @@ export function MaterialResolver(props: MaterialResolverProps) {
               roughness={materialData.roughness}
             />
           );
-          break;
         }
         case 'checker':
         case 'image': {
           console.warn(
             `${reflectanceTexture.type} texture not yet supported for specular material`,
           );
-          materialElement = (
+          return (
             <meshStandardMaterial
               attach="material"
               color={[1, 1, 1]}
@@ -82,26 +71,8 @@ export function MaterialResolver(props: MaterialResolverProps) {
               roughness={materialData.roughness}
             />
           );
-          break;
         }
       }
-      break;
     }
   }
-
-  const shouldCreatePointLight = emissiveColor && geometricData.type !== 'constant_volume';
-
-  return (
-    <>
-      {materialElement}
-      {shouldCreatePointLight && (
-        <pointLight
-          position={getCenterPoint(config, geometricData)}
-          intensity={Math.max(...emissiveColor)}
-          color={emissiveColor}
-          castShadow
-        />
-      )}
-    </>
-  );
 }


### PR DESCRIPTION
- **Fixes double-transform bug** — pointLight was nested inside `<mesh>`, inheriting parent position and doubling the offset. Moved to sibling level in GeometricRenderer.
- **Prevents self-shadowing** — emissive objects no longer cast shadows, so a point light inside a closed box can illuminate external surfaces instead of the box walls occluding everything.
- **Cleans up MaterialResolver** — replaces `materialElement` variable + `break` with direct returns from each nested switch branch.
- **Consolidates helpers** — `isEmissive` + `resolvePointLight` replaced by single `getEmissiveInfo` returning `EmissiveInfo | undefined`.
- **Unifies positioning** — all 4 geometric types use `getCenterPoint` for light position.