### PR TITLE
fix: prevent NaN propagation in ray tracer

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -208,9 +208,19 @@ impl Camera {
                         let pdf_val = pdf.strategy_density(incident_direction, index_of_strategy);
                         let mis_weight = pdf.power_heuristic(incident_direction, index_of_strategy);
 
+                        // degenerate sample from grazing-angle/proximity rejection in geometric direction_pdf
+                        if pdf_val <= 0.0 {
+                            return accumulated_color;
+                        }
+
                         attentuation_strength *= brdf_val * cos_theta * mis_weight / pdf_val;
                     } else {
                         let pdf_val = pdf.density(incident_direction);
+
+                        // degenerate sample from grazing-angle/proximity rejection in geometric direction_pdf
+                        if pdf_val <= 0.0 {
+                            return accumulated_color;
+                        }
 
                         attentuation_strength *= brdf_val * cos_theta / pdf_val;
                     }

--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -150,6 +150,14 @@ impl Vector {
         self.x * self.x + self.y * self.y + self.z * self.z
     }
 
+    pub fn de_nan(&self) -> Self {
+        Self {
+            x: if self.x.is_nan() { 0.0 } else { self.x },
+            y: if self.y.is_nan() { 0.0 } else { self.y },
+            z: if self.z.is_nan() { 0.0 } else { self.z },
+        }
+    }
+
     pub fn normalize(&mut self) {
         *self /= self.length();
     }

--- a/src/shading/color.rs
+++ b/src/shading/color.rs
@@ -50,20 +50,26 @@ impl Color {
         Self(self.0.scale_down(scale))
     }
 
+    pub fn de_nan(&self) -> Self {
+        Self(self.0.de_nan())
+    }
+
     pub fn as_rgba_u8(&self) -> image::Rgba<u8> {
+        let vec = self.0.de_nan();
         image::Rgba([
-            (self.0.x.clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
-            (self.0.y.clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
-            (self.0.z.clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
+            (vec.x.clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
+            (vec.y.clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
+            (vec.z.clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
             u8::MAX,
         ])
     }
 
     pub fn as_gamma_corrected_rgba_u8(&self, encoding_gamma: f64) -> image::Rgba<u8> {
+        let vec = self.0.de_nan();
         image::Rgba([
-            (self.0.x.powf(encoding_gamma).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
-            (self.0.y.powf(encoding_gamma).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
-            (self.0.z.powf(encoding_gamma).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
+            (vec.x.powf(encoding_gamma).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
+            (vec.y.powf(encoding_gamma).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
+            (vec.z.powf(encoding_gamma).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
             u8::MAX,
         ])
     }

--- a/src/tracing/tracer.rs
+++ b/src/tracing/tracer.rs
@@ -103,8 +103,11 @@ impl Tracer {
                                 + scaled_color)
                                 / checkpoint as f64;
 
+                            // guard against NaNs
+                            let safe_color = weighted_color.de_nan();
+
                             // send final pixel color
-                            ((x, y), weighted_color)
+                            ((x, y), safe_color)
                         })
                         .collect();
 


### PR DESCRIPTION
## Problem

NaN dead pixels appear in renders. Analysis of a 500×500 Cornell Box with glass spheres found 12 pixels where all 3 RGB channels were the x86 indefinite NaN (`0xfff8000000000000`).

## Root Cause

When MIS selects a geometric strategy (e.g., ceiling light sampling), the sampled direction can be nearly parallel to the light plane, causing `denominator.abs() <= 1e-8` in `Parallelogram::intersect()` to reject the ray. `direction_pdf` returns `0.0`, and with `cos_theta = 0` and `mis_weight = 0`, the division `0.0/0.0` at `camera.rs:211` produces NaN.

Confirmed by: MIS-disabled renders produce zero NaN pixels after 430+ checkpoints.

## Changes

Defense-in-depth across 3 layers:

| Layer | File | What |
|-------|------|------|
| **1 (root)** | `camera.rs` | `if pdf_val <= 0.0 { return accumulated_color }` — prevents the `0/0` division |
| **2** | `tracer.rs` | `weighted_color.de_nan()` — prevents NaN from being stored in checkpoint data |
| **3** | `color.rs` | `de_nan()` in output conversion — last-line sanitization at PNG encoding |
| helper | `vector.rs` | `de_nan()` method replacing NaN channels with `0.0` |

## Validation

- `cargo check` ✅
- `cargo test` — 10/10 ✅
- `cargo clippy -- -D clippy::correctness` ✅
- `npm run lint` / `prettier-check` / `type-check` ✅