### PR TITLE
Refactor admin QuotaEditModal to use TanStack Form (#142)

### DIFF
--- a/ui/src/views/admin/QuotaEditModal.tsx
+++ b/ui/src/views/admin/QuotaEditModal.tsx
@@ -1,14 +1,7 @@
-import { useState } from 'react';
-import {
-  Button,
-  Label,
-  Modal,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  TextInput,
-  ToggleSwitch,
-} from 'flowbite-react';
+import { Button, Label, Modal, ModalHeader, ModalBody, ModalFooter, ToggleSwitch } from 'flowbite-react';
+import { useSelector } from '@tanstack/react-store';
+import { useAppForm } from '@/hooks/useAppForm';
+import { z } from 'zod';
 import type { User } from '@/utils/api';
 import { useUpdateUserQuotas } from '@/hooks/useUserMutations';
 
@@ -17,51 +10,96 @@ export type QuotaEditModalProps = {
   onClose: () => void;
 };
 
-type QuotaFieldState = {
-  unlimited: boolean;
-  value: number;
-};
-
-function fieldStateFromUser(
-  user: User,
-  key: 'max_renders' | 'max_checkpoints_per_render' | 'max_render_pixel_count',
-  defaultVal: number,
-): QuotaFieldState {
-  const val = user[key];
-  if (val === null) {
-    return { unlimited: true, value: defaultVal };
-  }
-  return { unlimited: false, value: val };
-}
-
-function quotaValue(state: QuotaFieldState): number | null {
-  return state.unlimited ? null : state.value;
-}
-
 export function QuotaEditModal(props: QuotaEditModalProps) {
   const { user, onClose } = props;
 
   const { mutate: updateQuotas, isPending } = useUpdateUserQuotas();
 
-  const [renders, setRenders] = useState(() => fieldStateFromUser(user, 'max_renders', 1));
-  const [checkpoints, setCheckpoints] = useState(() =>
-    fieldStateFromUser(user, 'max_checkpoints_per_render', 1),
+  const form = useAppForm({
+    defaultValues: {
+      max_renders: user.max_renders ?? 1,
+      max_renders_unlimited: user.max_renders === null,
+      max_checkpoints_per_render: user.max_checkpoints_per_render ?? 1,
+      max_checkpoints_per_render_unlimited: user.max_checkpoints_per_render === null,
+      max_render_pixel_count: user.max_render_pixel_count ?? 250000,
+      max_render_pixel_count_unlimited: user.max_render_pixel_count === null,
+    },
+    validators: {
+      onChange: z
+        .object({
+          max_renders: z.number(),
+          max_renders_unlimited: z.boolean(),
+          max_checkpoints_per_render: z.number(),
+          max_checkpoints_per_render_unlimited: z.boolean(),
+          max_render_pixel_count: z.number(),
+          max_render_pixel_count_unlimited: z.boolean(),
+        })
+        .superRefine((data, ctx) => {
+          if (!data.max_renders_unlimited) {
+            if (!Number.isInteger(data.max_renders) || data.max_renders < 1) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'Must be a positive integer',
+                path: ['max_renders'],
+              });
+            }
+          }
+          if (!data.max_checkpoints_per_render_unlimited) {
+            if (
+              !Number.isInteger(data.max_checkpoints_per_render) ||
+              data.max_checkpoints_per_render < 1
+            ) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'Must be a positive integer',
+                path: ['max_checkpoints_per_render'],
+              });
+            }
+          }
+          if (!data.max_render_pixel_count_unlimited) {
+            if (!Number.isInteger(data.max_render_pixel_count) || data.max_render_pixel_count < 1) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'Must be a positive integer',
+                path: ['max_render_pixel_count'],
+              });
+            }
+          }
+        }),
+    },
+  });
+
+  const isFormValid = useSelector(form.store, (state) => state.isValid);
+
+  const isMaxRendersUnlimited = useSelector(
+    form.store,
+    (state) => state.values.max_renders_unlimited,
   );
