### PR TITLE
Respect `around` pivot in 3D preview and expose it in form controls

### DIFF
--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -1,7 +1,14 @@
 import type { NormalizedRenderConfig, RenderConfig } from './config';
 import { normalizeMaterialData, type RawMaterialData } from './material';
 import { normalizeTextureData, type RawTextureData } from './texture';
-import { AngleSchema, capitalize, getNextUniqueName, isTypedObject, toRadians, type Angle } from './utils';
+import {
+  AngleSchema,
+  capitalize,
+  getNextUniqueName,
+  isTypedObject,
+  toRadians,
+  type Angle,
+} from './utils';
 import { z } from 'zod';
 
 // geometric types
@@ -504,7 +511,7 @@ export const GeometricInstanceRotateXSchema = z
   .object({
     type: z.literal('rotate_x'),
     geometric: z.string().nonempty(),
-    around: z.tuple([z.number(), z.number(), z.number()]).nullish(),
+    around: z.tuple([z.number(), z.number(), z.number()]),
   })
   .and(AngleSchema);
 
@@ -512,7 +519,7 @@ export const GeometricInstanceRotateYSchema = z
   .object({
     type: z.literal('rotate_y'),
     geometric: z.string().nonempty(),
-    around: z.tuple([z.number(), z.number(), z.number()]).nullish(),
+    around: z.tuple([z.number(), z.number(), z.number()]),
   })
   .and(AngleSchema);
 
@@ -520,7 +527,7 @@ export const GeometricInstanceRotateZSchema = z
   .object({
     type: z.literal('rotate_z'),
     geometric: z.string().nonempty(),
-    around: z.tuple([z.number(), z.number(), z.number()]).nullish(),
+    around: z.tuple([z.number(), z.number(), z.number()]),
   })
   .and(AngleSchema);
 
@@ -559,7 +566,7 @@ export type NormalizedGeometricInstanceRotate = DistributiveOmit<
 export type RawGeometricInstanceRotate = {
   type: 'rotate_x' | 'rotate_y' | 'rotate_z';
   geometric: string | RawGeometricData;
-  around?: [number, number, number];
+  around: [number, number, number];
 } & Angle;
 
 export const GeometricInstanceTranslateSchema = z.object({

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
@@ -119,8 +119,22 @@ export function ControlsCardGeometric(props: ControlsCardGeometricProps) {
         return (
           <>
             <form.AppField name={`geometrics.${name}.${hasDegrees ? 'degrees' : 'radians'}`}>
-              {(field) => <field.RangeControl label={hasDegrees ? 'Degrees of Rotation' : 'Radians of Rotation'} min={0} max={hasDegrees ? 360 : 2 * Math.PI} step={hasDegrees ? 1.0 : 0.01} />}
+              {(field) => (
+                <field.RangeControl
+                  label={hasDegrees ? 'Degrees of Rotation' : 'Radians of Rotation'}
+                  min={0}
+                  max={hasDegrees ? 360 : 2 * Math.PI}
+                  step={hasDegrees ? 1.0 : 0.01}
+                />
+              )}
             </form.AppField>
+            <TextArrayInputControl
+              form={form}
+              fieldName={`geometrics.${name}.around`}
+              label="Rotation Point"
+              valueLabels={['x', 'y', 'z']}
+              type="number"
+            />
             <NestedGeometricHeader
               geometricName={embedddedGeometricName}
               renderConfig={renderConfig}

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -99,32 +99,53 @@ export function GeometricRenderer(props: GeometricRendererProps) {
         </>
       );
 
-    case 'rotate_x':
+    case 'rotate_x': {
+      const angleRad = toRadians(data);
+      const pivot = data.around ?? [0, 0, 0];
       return (
-        <GeometricRenderer
-          config={config}
-          name={data.geometric}
-          rotation={[rotation[0] + toRadians(data), rotation[1], rotation[2]]}
-        />
+        <group rotation={rotation}>
+          <group position={pivot}>
+            <group rotation={[angleRad, 0, 0]}>
+              <group position={[-pivot[0], -pivot[1], -pivot[2]]}>
+                <GeometricRenderer config={config} name={data.geometric} />
+              </group>
+            </group>
+          </group>
+        </group>
       );
+    }
 
-    case 'rotate_y':
+    case 'rotate_y': {
+      const angleRad = toRadians(data);
+      const pivot = data.around ?? [0, 0, 0];
       return (
-        <GeometricRenderer
-          config={config}
-          name={data.geometric}
-          rotation={[rotation[0], rotation[1] + toRadians(data), rotation[2]]}
-        />
+        <group rotation={rotation}>
+          <group position={pivot}>
+            <group rotation={[0, angleRad, 0]}>
+              <group position={[-pivot[0], -pivot[1], -pivot[2]]}>
+                <GeometricRenderer config={config} name={data.geometric} />
+              </group>
+            </group>
+          </group>
+        </group>
       );
+    }
 
-    case 'rotate_z':
+    case 'rotate_z': {
+      const angleRad = toRadians(data);
+      const pivot = data.around ?? [0, 0, 0];
       return (
-        <GeometricRenderer
-          config={config}
-          name={data.geometric}
-          rotation={[rotation[0], rotation[1], rotation[2] + toRadians(data)]}
-        />
+        <group rotation={rotation}>
+          <group position={pivot}>
+            <group rotation={[0, 0, angleRad]}>
+              <group position={[-pivot[0], -pivot[1], -pivot[2]]}>
+                <GeometricRenderer config={config} name={data.geometric} />
+              </group>
+            </group>
+          </group>
+        </group>
       );
+    }
 
     case 'translate':
       return (


### PR DESCRIPTION
## Summary

Closes #68 and addresses part of #69.

### Changes

**1. Schema & types (`geometric.ts`)** — Made `around` a required `[number, number, number]` tuple (was `.nullish()`). This matches the Rust backend default of `[0.0, 0.0, 0.0]` and enables reliable form binding.

**2. Form controls (`ControlsCardGeometric`)** — Added a `TextArrayInputControl` for the `around` pivot point on `rotate_x`/`rotate_y`/`rotate_z` geometrics. Labeled "Rotation Point" with x/y/z number inputs, following the same pattern as `translate.translation` and `sphere.center`.

**3. 3D preview fix (`GeometricRenderer`)** — Replaced Euler-angle accumulation in rotation instances with a pivot-aware group transform that mirrors the Rust backend: translate-to-pivot → rotate → translate-back. Nested rotations and translate-inside-rotate cases compose correctly through Three.js's scene graph.

### Verification
- ✅ `cargo check` — passes
- ✅ `cargo test` — 10 tests pass
- ✅ `cargo clippy` — no issues
- ✅ `npm run lint` (ESLint) — passes
- ✅ `npm run type-check` (TypeScript) — passes