### PR TITLE
chore: enforce prettier formatting in CI and `just validate`

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -50,6 +50,8 @@ jobs:
               - 'ui/tsconfig*.json'
               - 'ui/vite.config.ts'
               - 'ui/eslint.config.*'
+              - 'ui/.prettierrc'
+              - 'ui/.prettierignore'
               - 'ui/.nvmrc'
               - 'ui/index.html'
               - 'justfile'
@@ -100,6 +102,10 @@ jobs:
       - name: eslint
         if: github.event_name == 'pull_request' && steps.filter.outputs.ui == 'true'
         run: just lint-ui-ci
+
+      - name: prettier
+        if: github.event_name == 'pull_request' && steps.filter.outputs.ui == 'true'
+        run: just prettier-check-ui-ci
 
       - name: tsc type-check
         if: github.event_name == 'pull_request' && steps.filter.outputs.ui == 'true'

--- a/justfile
+++ b/justfile
@@ -56,6 +56,7 @@ build-cli:
 validate: cargo-check cargo-test cargo-clippy
     cd ui \
     && npm run lint \
+    && npm run prettier-check \
     && npm run type-check
 
 [group('validate')]
@@ -85,6 +86,13 @@ lint-ui: setup-ui-env
 [group('validate')]
 lint-ui-ci:
     cd ui && npm run lint -- --max-warnings 0
+
+[group('validate')]
+prettier-check-ui: setup-ui-env
+    cd ui && npm run prettier-check
+[group('validate')]
+prettier-check-ui-ci:
+    cd ui && npm run prettier-check
 
 [group('validate')]
 typecheck-ui: setup-ui-env

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -1,10 +1,10 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
-import prettier from 'eslint-config-prettier'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import { defineConfig, globalIgnores } from 'eslint/config';
+import prettier from 'eslint-config-prettier';
 
 export default defineConfig([
   globalIgnores(['dist']),
@@ -21,8 +21,11 @@ export default defineConfig([
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'warn',
-      'react-refresh/only-export-components': ['warn', { allowConstantExport: true, allowExportNames: ['useAuth'] }],
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true, allowExportNames: ['useAuth'] },
+      ],
     },
   },
   prettier,
-])
+]);

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "prettier-check": "prettier --check .",
     "type-check": "tsc -b --noEmit",
     "preview": "vite preview"
   },

--- a/ui/src/components/ExpandableSection.tsx
+++ b/ui/src/components/ExpandableSection.tsx
@@ -23,9 +23,7 @@ export function ExpandableSection(props: ExpandableSectionProps) {
         }
       }}
     >
-      <div style={{ overflow: 'hidden' }}>
-        {children}
-      </div>
+      <div style={{ overflow: 'hidden' }}>{children}</div>
     </div>
   );
 }

--- a/ui/src/components/form-controls/ToggleControlUnbound.tsx
+++ b/ui/src/components/form-controls/ToggleControlUnbound.tsx
@@ -24,8 +24,8 @@ export function ToggleControlUnbound(props: ToggleControlUnboundProps) {
           onChange={(checked) => {
             const syntheticEvent = {
               target: { checked },
-            // ToggleSwitch onChange provides boolean, not a DOM event;
-            // synthesize a ChangeEvent so callers receive a consistent interface
+              // ToggleSwitch onChange provides boolean, not a DOM event;
+              // synthesize a ChangeEvent so callers receive a consistent interface
             } as ChangeEvent<HTMLInputElement>;
             onChange?.(syntheticEvent);
             // same synthetic event adapted to the InputEvent shape

--- a/ui/src/hooks/useUserMutations.ts
+++ b/ui/src/hooks/useUserMutations.ts
@@ -35,8 +35,7 @@ export function useUpdateUserQuotas() {
       maxRenders: number | null;
       maxCheckpointsPerRender: number | null;
       maxRenderPixelCount: number | null;
-    }) =>
-      updateUserQuotas(token, userID, maxRenders, maxCheckpointsPerRender, maxRenderPixelCount),
+    }) => updateUserQuotas(token, userID, maxRenders, maxCheckpointsPerRender, maxRenderPixelCount),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['allUsers'] });
     },

--- a/ui/src/utils/render/scene.ts
+++ b/ui/src/utils/render/scene.ts
@@ -65,7 +65,10 @@ export function isSceneData(x: unknown): x is SceneData {
   );
 }
 