-  const [pixels, setPixels] = useState(() =>
-    fieldStateFromUser(user, 'max_render_pixel_count', 250000),
+  const isMaxCheckpointsUnlimited = useSelector(
+    form.store,
+    (state) => state.values.max_checkpoints_per_render_unlimited,
+  );
+  const isMaxPixelsUnlimited = useSelector(
+    form.store,
+    (state) => state.values.max_render_pixel_count_unlimited,
   );
 
-  const handleSave = () => {
+  function handleSave() {
+    const values = form.state.values;
     updateQuotas(
       {
         userID: user.id,
-        maxRenders: quotaValue(renders),
-        maxCheckpointsPerRender: quotaValue(checkpoints),
-        maxRenderPixelCount: quotaValue(pixels),
+        maxRenders: values.max_renders_unlimited ? null : values.max_renders,
+        maxCheckpointsPerRender: values.max_checkpoints_per_render_unlimited
+          ? null
+          : values.max_checkpoints_per_render,
+        maxRenderPixelCount: values.max_render_pixel_count_unlimited
+          ? null
+          : values.max_render_pixel_count,
       },
       { onSuccess: () => onClose() },
     );
-  };
+  }
 
   return (
     <Modal show onClose={onClose}>
@@ -71,71 +109,84 @@ export function QuotaEditModal(props: QuotaEditModalProps) {
           {/* Max Renders */}
           <fieldset className="flex flex-col gap-2 rounded-lg border border-zinc-700 p-3">
             <div className="flex items-center justify-between">
-              <Label htmlFor="max-renders" className="text-zinc-300">
-                Max Renders
-              </Label>
-              <ToggleSwitch
-                checked={renders.unlimited}
-                label="Unlimited"
-                onChange={(checked) => setRenders({ unlimited: checked, value: renders.value })}
-              />
+              <Label className="text-zinc-300">Max Renders</Label>
+              <form.AppField name="max_renders_unlimited">
+                {(field) => (
+                  <ToggleSwitch
+                    checked={field.state.value}
+                    label="Unlimited"
+                    onChange={(checked) => field.handleChange(checked)}
+                  />
+                )}
+              </form.AppField>
             </div>
-            {!renders.unlimited && (
-              <TextInput
-                id="max-renders"
-                type="number"
-                min={0}
-                value={renders.value}
-                onChange={(e) => setRenders({ ...renders, value: Number(e.target.value) })}
-              />
+            {!isMaxRendersUnlimited && (
+              <form.AppField name="max_renders">
+                {(field) => (
+                  <field.FormTextField
+                    type="number"
+                    valueLabel=""
+                    required
+                    className="w-full"
+                  />
+                )}
+              </form.AppField>
             )}
           </fieldset>
 
           {/* Max Checkpoints Per Render */}
           <fieldset className="flex flex-col gap-2 rounded-lg border border-zinc-700 p-3">
             <div className="flex items-center justify-between">
-              <Label htmlFor="max-checkpoints" className="text-zinc-300">
-                Max Checkpoints Per Render
-              </Label>
-              <ToggleSwitch
-                checked={checkpoints.unlimited}
-                label="Unlimited"
-                onChange={(checked) =>
-                  setCheckpoints({ unlimited: checked, value: checkpoints.value })
-                }
-              />
+              <Label className="text-zinc-300">Max Checkpoints Per Render</Label>
+              <form.AppField name="max_checkpoints_per_render_unlimited">
+                {(field) => (
+                  <ToggleSwitch
+                    checked={field.state.value}
+                    label="Unlimited"
+                    onChange={(checked) => field.handleChange(checked)}
+                  />
+                )}
+              </form.AppField>
             </div>
-            {!checkpoints.unlimited && (
-              <TextInput
-                id="max-checkpoints"
-                type="number"
-                min={0}
-                value={checkpoints.value}
-                onChange={(e) => setCheckpoints({ ...checkpoints, value: Number(e.target.value) })}
-              />
+            {!isMaxCheckpointsUnlimited && (
+              <form.AppField name="max_checkpoints_per_render">
+                {(field) => (
+                  <field.FormTextField
+                    type="number"
+                    valueLabel=""
+                    required
+                    className="w-full"
+                  />
+                )}
+              </form.AppField>
             )}
           </fieldset>
 
           {/* Max Render Pixel Count */}
           <fieldset className="flex flex-col gap-2 rounded-lg border border-zinc-700 p-3">
             <div className="flex items-center justify-between">
-              <Label htmlFor="max-pixels" className="text-zinc-300">
-                Max Render Pixel Count
-              </Label>
-              <ToggleSwitch
-                checked={pixels.unlimited}
-                label="Unlimited"
-                onChange={(checked) => setPixels({ unlimited: checked, value: pixels.value })}
-              />
+              <Label className="text-zinc-300">Max Render Pixel Count</Label>
+              <form.AppField name="max_render_pixel_count_unlimited">
+                {(field) => (
+                  <ToggleSwitch
+                    checked={field.state.value}
+                    label="Unlimited"
+                    onChange={(checked) => field.handleChange(checked)}
+                  />
+                )}
+              </form.AppField>
             </div>
-            {!pixels.unlimited && (
-              <TextInput
-                id="max-pixels"
-                type="number"
-                min={0}
-                value={pixels.value}
-                onChange={(e) => setPixels({ ...pixels, value: Number(e.target.value) })}
-              />
+            {!isMaxPixelsUnlimited && (
+              <form.AppField name="max_render_pixel_count">
+                {(field) => (
+                  <field.FormTextField
+                    type="number"
+                    valueLabel=""
+                    required
+                    className="w-full"
+                  />
+                )}
+              </form.AppField>
             )}
           </fieldset>
         </div>
@@ -144,7 +195,7 @@ export function QuotaEditModal(props: QuotaEditModalProps) {
         <Button color="default" onClick={onClose}>
           Cancel
         </Button>
-        <Button onClick={handleSave} disabled={isPending}>
+        <Button onClick={handleSave} disabled={isPending || !isFormValid}>
           {isPending ? 'Saving...' : 'Save'}
         </Button>
       </ModalFooter>

--- a/ui/src/views/admin/QuotaEditModal.tsx
+++ b/ui/src/views/admin/QuotaEditModal.tsx
@@ -1,4 +1,12 @@
-import { Button, Label, Modal, ModalHeader, ModalBody, ModalFooter, ToggleSwitch } from 'flowbite-react';
+import {
+  Button,
+  Label,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ToggleSwitch,
+} from 'flowbite-react';
 import { useSelector } from '@tanstack/react-store';
 import { useAppForm } from '@/hooks/useAppForm';
 import { z } from 'zod';
@@ -123,12 +131,7 @@ export function QuotaEditModal(props: QuotaEditModalProps) {
             {!isMaxRendersUnlimited && (
               <form.AppField name="max_renders">
                 {(field) => (
-                  <field.FormTextField
-                    type="number"
-                    valueLabel=""
-                    required
-                    className="w-full"
-                  />
+                  <field.FormTextField type="number" valueLabel="" required className="w-full" />
                 )}
               </form.AppField>
             )}
@@ -151,12 +154,7 @@ export function QuotaEditModal(props: QuotaEditModalProps) {
             {!isMaxCheckpointsUnlimited && (
               <form.AppField name="max_checkpoints_per_render">
                 {(field) => (
-                  <field.FormTextField
-                    type="number"
-                    valueLabel=""
-                    required
-                    className="w-full"
-                  />
+                  <field.FormTextField type="number" valueLabel="" required className="w-full" />
                 )}
               </form.AppField>
             )}
@@ -179,12 +177,7 @@ export function QuotaEditModal(props: QuotaEditModalProps) {
             {!isMaxPixelsUnlimited && (
               <form.AppField name="max_render_pixel_count">
                 {(field) => (
-                  <field.FormTextField
-                    type="number"
-                    valueLabel=""
-                    required
-                    className="w-full"
-                  />
+                  <field.FormTextField type="number" valueLabel="" required className="w-full" />
                 )}
               </form.AppField>
             )}


### PR DESCRIPTION
Closes #142

Replaces the plain `useState` + `TextInput` + `ToggleSwitch` approach in the admin quotas modal with a TanStack Form instance using Zod validation, matching the pattern from `CheckpointLimitForm`.

- 6 form fields (3 number + 3 boolean toggles) managed by `useAppForm`
- Zod `superRefine` for conditional validation — number fields only validated when not unlimited
- `useSelector` for reactive conditional rendering of number inputs based on toggle state
- Invalid input stays in the field with inline validation errors instead of auto-converting to a number