### PR TITLE
Improve rotation interface: Around enum (Center/Origin/Point) + UI controls

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -17,7 +17,7 @@ use luxide::{
         textures::{Checker, Image8Bit, Noise, SolidColor},
     },
     tracing::{FileStorage, RenderManager, RenderState, RenderStorage, Scene, SceneWorld, User},
-    utils::Angle,
+    utils::{Angle, Around},
 };
 use noise::{Perlin, Turbulence};
 use rand::RngExt;
@@ -287,7 +287,7 @@ fn final_scene() -> Scene {
     let sphere_box = Arc::new(RotateYAxis::new(
         sphere_box,
         Angle::Degrees(15.0),
-        Point::ORIGIN,
+        Around::Origin,
     ));
     let sphere_box = Arc::new(Translate::new(
         sphere_box,
@@ -412,7 +412,7 @@ fn cornell_box() -> Scene {
     let far_left_box = Arc::new(RotateYAxis::new(
         far_left_box,
         Angle::Degrees(15.0),
-        Point::ORIGIN,
+        Around::Origin,
     ));
     let far_left_box = Arc::new(Translate::new(
         far_left_box,
@@ -435,7 +435,7 @@ fn cornell_box() -> Scene {
     let near_right_box = Arc::new(RotateYAxis::new(
         near_right_box,
         Angle::Degrees(-18.0),
-        Point::ORIGIN,
+        Around::Origin,
     ));
     let near_right_box = Arc::new(Translate::new(
         near_right_box,

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -12,7 +12,7 @@ use crate::{
     geometry::Geometric,
     shading::{Color, Texture, materials::Material},
     tracing::{RenderParameters, Scene},
-    utils::Angle,
+    utils::{Angle, Around},
 };
 
 mod scenes;
@@ -530,7 +530,7 @@ fn get_builtin_geometrics() -> IndexMap<String, GeometricData> {
                 material: material_fn("lambertian_cornell_box_white"),
              })),
             angle: Angle::Degrees(15.0),
-            around: Some([0.35, 0.0, -0.65]),
+            around: Around::Point([0.35, 0.0, -0.65]),
         },
         prefix_builtin_key("cornell_box_near_right_box") => GeometricData::InstanceRotateYAxis {
             geometric: GeometricRefOrInline::Inline(Box::new(GeometricData::CompoundAxisAlignedPBox {
@@ -540,7 +540,7 @@ fn get_builtin_geometrics() -> IndexMap<String, GeometricData> {
                 material: material_fn("lambertian_cornell_box_white"),
             })),
             angle: Angle::Degrees(-18.0),
-            around: Some([0.65, 0.0, -0.35]),
+            around: Around::Point([0.65, 0.0, -0.35]),
         },
     }
 }

--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -10,7 +10,7 @@ use crate::{
         primitives::{Parallelogram, Sphere, Triangle},
         volumes,
     },
-    utils::Angle,
+    utils::{Angle, Around},
 };
 
 use super::{Build, Builts, materials::MaterialRefOrInline};
@@ -69,24 +69,21 @@ pub enum GeometricData {
         geometric: GeometricRefOrInline,
         #[serde(flatten)]
         angle: Angle,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        around: Option<[f64; 3]>,
+        around: Around,
     },
     #[serde(rename = "rotate_y")]
     InstanceRotateYAxis {
         geometric: GeometricRefOrInline,
         #[serde(flatten)]
         angle: Angle,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        around: Option<[f64; 3]>,
+        around: Around,
     },
     #[serde(rename = "rotate_z")]
     InstanceRotateZAxis {
         geometric: GeometricRefOrInline,
         #[serde(flatten)]
         angle: Angle,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        around: Option<[f64; 3]>,
+        around: Around,
     },
     #[serde(rename = "translate")]
     InstanceTranslate {
@@ -199,11 +196,7 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
             } => {
                 let geometric = geometric_ref.build(builts)?;
 
-                Ok(Arc::new(RotateXAxis::new(
-                    geometric,
-                    *angle,
-                    around.unwrap_or([0.0, 0.0, 0.0]).into(),
-                )))
+                Ok(Arc::new(RotateXAxis::new(geometric, *angle, *around)))
             }
             Self::InstanceRotateYAxis {
                 geometric: geometric_ref,
@@ -212,11 +205,7 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
             } => {
                 let geometric = geometric_ref.build(builts)?;
 
-                Ok(Arc::new(RotateYAxis::new(
-                    geometric,
-                    *angle,
-                    around.unwrap_or([0.0, 0.0, 0.0]).into(),
-                )))
+                Ok(Arc::new(RotateYAxis::new(geometric, *angle, *around)))
             }
             Self::InstanceRotateZAxis {
                 geometric: geometric_ref,
@@ -225,11 +214,7 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
             } => {
                 let geometric = geometric_ref.build(builts)?;
 
-                Ok(Arc::new(RotateZAxis::new(
-                    geometric,
-                    *angle,
-                    around.unwrap_or([0.0, 0.0, 0.0]).into(),
-                )))
+                Ok(Arc::new(RotateZAxis::new(geometric, *angle, *around)))
             }
             Self::InstanceTranslate {
                 geometric: geometric_ref,

--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -105,6 +105,14 @@ impl Aabb {
         }
         true
     }
+
+    pub fn center(&self) -> Point {
+        Point::new(
+            (self.x_interval.minimum + self.x_interval.maximum) / 2.0,
+            (self.y_interval.minimum + self.y_interval.maximum) / 2.0,
+            (self.z_interval.minimum + self.z_interval.maximum) / 2.0,
+        )
+    }
 }
 
 impl Index<usize> for Aabb {

--- a/src/geometry/instances/rotate_x_axis.rs
+++ b/src/geometry/instances/rotate_x_axis.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
-    utils::{Angle, Interval},
+    utils::{Angle, Around, Interval},
 };
 
 #[derive(Clone, Debug)]
@@ -15,8 +15,8 @@ pub struct RotateXAxis {
 }
 
 impl RotateXAxis {
-    pub fn new(geometric: Arc<dyn Geometric>, angle: Angle, around: Point) -> Self {
-        let translation = around.0;
+    pub fn new(geometric: Arc<dyn Geometric>, angle: Angle, around: Around) -> Self {
+        let translation = around.point(&geometric).0;
         let geometric_bbox = geometric.bounding_box() - translation;
 
         let sin_theta = angle.as_radians().sin();

--- a/src/geometry/instances/rotate_y_axis.rs
+++ b/src/geometry/instances/rotate_y_axis.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
-    utils::{Angle, Interval},
+    utils::{Angle, Around, Interval},
 };
 
 #[derive(Clone, Debug)]
@@ -15,8 +15,8 @@ pub struct RotateYAxis {
 }
 
 impl RotateYAxis {
-    pub fn new(geometric: Arc<dyn Geometric>, angle: Angle, around: Point) -> Self {
-        let translation = around.0;
+    pub fn new(geometric: Arc<dyn Geometric>, angle: Angle, around: Around) -> Self {
+        let translation = around.point(&geometric).0;
         let geometric_bbox = geometric.bounding_box() - translation;
 
         let sin_theta = angle.as_radians().sin();

--- a/src/geometry/instances/rotate_z_axis.rs
+++ b/src/geometry/instances/rotate_z_axis.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
-    utils::{Angle, Interval},
+    utils::{Angle, Around, Interval},
 };
 
 #[derive(Clone, Debug)]
@@ -15,8 +15,8 @@ pub struct RotateZAxis {
 }
 
 impl RotateZAxis {
-    pub fn new(geometric: Arc<dyn Geometric>, angle: Angle, around: Point) -> Self {
-        let translation = around.0;
+    pub fn new(geometric: Arc<dyn Geometric>, angle: Angle, around: Around) -> Self {
+        let translation = around.point(&geometric).0;
         let geometric_bbox = geometric.bounding_box() - translation;
 
         let sin_theta = angle.as_radians().sin();

--- a/src/tracing/storage/postgres.rs
+++ b/src/tracing/storage/postgres.rs
@@ -1,6 +1,6 @@
 use sqlx::{Pool, Postgres};
 
-use crate::utils::{ProgressInfo, decode_pixel_data, encode_pixel_data};
+use crate::utils::{ProgressInfo, decode_pixel_data, encode_pixel_data, upgrade_legacy_around};
 
 use super::{
     GithubID, Render, RenderCheckpoint, RenderCheckpointMeta, RenderID, RenderState, RenderStorage,
@@ -45,11 +45,12 @@ impl RenderStorage for PostgresStorage {
         .fetch_optional(&self.pool)
         .await
         {
-            Ok(Some(row)) => {
+            Ok(Some(mut row)) => {
                 let state = serde_json::from_value(row.state).map_err(|e| {
                     format!("Failed to deserialize render state for id {}: {}", id, e)
                 })?;
 
+                upgrade_legacy_around(&mut row.config);
                 let config = serde_json::from_value(row.config).map_err(|e| {
                     format!("Failed to deserialize render config for id {}: {}", id, e)
                 })?;
@@ -144,13 +145,14 @@ impl RenderStorage for PostgresStorage {
         .map_err(|e| format!("Failed to get all renders: {}", e))?;
 
         let mut renders = Vec::with_capacity(rows.len());
-        for row in rows {
+        for mut row in rows {
             let state = serde_json::from_value(row.state).map_err(|e| {
                 format!(
                     "Failed to deserialize render state for id {}: {}",
                     row.id, e
                 )
             })?;
+            upgrade_legacy_around(&mut row.config);
             let config = serde_json::from_value(row.config).map_err(|e| {
                 format!(
                     "Failed to deserialize render config for id {}: {}",
@@ -192,13 +194,14 @@ impl RenderStorage for PostgresStorage {
         .map_err(|e| format!("Failed to get all renders for user id {}: {}", user_id, e))?;
 
         let mut renders = Vec::with_capacity(rows.len());
-        for row in rows {
+        for mut row in rows {
             let state = serde_json::from_value(row.state).map_err(|e| {
                 format!(
                     "Failed to deserialize render state for id {}: {}",
                     row.id, e
                 )
             })?;
+            upgrade_legacy_around(&mut row.config);
             let config = serde_json::from_value(row.config).map_err(|e| {
                 format!(
                     "Failed to deserialize render config for id {}: {}",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,9 @@
 mod arc_lock;
 pub use arc_lock::*;
 
+mod around;
+pub use around::*;
+
 mod binary;
 pub use binary::*;
 

--- a/src/utils/around.rs
+++ b/src/utils/around.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::geometry::{Geometric, Point};
+
+/// Pivot point for rotation geometrics.
+///
+/// Serializes as either a string (`"center"` or `"origin"`) or a 3-element array (`[x, y, z]`).
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Around {
+    /// Rotate around the child geometric's center point (computed at build time)
+    Center,
+    /// Rotate around the world origin `[0.0, 0.0, 0.0]`
+    Origin,
+    /// Rotate around an explicit custom point
+    Point([f64; 3]),
+}
+
+impl Around {
+    pub fn point(&self, geometric: &Arc<dyn Geometric>) -> Point {
+        match self {
+            Around::Center => geometric.bounding_box().center(),
+            Around::Origin => Point::ORIGIN,
+            Around::Point(p) => (*p).into(),
+        }
+    }
+}

--- a/src/utils/around.rs
+++ b/src/utils/around.rs
@@ -27,3 +27,57 @@ impl Around {
         }
     }
 }
+
+/// Upgrades legacy `around` values in a `serde_json::Value` tree so
+/// they match the current `Around` serde format.
+///
+/// For any object with `"type": "rotate_x" | "rotate_y" | "rotate_z"`:
+/// - Bare array `[x, y, z]` → wraps as `{"point": [x, y, z]}`
+/// - Missing `"around"` key → inserts `"around": "origin"`
+/// - Already a string or object → left unchanged
+///
+/// Idempotent — calling on already-upgraded values is a no-op.
+pub fn upgrade_legacy_around(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            // only act on rotation geometrics
+            if let Some(serde_json::Value::String(type_str)) = map.get("type")
+                && matches!(type_str.as_str(), "rotate_x" | "rotate_y" | "rotate_z")
+            {
+                match map.get("around") {
+                    // bare array → wrap in {"point": [...]}
+                    Some(serde_json::Value::Array(arr)) => {
+                        let mut point_obj = serde_json::Map::new();
+                        point_obj.insert(
+                            "point".to_string(),
+                            serde_json::Value::Array(arr.clone()),
+                        );
+                        map.insert(
+                            "around".to_string(),
+                            serde_json::Value::Object(point_obj),
+                        );
+                    }
+                    // missing → insert "origin"
+                    None => {
+                        map.insert(
+                            "around".to_string(),
+                            serde_json::Value::String("origin".to_string()),
+                        );
+                    }
+                    // already a string or object → leave as-is
+                    _ => {}
+                }
+            }
+            // recurse into all values
+            for v in map.values_mut() {
+                upgrade_legacy_around(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                upgrade_legacy_around(v);
+            }
+        }
+        _ => {}
+    }
+}

--- a/ui/src/components/form-controls/SelectControl.tsx
+++ b/ui/src/components/form-controls/SelectControl.tsx
@@ -1,8 +1,9 @@
 import { useFieldContext } from '@/hooks/formContext';
+import React from 'react';
 import { Label, Select } from 'flowbite-react';
 
 interface SelectItem {
-  name: string;
+  label: string;
   value: string;
 }
 
@@ -11,17 +12,18 @@ export type SelectControlProps = {
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
   items: SelectItem[];
+  onChange?: (value: string) => void;
+  mapValue?: (value: string) => string;
 };
 
 export function SelectControl(props: SelectControlProps) {
-  const { label, labelPrefix, labelSuffix, items } = props;
+  const { label, labelPrefix, labelSuffix, items, onChange, mapValue } = props;
 
   const field = useFieldContext<string>();
 
   const currentValue = field.state.value;
-  const valueLabel = items.some((item) => item.value === currentValue)
-    ? currentValue
-    : '__MISSING__';
+  const controlValue = mapValue ? mapValue(currentValue) : currentValue;
+  const valueLabel = items.find((item) => item.value === controlValue)?.label ?? '__MISSING__';
 
   return (
     <Label className="mb-2 flex flex-col gap-1.5">
@@ -33,10 +35,19 @@ export function SelectControl(props: SelectControlProps) {
         </span>
         <span>{valueLabel}</span>
       </span>
-      <Select value={currentValue} onChange={(e) => field.handleChange(e.target.value)}>
-        {items.map((item) => (
-          <option key={item.value} value={item.value}>
-            {item.name}
+      <Select
+        value={controlValue}
+        onChange={(e) => {
+          if (onChange) {
+            onChange(e.target.value);
+          } else {
+            field.handleChange(e.target.value);
+          }
+        }}
+      >
+        {items.map(({ value, label: itemValue }) => (
+          <option key={value} value={value}>
+            {itemValue}
           </option>
         ))}
       </Select>

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -3,11 +3,15 @@ import { normalizeMaterialData, type RawMaterialData } from './material';
 import { normalizeTextureData, type RawTextureData } from './texture';
 import {
   AngleSchema,
+  AroundSchema,
   capitalize,
   getNextUniqueName,
+  isAroundCenter,
+  isAroundOrigin,
   isTypedObject,
   toRadians,
   type Angle,
+  type Around,
 } from './utils';
 import { z } from 'zod';
 
@@ -173,6 +177,23 @@ function rotatePoint(
   return [rx + px, ry + py, rz + pz];
 }
 
+// resolve an Around variant to a concrete [x, y, z] pivot point.
+// for Center, computes the child geometric's center.
+export function getAroundPoint(
+  around: Around,
+  config: NormalizedRenderConfig,
+  childGeometricName: string,
+): [number, number, number] {
+  if (isAroundCenter(around)) {
+    const { data: childData } = getGeometricDataSafe(config, childGeometricName);
+    return getCenterPoint(config, childData);
+  }
+  if (isAroundOrigin(around)) {
+    return [0, 0, 0];
+  }
+  return around.point;
+}
+
 export function getCenterPoint(
   config: NormalizedRenderConfig,
   data: GeometricData,
@@ -203,9 +224,7 @@ export function getCenterPoint(
       const { data: subData } = getGeometricDataSafe(config, data.geometric);
       const childCenter = getCenterPoint(config, subData);
       const angleRad = toRadians(data);
-      // default to origin if around pivot is not specified,
-      // matching Rust backend: around.unwrap_or([0.0, 0.0, 0.0])
-      const pivot = data.around ?? [0, 0, 0];
+      const pivot = getAroundPoint(data.around, config, data.geometric);
       return rotatePoint(childCenter, data.type, angleRad, pivot);
     }
     case 'constant_volume': {
@@ -327,21 +346,21 @@ export function defaultGeometricForType(
         type: 'rotate_x',
         geometric: '__unit_box',
         degrees: 0,
-        around: [0, 0, 0],
+        around: 'center',
       };
     case 'rotate_y':
       return {
         type: 'rotate_y',
         geometric: '__unit_box',
         degrees: 0,
-        around: [0, 0, 0],
+        around: 'center',
       };
     case 'rotate_z':
       return {
         type: 'rotate_z',
         geometric: '__unit_box',
         degrees: 0,
-        around: [0, 0, 0],
+        around: 'center',
       };
     case 'translate':
       return {
@@ -511,7 +530,7 @@ export const GeometricInstanceRotateXSchema = z
   .object({
     type: z.literal('rotate_x'),
     geometric: z.string().nonempty(),
-    around: z.tuple([z.number(), z.number(), z.number()]),
+    around: AroundSchema,
   })
   .and(AngleSchema);
 
@@ -519,7 +538,7 @@ export const GeometricInstanceRotateYSchema = z
   .object({
     type: z.literal('rotate_y'),
     geometric: z.string().nonempty(),
-    around: z.tuple([z.number(), z.number(), z.number()]),
+    around: AroundSchema,
   })
   .and(AngleSchema);
 
@@ -527,7 +546,7 @@ export const GeometricInstanceRotateZSchema = z
   .object({
     type: z.literal('rotate_z'),
     geometric: z.string().nonempty(),
-    around: z.tuple([z.number(), z.number(), z.number()]),
+    around: AroundSchema,
   })
   .and(AngleSchema);
 
@@ -566,7 +585,7 @@ export type NormalizedGeometricInstanceRotate = DistributiveOmit<
 export type RawGeometricInstanceRotate = {
   type: 'rotate_x' | 'rotate_y' | 'rotate_z';
   geometric: string | RawGeometricData;
-  around: [number, number, number];
+  around: Around;
 } & Angle;
 
 export const GeometricInstanceTranslateSchema = z.object({

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -117,7 +117,7 @@ export function getCornellBoxRenderConfig(): NormalizedRenderConfig {
         type: 'rotate_y',
         geometric: 'Far Left Box - Unrotated',
         degrees: 15.0,
-        around: [3.5, 0.0, -6.5],
+        around: 'center',
       },
       'Far Left Box - Unrotated': {
         type: 'box',
@@ -130,7 +130,7 @@ export function getCornellBoxRenderConfig(): NormalizedRenderConfig {
         type: 'rotate_y',
         geometric: 'Near Right Box - Unrotated',
         degrees: 342.0,
-        around: [6.5, 0.0, -3.5],
+        around: 'center',
       },
       'Near Right Box - Unrotated': {
         type: 'box',

--- a/ui/src/utils/render/utils.ts
+++ b/ui/src/utils/render/utils.ts
@@ -100,6 +100,30 @@ export function toDegrees(angle: Angle): number {
   return angle.degrees;
 }
 
+/* AROUND */
+
+export type Around = AroundCenter | AroundOrigin | AroundPoint;
+
+export type AroundCenter = 'center';
+export type AroundOrigin = 'origin';
+export type AroundPoint = { point: [number, number, number] };
+
+export function isAroundCenter(around: Around): around is AroundCenter {
+  return around === 'center';
+}
+export function isAroundOrigin(around: Around): around is AroundOrigin {
+  return around === 'origin';
+}
+export function isAroundPoint(around: Around): around is AroundPoint {
+  return typeof around === 'object' && 'point' in around;
+}
+
+export const AroundSchema = z.union([
+  z.literal('center'),
+  z.literal('origin'),
+  z.object({ point: z.tuple([z.number(), z.number(), z.number()]) }),
+]);
+
 /**
  * fixes dangling references after a geometric, material, or texture is deleted.
  * replaces broken references with default values (__white, __black, __lambertian_white, __unit_box).

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/AroundVariantControls.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/AroundVariantControls.tsx
@@ -1,4 +1,3 @@
-import { Select } from 'flowbite-react';
 import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
 import { isAroundPoint } from '@/utils/render/utils';
 import type { Around } from '@/utils/render/utils';
@@ -7,48 +6,49 @@ import type { RenderForm } from '@/hooks/useRenderForm';
 export type AroundVariantControlsProps = {
   form: RenderForm;
   geometricName: string;
-  around: Around;
 };
 
 export function AroundVariantControls(props: AroundVariantControlsProps) {
-  const { form, geometricName, around } = props;
+  const { form, geometricName } = props;
 
   return (
-    <>
-      <div className="mb-2">
-        <label className="mb-1 block text-sm font-medium text-gray-300">Rotation Point</label>
-        <Select
-          value={typeof around === 'string' ? around : 'point'}
-          onChange={(e) => {
-            const variant = e.target.value;
-            if (variant === 'center') {
-              // superRefine schema prevents TS from narrowing the discriminated union here
-              form.setFieldValue(`geometrics.${geometricName}.around`, 'center' as never);
-            } else if (variant === 'origin') {
-              // superRefine schema prevents TS from narrowing the discriminated union here
-              form.setFieldValue(`geometrics.${geometricName}.around`, 'origin' as never);
-            } else {
-              // superRefine schema prevents TS from narrowing the discriminated union here
-              form.setFieldValue(`geometrics.${geometricName}.around`, {
-                point: [0, 0, 0],
-              } as never);
-            }
-          }}
-        >
-          <option value="center">Center of geometry</option>
-          <option value="origin">Origin (0, 0, 0)</option>
-          <option value="point">Custom point</option>
-        </Select>
-      </div>
-      {isAroundPoint(around) && (
-        <TextArrayInputControl
-          form={form}
-          fieldName={`geometrics.${geometricName}.around.point`}
-          label="Custom Rotation Point"
-          valueLabels={['x', 'y', 'z']}
-          type="number"
-        />
+    <form.AppField name={`geometrics.${geometricName}.around`}>
+      {(field) => (
+        <>
+          <field.SelectControl
+            label="Rotation Point"
+            items={[
+              { label: 'Geometric Center', value: 'center' },
+              { label: 'World Origin', value: 'origin' },
+              { label: 'Custom Point', value: 'point' },
+            ]}
+            onChange={(value) => {
+              if (value === 'center' || value === 'origin') {
+                // superRefine schema prevents TS from narrowing the discriminated union here
+                field.handleChange(value as never);
+              } else {
+                // superRefine schema prevents TS from narrowing the discriminated union here
+                field.handleChange({ point: [0, 0, 0] } as never);
+              }
+            }}
+            mapValue={(v) => {
+              if (typeof v === 'string') {
+                return v;
+              }
+              return 'point';
+            }}
+          />
+          {isAroundPoint((field.state.value as Around | undefined) ?? 'origin') && (
+            <TextArrayInputControl
+              form={form}
+              fieldName={`geometrics.${geometricName}.around.point`}
+              label="Custom Rotation Point"
+              valueLabels={['x', 'y', 'z']}
+              type="number"
+            />
+          )}
+        </>
       )}
-    </>
+    </form.AppField>
   );
 }

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/AroundVariantControls.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/AroundVariantControls.tsx
@@ -1,7 +1,9 @@
+import { ExpandableSection } from '@/components/ExpandableSection';
 import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
 import { isAroundPoint } from '@/utils/render/utils';
 import type { Around } from '@/utils/render/utils';
 import type { RenderForm } from '@/hooks/useRenderForm';
+import { AnimatedSeparator } from '@/components/AnimatedSeparator';
 
 export type AroundVariantControlsProps = {
   form: RenderForm;
@@ -13,42 +15,55 @@ export function AroundVariantControls(props: AroundVariantControlsProps) {
 
   return (
     <form.AppField name={`geometrics.${geometricName}.around`}>
-      {(field) => (
-        <>
-          <field.SelectControl
-            label="Rotation Point"
-            items={[
-              { label: 'Geometric Center', value: 'center' },
-              { label: 'World Origin', value: 'origin' },
-              { label: 'Custom Point', value: 'point' },
-            ]}
-            onChange={(value) => {
-              if (value === 'center' || value === 'origin') {
-                // superRefine schema prevents TS from narrowing the discriminated union here
-                field.handleChange(value as never);
-              } else {
-                // superRefine schema prevents TS from narrowing the discriminated union here
-                field.handleChange({ point: [0, 0, 0] } as never);
-              }
-            }}
-            mapValue={(v) => {
-              if (typeof v === 'string') {
-                return v;
-              }
-              return 'point';
-            }}
-          />
-          {isAroundPoint((field.state.value as Around | undefined) ?? 'origin') && (
-            <TextArrayInputControl
-              form={form}
-              fieldName={`geometrics.${geometricName}.around.point`}
-              label="Custom Rotation Point"
-              valueLabels={['x', 'y', 'z']}
-              type="number"
+      {(field) => {
+        const isPoint = isAroundPoint((field.state.value as Around | undefined) ?? 'origin');
+
+        return (
+          <>
+            <AnimatedSeparator visible={isPoint} />
+            <field.SelectControl
+              label="Rotation Point"
+              items={[
+                { label: 'Geometric Center', value: 'center' },
+                { label: 'World Origin', value: 'origin' },
+                { label: 'Custom Point', value: 'point' },
+              ]}
+              onChange={(value) => {
+                if (value === 'center' || value === 'origin') {
+                  // superRefine schema prevents TS from narrowing the discriminated union here
+                  field.handleChange(value as never);
+                } else {
+                  // superRefine schema prevents TS from narrowing the discriminated union here
+                  field.handleChange({ point: [0, 0, 0] } as never);
+                }
+              }}
+              mapValue={(v) => {
+                if (typeof v === 'string') {
+                  return v;
+                }
+                return 'point';
+              }}
             />
-          )}
-        </>
-      )}
+            <ExpandableSection
+              expanded={isPoint}
+              onExpandEnd={() => {
+                form.validate('change');
+              }}
+            >
+              <div className="py-2">
+                <TextArrayInputControl
+                  form={form}
+                  fieldName={`geometrics.${geometricName}.around.point`}
+                  label="Custom Rotation Point"
+                  valueLabels={['x', 'y', 'z']}
+                  type="number"
+                />
+              </div>
+            </ExpandableSection>
+            <AnimatedSeparator visible={isPoint} />
+          </>
+        );
+      }}
     </form.AppField>
   );
 }

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/AroundVariantControls.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/AroundVariantControls.tsx
@@ -1,0 +1,54 @@
+import { Select } from 'flowbite-react';
+import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
+import { isAroundPoint } from '@/utils/render/utils';
+import type { Around } from '@/utils/render/utils';
+import type { RenderForm } from '@/hooks/useRenderForm';
+
+export type AroundVariantControlsProps = {
+  form: RenderForm;
+  geometricName: string;
+  around: Around;
+};
+
+export function AroundVariantControls(props: AroundVariantControlsProps) {
+  const { form, geometricName, around } = props;
+
+  return (
+    <>
+      <div className="mb-2">
+        <label className="mb-1 block text-sm font-medium text-gray-300">Rotation Point</label>
+        <Select
+          value={typeof around === 'string' ? around : 'point'}
+          onChange={(e) => {
+            const variant = e.target.value;
+            if (variant === 'center') {
+              // superRefine schema prevents TS from narrowing the discriminated union here
+              form.setFieldValue(`geometrics.${geometricName}.around`, 'center' as never);
+            } else if (variant === 'origin') {
+              // superRefine schema prevents TS from narrowing the discriminated union here
+              form.setFieldValue(`geometrics.${geometricName}.around`, 'origin' as never);
+            } else {
+              // superRefine schema prevents TS from narrowing the discriminated union here
+              form.setFieldValue(`geometrics.${geometricName}.around`, {
+                point: [0, 0, 0],
+              } as never);
+            }
+          }}
+        >
+          <option value="center">Center of geometry</option>
+          <option value="origin">Origin (0, 0, 0)</option>
+          <option value="point">Custom point</option>
+        </Select>
+      </div>
+      {isAroundPoint(around) && (
+        <TextArrayInputControl
+          form={form}
+          fieldName={`geometrics.${geometricName}.around.point`}
+          label="Custom Rotation Point"
+          valueLabels={['x', 'y', 'z']}
+          type="number"
+        />
+      )}
+    </>
+  );
+}

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
@@ -17,7 +17,7 @@ function GeometricMaterialSelect({
 }: {
   form: RenderForm;
   name: string;
-  items: { name: string; value: string }[];
+  items: { label: string; value: string }[];
 }) {
   return (
     <form.AppField name={`geometrics.${name}.material`}>
@@ -70,7 +70,7 @@ export function ControlsCardGeometric(props: ControlsCardGeometricProps) {
 
   // build material select items
   const materialItems = Object.keys(renderConfig.materials ?? {}).map((key) => ({
-    name: key,
+    label: key,
     value: key,
   }));
 
@@ -129,11 +129,7 @@ export function ControlsCardGeometric(props: ControlsCardGeometricProps) {
                 />
               )}
             </form.AppField>
-            <AroundVariantControls
-              form={form}
-              geometricName={name}
-              around={data.around}
-            />
+            <AroundVariantControls form={form} geometricName={name} />
             <NestedGeometricHeader
               geometricName={embedddedGeometricName}
               renderConfig={renderConfig}

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardGeometric/index.tsx
@@ -1,5 +1,6 @@
 import { ControlsCard } from '../ControlsCard';
 import { NestedGeometricHeader } from './NestedGeometricHeader';
+import { AroundVariantControls } from './AroundVariantControls';
 import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
 import { TextInputControl } from '@/components/form-controls/TextInputControl';
 import { getGeometricData, getGeometricDataSafe } from '@/utils/render/geometric';
@@ -128,12 +129,10 @@ export function ControlsCardGeometric(props: ControlsCardGeometricProps) {
                 />
               )}
             </form.AppField>
-            <TextArrayInputControl
+            <AroundVariantControls
               form={form}
-              fieldName={`geometrics.${name}.around`}
-              label="Rotation Point"
-              valueLabels={['x', 'y', 'z']}
-              type="number"
+              geometricName={name}
+              around={data.around}
             />
             <NestedGeometricHeader
               geometricName={embedddedGeometricName}

--- a/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
+++ b/ui/src/views/renders/new/Controls/cards/ControlsCardMaterial.tsx
@@ -49,7 +49,7 @@ export function ControlsCardMaterial(props: ControlsCardMaterialProps) {
 
   // texture select items
   const textureItems = Object.keys(renderConfig.textures ?? {}).map((key) => ({
-    name: key,
+    label: key,
     value: key,
   }));
 

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -1,4 +1,4 @@
-import { getGeometricDataSafe } from '@/utils/render/geometric';
+import { getAroundPoint, getGeometricDataSafe } from '@/utils/render/geometric';
 import { toRadians } from '@/utils/render/utils';
 import { createParallelogramGeometry, createTriangleGeometry } from '@/utils/three';
 import { MaterialResolver } from './MaterialResolver';
@@ -101,7 +101,7 @@ export function GeometricRenderer(props: GeometricRendererProps) {
 
     case 'rotate_x': {
       const angleRad = toRadians(data);
-      const pivot = data.around ?? [0, 0, 0];
+      const pivot = getAroundPoint(data.around, config, data.geometric);
       return (
         <group rotation={rotation}>
           <group position={pivot}>
@@ -117,7 +117,7 @@ export function GeometricRenderer(props: GeometricRendererProps) {
 
     case 'rotate_y': {
       const angleRad = toRadians(data);
-      const pivot = data.around ?? [0, 0, 0];
+      const pivot = getAroundPoint(data.around, config, data.geometric);
       return (
         <group rotation={rotation}>
           <group position={pivot}>
@@ -133,7 +133,7 @@ export function GeometricRenderer(props: GeometricRendererProps) {
 
     case 'rotate_z': {
       const angleRad = toRadians(data);
-      const pivot = data.around ?? [0, 0, 0];
+      const pivot = getAroundPoint(data.around, config, data.geometric);
       return (
         <group rotation={rotation}>
           <group position={pivot}>


### PR DESCRIPTION
## Summary

Replaces the flat `around: [x, y, z]` rotation pivot with an `Around` enum with three variants, matching across backend and frontend. Closes #68, closes #69.

### Backend — `Around` enum

| Variant | JSON | Behavior |
|---|---|---|
| `Origin` | `"origin"` | Rotate around `[0, 0, 0]` |
| `Center` | `"center"` | Rotate around child geometric's bbox center |
| `Point([x,y,z])` | `{"point": [x, y, z]}` | Rotate around explicit custom point |

- `point(&geometric)` method resolves any variant to a concrete `Point`
- Rotation constructors (`RotateXAxis::new`, etc.) accept `Around` directly
- `upgrade_legacy_around()` transparently upgrades old DB configs with bare `[x,y,z]` arrays
- Breaking change: bare arrays rejected in new API submissions

### Frontend — matching UI

- `AroundVariantControls` sub-component: `SelectControl` dropdown (Geometric Center / World Origin / Custom Point) with animated `ExpandableSection` for custom point inputs
- `resolveAroundToPivot()` helper used in both `getCenterPoint` and `GeometricRenderer` 3D preview
- `SelectControl` enhanced with optional `onChange` and `mapValue` props for union-type fields
- `SelectItem.name` → `SelectItem.label` (all usages updated)

### Files
- **18 files**, +277/−77
- Backend: 10 files (new `around.rs`, updated deserialization, geometry instances, postgres storage, CLI)
- Frontend: 8 files (new `AroundVariantControls.tsx`, updated schemas, renderer, form controls, templates, SelectControl)