-export function getSceneData(config: NormalizedRenderConfig, nameOrData: string | SceneData): SceneData {
+export function getSceneData(
+  config: NormalizedRenderConfig,
+  nameOrData: string | SceneData,
+): SceneData {
   if (isSceneData(nameOrData)) {
     return nameOrData;
   }

--- a/ui/src/utils/three.ts
+++ b/ui/src/utils/three.ts
@@ -13,17 +13,7 @@ export type TriangleGeometry = {
 export function createTriangleGeometry(geometricData: GeometricTriangle): TriangleGeometry {
   const { a, b, c, a_normal, b_normal, c_normal } = geometricData;
 
-  const vertices = new Float32Array([
-    a[0],
-    a[1],
-    a[2],
-    b[0],
-    b[1],
-    b[2],
-    c[0],
-    c[1],
-    c[2],
-  ]);
+  const vertices = new Float32Array([a[0], a[1], a[2], b[0], b[1], b[2], c[0], c[1], c[2]]);
 
   const indices = new Uint16Array([0, 1, 2]);
 

--- a/ui/src/views/renders/CreateRenderModal/ExistingRenderPicker.tsx
+++ b/ui/src/views/renders/CreateRenderModal/ExistingRenderPicker.tsx
@@ -99,7 +99,10 @@ export function ExistingRenderPicker(props: ExistingRenderPickerProps) {
                   >
                     <div className="flex min-w-0 items-center justify-between gap-2">
                       <div className="flex min-w-0 items-center gap-2">
-                        <span className="truncate font-medium text-zinc-200" title={render.config.name}>
+                        <span
+                          className="truncate font-medium text-zinc-200"
+                          title={render.config.name}
+                        >
                           {render.config.name}
                         </span>
                         <span className="shrink-0 text-sm text-zinc-500">#{render.id}</span>

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -55,15 +55,7 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
         )}
       </form.AppField>
 
-      <Button
-        color="default"
-        outline
-        onClick={handleSubmit}
-        disabled={
-          isUpdating ||
-          !isFormValid
-        }
-      >
+      <Button color="default" outline onClick={handleSubmit} disabled={isUpdating || !isFormValid}>
         {isUpdating ? (
           <span className="flex items-center justify-center">
             <Spinner size="sm" className="mr-2" />

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderControls.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderControls.tsx
@@ -62,27 +62,27 @@ export function RenderControls(props: RenderControlsProps) {
 
   return (
     <div className="flex justify-evenly gap-2">
-        <Button
-          color={isPaused || isPausing ? 'default' : 'yellow'}
-          outline
-          onClick={handlePauseOrResume}
-          disabled={isPausingOrResuming || !(isPaused || isPausing || isRunning)}
-        >
-          {isPausingOrResuming ? (
-            <span className="flex items-center justify-center">
-              <Spinner size="sm" className="mr-2" />
-              Processing...
-            </span>
-          ) : isPaused || isPausing ? (
-            'Resume Render'
-          ) : (
-            'Pause Render'
-          )}
-        </Button>
+      <Button
+        color={isPaused || isPausing ? 'default' : 'yellow'}
+        outline
+        onClick={handlePauseOrResume}
+        disabled={isPausingOrResuming || !(isPaused || isPausing || isRunning)}
+      >
+        {isPausingOrResuming ? (
+          <span className="flex items-center justify-center">
+            <Spinner size="sm" className="mr-2" />
+            Processing...
+          </span>
+        ) : isPaused || isPausing ? (
+          'Resume Render'
+        ) : (
+          'Pause Render'
+        )}
+      </Button>
 
-        <Button color="red" onClick={handleDelete} disabled={isPausing || isRunning}>
-          Delete Render
-        </Button>
+      <Button color="red" onClick={handleDelete} disabled={isPausing || isRunning}>
+        Delete Render
+      </Button>
     </div>
   );
 }

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
@@ -74,7 +74,9 @@ export function ControlsCardMaterial(props: ControlsCardMaterialProps) {
         return (
           <>
             <form.AppField name={`materials.${name}.index_of_refraction`}>
-              {(field) => <field.RangeControl label="Index of Refraction" min={1.0} max={10.0} step={0.01} />}
+              {(field) => (
+                <field.RangeControl label="Index of Refraction" min={1.0} max={10.0} step={0.01} />
+              )}
             </form.AppField>
             <TextureSelects name={name} />
           </>

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary

Applies Prettier formatting across the codebase and enforces it going forward so misformatted files are caught before merge.

## Changes

### Prettier formatting fixes (1st commit)
- 14 files reformatted to match `.prettierrc` rules (semicolons, trailing commas, line wrapping, bracket spacing, import style)

### CI + `just validate` enforcement (2nd commit)
- **`ui/package.json`** — added `"prettier-check": "prettier --check ."` npm script
- **`justfile`** — added `prettier-check-ui` and `prettier-check-ui-ci` recipes under the `validate` group; wired `prettier-check` into the `validate` recipe chain
- **`.github/workflows/docker-build.yml`** — added a `prettier` step to PR checks (gated on UI file changes, runs `just prettier-check-ui-ci`); added `.prettierrc` / `.prettierignore` to the UI path filter

### How it works
- `just validate` now runs `prettier --check .` (after ESLint, before type-check). Non-zero exit → failure.
- CI PR checks now fail ❌ if any tracked file isn't formatted according to `.prettierrc`.