### PR TITLE
Add render detail enhancements: pixel counts, progress %, and local ETA (#141)

### DIFF
--- a/src/server/handlers/get_render_stats.rs
+++ b/src/server/handlers/get_render_stats.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
 };
@@ -11,7 +11,7 @@ use crate::{
     utils::format_duration,
 };
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize)]
 pub struct FormattedRenderStats {
@@ -61,16 +61,38 @@ impl From<RenderCheckpointStats> for FormattedRenderCheckpointStats {
     }
 }
 
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub enum StatsFormat {
+    #[default]
+    Precise,
+    Pretty,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StatsFormatQueryParameters {
+    pub format: Option<StatsFormat>,
+}
+
 pub async fn get_render_stats(
     State(state): State<LuxideState>,
     claims: Claims,
     Path(id): Path<RenderID>,
+    Query(stats_format): Query<StatsFormatQueryParameters>,
 ) -> Response {
     println!("Handing request for get_render_stats (id: {})...", id);
 
     match state.render_manager.get_render_stats(id, claims.sub).await {
         Ok(Some(stats)) => {
-            (StatusCode::OK, Json(FormattedRenderStats::from(stats))).into_response()
+            let format = stats_format.format.unwrap_or_default();
+            match format {
+                StatsFormat::Precise => (StatusCode::OK, Json(stats)).into_response(),
+                StatsFormat::Pretty => {
+                    (StatusCode::OK, Json(FormattedRenderStats::from(stats))).into_response()
+                }
+            }
         }
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
         Err(e) => e.into(),

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -272,9 +272,9 @@ export async function updateRenderTotalCheckpoints(
 }
 
 export type RenderCheckpointStats = {
-  average_elapsed: string;
-  min_elapsed: string;
-  max_elapsed: string;
+  average_elapsed: Duration;
+  min_elapsed: Duration;
+  max_elapsed: Duration;
 };
 
 export type RenderStats = {
@@ -284,14 +284,14 @@ export type RenderStats = {
   completed_iterations: number;
   pixel_samples_per_checkpoint: number;
   total_samples_taken: number;
-  elapsed: string;
-  estimated_remaining: string;
-  estimated_total: string;
+  elapsed: Duration;
+  estimated_remaining: Duration;
+  estimated_total: Duration;
   checkpoint_stats: RenderCheckpointStats;
 };
 
 export async function getRenderStats(token: string, renderID: number): Promise<RenderStats> {
-  const response = await fetch(`${getAPIURL()}/renders/${renderID}/stats`, {
+  const response = await fetch(`${getAPIURL()}/renders/${renderID}/stats?format=precise`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 

--- a/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/RenderTiming.tsx
+++ b/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/RenderTiming.tsx
@@ -1,16 +1,40 @@
-type TimingData = {
+import { useEffect, useState } from 'react';
+
+export type RenderTimingData = {
   elapsed: string;
   remaining: string;
   total: string;
+  remainingSeconds?: number;
 };
 
 export type RenderTimingProps = {
   title: string;
-  timings: TimingData | null;
+  timings?: RenderTimingData;
 };
 
 export function RenderTiming(props: RenderTimingProps) {
   const { title, timings } = props;
+
+  // track current time as state, updating every second
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+
+    return () => {
+      clearInterval(id);
+    };
+  }, []);
+
+  const localCompletion =
+    timings?.remainingSeconds && timings.remainingSeconds > 0
+      ? new Date(now + timings.remainingSeconds * 1000).toLocaleTimeString([], {
+          hour: 'numeric',
+          minute: '2-digit',
+        })
+      : null;
 
   return (
     <div className="flex-1 rounded-lg border border-zinc-700 bg-zinc-800/30 p-3">
@@ -22,7 +46,10 @@ export function RenderTiming(props: RenderTimingProps) {
         </div>
         <div className="flex justify-between">
           <span className="text-zinc-500">Remaining</span>
-          <span className="text-zinc-300">{timings?.remaining ?? '—'}</span>
+          <span className="flex gap-2 text-zinc-300">
+            {localCompletion && <span className="text-zinc-500">(~{localCompletion}) </span>}
+            {timings?.remaining ?? '—'}
+          </span>
         </div>
         <div className="flex justify-between">
           <span className="text-zinc-500">Total</span>

--- a/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/index.tsx
+++ b/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/index.tsx
@@ -10,7 +10,7 @@ import { useRender } from '@/hooks/useRender';
 import { useRenderStats } from '@/hooks/useRenderStats';
 import { Spinner } from 'flowbite-react';
 import { ProgressState } from './ProgressState';
-import { RenderTiming } from './RenderTiming';
+import { RenderTiming, type RenderTimingData } from './RenderTiming';
 
 export function RenderProgress({ renderID }: { renderID: number }) {
   const {
@@ -63,27 +63,30 @@ export function RenderProgress({ renderID }: { renderID: number }) {
 
   // ---- checkpoint timing (from ProgressInfo, needs formatDuration) ----
 
-  let checkpointTiming = null;
+  let checkpointTiming: RenderTimingData | undefined;
   if (showProgress) {
     const progressInfo = isRenderStateRunning(state)
       ? state.running.progress_info
       : state.pausing.progress_info;
+
     checkpointTiming = {
       elapsed: formatDuration(progressInfo.elapsed),
       remaining: formatDuration(progressInfo.estimated_remaining),
       total: formatDuration(progressInfo.estimated_total),
+      remainingSeconds: progressInfo.estimated_remaining.secs,
     };
   }
 
-  // ---- whole render timing (from /stats, already formatted strings) ----
+  // ---- whole render timing (from /stats) ----
 
-  const wholeRenderTiming = renderStats
+  const wholeRenderTiming: RenderTimingData | undefined = renderStats
     ? {
         elapsed: formatDuration(renderStats.elapsed),
         remaining: formatDuration(renderStats.estimated_remaining),
         total: formatDuration(renderStats.estimated_total),
+        remainingSeconds: renderStats.estimated_remaining.secs,
       }
-    : null;
+    : undefined;
 
   // ---- status text ----
 

--- a/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/index.tsx
+++ b/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/index.tsx
@@ -79,9 +79,9 @@ export function RenderProgress({ renderID }: { renderID: number }) {
 
   const wholeRenderTiming = renderStats
     ? {
-        elapsed: renderStats.elapsed,
-        remaining: renderStats.estimated_remaining,
-        total: renderStats.estimated_total,
+        elapsed: formatDuration(renderStats.elapsed),
+        remaining: formatDuration(renderStats.estimated_remaining),
+        total: formatDuration(renderStats.estimated_total),
       }
     : null;
 
@@ -97,7 +97,7 @@ export function RenderProgress({ renderID }: { renderID: number }) {
   } else if (isRenderStatePaused(state)) {
     statusText = `Paused at checkpoint ${state.paused} of ${totalCheckpoints}`;
   } else if (isRenderStateFinishedCheckpointIteration(state)) {
-    const timeInfo = renderStats ? ` — Total time: ${renderStats.elapsed}` : '';
+    const timeInfo = renderStats ? ` — Total time: ${formatDuration(renderStats.elapsed)}` : '';
     statusText = `Finished checkpoint ${state.finished_checkpoint_iteration} of ${totalCheckpoints}${timeInfo}`;
   } else {
     statusText = 'Unknown state';

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderInfo/index.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderInfo/index.tsx
@@ -2,6 +2,41 @@ import { useRender } from '@/hooks/useRender';
 import { Spinner } from 'flowbite-react';
 import { PropertyRow } from './PropertyRow';
 import { ViewRenderJSONButton } from '@/components/ViewRenderJSONButton';
+import { useRenderStats } from '@/hooks/useRenderStats';
+
+/**
+ * Formats a pixel sample count for display.
+ * - Under 10M: comma-separated (e.g., "3,125,000")
+ * - 10M-999M: abbreviated with one decimal (e.g., "12.5M")
+ * - 1B+: abbreviated with one decimal (e.g., "1.3B")
+ */
+function formatPixelCount(count: number): string {
+  if (count >= 1_000_000_000) {
+    return `${(count / 1_000_000_000).toFixed(1)} billion`;
+  }
+  if (count >= 10_000_000) {
+    return `${(count / 1_000_000).toFixed(1)} million`;
+  }
+  return count.toLocaleString();
+}
+
+function formatPercentage(percentage: number): string {
+  // convert to fixed-point with 4 decimal places (e.g. 0.4257 → 4257)
+  const significand = Math.round(percentage * 10_000);
+
+  // determine precision by checking trailing digits
+  let precision: number;
+  if (significand % 100 === 0) {
+    precision = 0;
+  } else if (significand % 10 === 0) {
+    precision = 1;
+  } else {
+    precision = 2;
+  }
+
+  // convert back to percentage
+  return `${(significand / 100).toFixed(precision)}%`;
+}
 
 export type RenderInfoProps = {
   renderID: number;
@@ -16,6 +51,16 @@ export function RenderInfo(props: RenderInfoProps) {
     isError: isRenderError,
     error: renderError,
   } = useRender({ renderID });
+
+  const { data: renderStats } = useRenderStats({ renderID });
+
+  const totalSamples = renderStats
+    ? renderStats.total_iterations * renderStats.pixel_samples_per_checkpoint
+    : undefined;
+
+  const totalProgressPercentage = renderStats
+    ? renderStats.total_samples_taken / totalSamples!
+    : undefined;
 
   return (
     <div className="rounded border border-zinc-700 p-3">
@@ -44,6 +89,30 @@ export function RenderInfo(props: RenderInfoProps) {
             label="Total checkpoints"
             value={render.config.parameters.total_checkpoints}
           />
+          {renderStats && totalSamples && totalProgressPercentage && (
+            <>
+              <PropertyRow
+                label="Samples taken"
+                value={
+                  <span title={renderStats.total_samples_taken.toLocaleString()}>
+                    {formatPixelCount(renderStats.total_samples_taken)}
+                  </span>
+                }
+              />
+              <PropertyRow
+                label="Total samples"
+                value={
+                  <span title={totalSamples.toLocaleString()}>
+                    {formatPixelCount(totalSamples)}
+                  </span>
+                }
+              />{' '}
+              <PropertyRow
+                label="Overall progress"
+                value={formatPercentage(totalProgressPercentage)}
+              />
+            </>
+          )}
           <PropertyRow
             label="Created"
             value={new Date(render.created_at).toLocaleDateString('en-US', {


### PR DESCRIPTION
Closes #141

## What's in this PR

### Backend
- `GET /renders/:id/stats` now accepts `?format=precise` (raw Duration objects, new default) and `?format=pretty` (formatted strings). This lets the frontend do its own duration formatting and compute local completion times.

### Frontend — Render Info sidebar
- New rows: **Samples taken**, **Total samples**, and **Overall progress** (percentage with dynamic precision)
- Exact numbers visible on hover via `title` tooltips
- Sample counts formatted with comma separators (< 10M) or abbreviated (≥ 10M, e.g. "12.5 million")

### Frontend — Timing cards
- Local estimated completion time displayed left of remaining duration: `(~ 3:15 PM) 1h 20m`
- Works for both "This Checkpoint" and "Whole Render" panels
- Uses canonical React `setInterval` pattern for `Date.now()` to satisfy purity rules

### Files changed
| File | Change |
|------|--------|
| `src/server/handlers/get_render_stats.rs` | Added `StatsFormat` enum + query param |
| `ui/src/utils/api.ts` | Duration fields `string` → `Duration`; `?format=precise` on stats URL |
| `ui/src/.../RenderTiming.tsx` | Accepts `remainingSecs`, shows local completion time |
| `ui/src/.../RenderProgress/index.tsx` | Passes `remainingSecs` to timing cards |
| `ui/src/.../RenderInfo/index.tsx` | New pixel count + progress rows with tooltips |