### PR TITLE
feat(ui): surface API errors with toast notifications via react-hot-toast

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -23,7 +23,7 @@ export default defineConfig([
       '@typescript-eslint/no-explicit-any': 'warn',
       'react-refresh/only-export-components': [
         'warn',
-        { allowConstantExport: true, allowExportNames: ['useAuth'] },
+        { allowConstantExport: true, allowExportNames: ['useAuth', 'useToast'] },
       ],
     },
   },

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -23,7 +23,7 @@ export default defineConfig([
       '@typescript-eslint/no-explicit-any': 'warn',
       'react-refresh/only-export-components': [
         'warn',
-        { allowConstantExport: true, allowExportNames: ['useAuth', 'useToast'] },
+        { allowConstantExport: true, allowExportNames: ['useAuth', 'createToast'] },
       ],
     },
   },

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -23,6 +23,7 @@
         "luxon": "^3.7.2",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "react-hot-toast": "^2.6.0",
         "react-icons": "^5.6.0",
         "react-router-dom": "^7.15.1",
         "react-syntax-highlighter": "^16.1.1",
@@ -3161,6 +3162,14 @@
       "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w=="
     },
+    "node_modules/goober": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4176,6 +4185,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "luxon": "^3.7.2",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "react-hot-toast": "^2.6.0",
     "react-icons": "^5.6.0",
     "react-router-dom": "^7.15.1",
     "react-syntax-highlighter": "^16.1.1",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from 'flowbite-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './providers/auth';
-import { ToastProvider } from './providers/toast';
+import { LuxideToaster } from './providers/toast';
 import { Layout } from './layouts/Layout';
 import { AuthenticatedRouteLayout } from './layouts/AuthenticatedRouteLayout';
 import { HomePage } from './views';
@@ -25,34 +25,33 @@ const queryClient = new QueryClient({
 export default function App() {
   return (
     <ThemeProvider>
-      <ToastProvider>
-        <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <BrowserRouter>
-              <Routes>
-                <Route element={<Layout />}>
-                  {/* public routes */}
-                  <Route path="/" element={<HomePage />} />
-                  <Route path="/login" element={<LoginPage />} />
-                  <Route path="/auth/github/callback" element={<AuthCallbackPage />} />
+      <LuxideToaster />
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route element={<Layout />}>
+                {/* public routes */}
+                <Route path="/" element={<HomePage />} />
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/auth/github/callback" element={<AuthCallbackPage />} />
 
-                  {/* authenticated routes — nested inside authenticated layout to redirect to /login if not logged in */}
-                  <Route element={<AuthenticatedRouteLayout />}>
-                    <Route path="/renders" element={<RendersPage />} />
-                    <Route path="/renders/:id" element={<RenderDetailPage />} />
-                    <Route path="/renders/new" element={<NewRenderPage />} />
-                  </Route>
-
-                  {/* admin routes — nested inside admin layout to redirect non-admins */}
-                  <Route element={<AdminRouteLayout />}>
-                    <Route path="/admin" element={<AdminPage />} />
-                  </Route>
+                {/* authenticated routes — nested inside authenticated layout to redirect to /login if not logged in */}
+                <Route element={<AuthenticatedRouteLayout />}>
+                  <Route path="/renders" element={<RendersPage />} />
+                  <Route path="/renders/:id" element={<RenderDetailPage />} />
+                  <Route path="/renders/new" element={<NewRenderPage />} />
                 </Route>
-              </Routes>
-            </BrowserRouter>
-          </AuthProvider>
-        </QueryClientProvider>
-      </ToastProvider>
+
+                {/* admin routes — nested inside admin layout to redirect non-admins */}
+                <Route element={<AdminRouteLayout />}>
+                  <Route path="/admin" element={<AdminPage />} />
+                </Route>
+              </Route>
+            </Routes>
+          </BrowserRouter>
+        </AuthProvider>
+      </QueryClientProvider>
     </ThemeProvider>
   );
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from 'flowbite-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './providers/auth';
-import { ToastProvider } from './providers/ToastProvider';
+import { ToastProvider } from './providers/toast';
 import { Layout } from './layouts/Layout';
 import { AuthenticatedRouteLayout } from './layouts/AuthenticatedRouteLayout';
 import { HomePage } from './views';

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from 'flowbite-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './providers/auth';
+import { ToastProvider } from './providers/ToastProvider';
 import { Layout } from './layouts/Layout';
 import { AuthenticatedRouteLayout } from './layouts/AuthenticatedRouteLayout';
 import { HomePage } from './views';
@@ -24,32 +25,34 @@ const queryClient = new QueryClient({
 export default function App() {
   return (
     <ThemeProvider>
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <BrowserRouter>
-            <Routes>
-              <Route element={<Layout />}>
-                {/* public routes */}
-                <Route path="/" element={<HomePage />} />
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/auth/github/callback" element={<AuthCallbackPage />} />
+      <ToastProvider>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <BrowserRouter>
+              <Routes>
+                <Route element={<Layout />}>
+                  {/* public routes */}
+                  <Route path="/" element={<HomePage />} />
+                  <Route path="/login" element={<LoginPage />} />
+                  <Route path="/auth/github/callback" element={<AuthCallbackPage />} />
 
-                {/* authenticated routes — nested inside authenticated layout to redirect to /login if not logged in */}
-                <Route element={<AuthenticatedRouteLayout />}>
-                  <Route path="/renders" element={<RendersPage />} />
-                  <Route path="/renders/:id" element={<RenderDetailPage />} />
-                  <Route path="/renders/new" element={<NewRenderPage />} />
-                </Route>
+                  {/* authenticated routes — nested inside authenticated layout to redirect to /login if not logged in */}
+                  <Route element={<AuthenticatedRouteLayout />}>
+                    <Route path="/renders" element={<RendersPage />} />
+                    <Route path="/renders/:id" element={<RenderDetailPage />} />
+                    <Route path="/renders/new" element={<NewRenderPage />} />
+                  </Route>
 
-                {/* admin routes — nested inside admin layout to redirect non-admins */}
-                <Route element={<AdminRouteLayout />}>
-                  <Route path="/admin" element={<AdminPage />} />
+                  {/* admin routes — nested inside admin layout to redirect non-admins */}
+                  <Route element={<AdminRouteLayout />}>
+                    <Route path="/admin" element={<AdminPage />} />
+                  </Route>
                 </Route>
-              </Route>
-            </Routes>
-          </BrowserRouter>
-        </AuthProvider>
-      </QueryClientProvider>
+              </Routes>
+            </BrowserRouter>
+          </AuthProvider>
+        </QueryClientProvider>
+      </ToastProvider>
     </ThemeProvider>
   );
 }

--- a/ui/src/providers/ToastProvider.tsx
+++ b/ui/src/providers/ToastProvider.tsx
@@ -1,0 +1,81 @@
+import { createContext, useContext, useState, useCallback } from 'react';
+import type { ReactNode } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Toast, ToastToggle, type ToastTheme } from 'flowbite-react';
+import { HiExclamation } from 'react-icons/hi';
+import type { DeepPartial } from 'flowbite-react/types';
+
+type ToastItem = {
+  id: string;
+  message: string;
+};
+
+interface ToastContextType {
+  /**
+   * Create a new error toast. Returns a function that can be called
+   * to programmatically dismiss the toast before the user dismisses it manually.
+   */
+  createToast: (message: string) => () => void;
+}
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+// override the default max-w-xs so toasts aren't constrained to ~320px
+const toastTheme: DeepPartial<ToastTheme> = {
+  root: { base: 'max-w-lg' },
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const createToast = useCallback((message: string) => {
+    const id = crypto.randomUUID();
+    setToasts((prev) => [...prev, { id, message }]);
+    return () => {
+      setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    };
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ createToast }}>
+      {children}
+
+      <div className="fixed right-4 bottom-4 z-50 flex flex-col gap-2">
+        <AnimatePresence>
+          {toasts.map((toast) => (
+            <motion.div
+              key={toast.id}
+              className="max-w-lg"
+              initial={{ x: '100%', opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              exit={{ x: '100%', opacity: 0 }}
+              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            >
+              <Toast theme={toastTheme}>
+                <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
+                  <HiExclamation className="h-5 w-5" />
+                </div>
+                <div className="ml-3 text-sm font-normal text-red-600 dark:text-red-400">
+                  {toast.message}
+                </div>
+                <ToastToggle
+                  onDismiss={() =>
+                    setToasts((prev) => prev.filter((t) => t.id !== toast.id))
+                  }
+                />
+              </Toast>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextType {
+  const context = useContext(ToastContext);
+  if (context === null) {
+    throw new Error('useToast must be used within <ToastProvider>');
+  }
+  return context;
+}

--- a/ui/src/providers/auth.tsx
+++ b/ui/src/providers/auth.tsx
@@ -13,7 +13,13 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
+export type AuthProviderProps = {
+  children: React.ReactNode;
+};
+
+export function AuthProvider(props: AuthProviderProps) {
+  const { children } = props;
+
   const [token, setTokenState] = useState<string | undefined>(() => {
     return localStorage?.getItem('auth_token') ?? undefined;
   });

--- a/ui/src/providers/toast.tsx
+++ b/ui/src/providers/toast.tsx
@@ -1,5 +1,4 @@
 import { createContext, useContext, useState, useCallback } from 'react';
-import type { ReactNode } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Toast, ToastToggle, type ToastTheme } from 'flowbite-react';
 import { HiExclamation } from 'react-icons/hi';
@@ -25,7 +24,13 @@ const toastTheme: DeepPartial<ToastTheme> = {
   root: { base: 'max-w-lg' },
 };
 
-export function ToastProvider({ children }: { children: ReactNode }) {
+export type ToastProviderProps = {
+  children: React.ReactNode;
+};
+
+export function ToastProvider(props: ToastProviderProps) {
+  const { children } = props;
+
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
   const createToast = useCallback((message: string) => {
@@ -59,9 +64,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
                   {toast.message}
                 </div>
                 <ToastToggle
-                  onDismiss={() =>
-                    setToasts((prev) => prev.filter((t) => t.id !== toast.id))
-                  }
+                  onDismiss={() => setToasts((prev) => prev.filter((t) => t.id !== toast.id))}
                 />
               </Toast>
             </motion.div>

--- a/ui/src/providers/toast.tsx
+++ b/ui/src/providers/toast.tsx
@@ -1,85 +1,39 @@
-import { createContext, useContext, useState, useCallback } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import toast, { Toaster, resolveValue } from 'react-hot-toast';
+import { motion } from 'framer-motion';
 import { Toast, ToastToggle, type ToastTheme } from 'flowbite-react';
 import { HiExclamation } from 'react-icons/hi';
 import type { DeepPartial } from 'flowbite-react/types';
-
-type ToastItem = {
-  id: string;
-  message: string;
-};
-
-interface ToastContextType {
-  /**
-   * Create a new error toast. Returns a function that can be called
-   * to programmatically dismiss the toast before the user dismisses it manually.
-   */
-  createToast: (message: string) => () => void;
-}
-
-const ToastContext = createContext<ToastContextType | null>(null);
 
 // override the default max-w-xs so toasts aren't constrained to ~320px
 const toastTheme: DeepPartial<ToastTheme> = {
   root: { base: 'max-w-lg' },
 };
 
-export type ToastProviderProps = {
-  children: React.ReactNode;
-};
-
-export function ToastProvider(props: ToastProviderProps) {
-  const { children } = props;
-
-  const [toasts, setToasts] = useState<ToastItem[]>([]);
-
-  const createToast = useCallback((message: string) => {
-    const id = crypto.randomUUID();
-    setToasts((prev) => [...prev, { id, message }]);
-    return () => {
-      setToasts((prev) => prev.filter((toast) => toast.id !== id));
-    };
-  }, []);
-
+/**
+ * Renders all toasts using flowbite-react's `Toast` component with framer-motion
+ * animation. Place once at the root of the app — no context or provider needed.
+ */
+export function LuxideToaster() {
   return (
-    <ToastContext.Provider value={{ createToast }}>
-      {children}
-
-      <div className="fixed right-4 bottom-4 z-50 flex flex-col gap-2">
-        <AnimatePresence>
-          {toasts.map((toast) => (
-            <motion.div
-              key={toast.id}
-              layout
-              className="max-w-lg"
-              initial={{ x: '100%', opacity: 0 }}
-              animate={{ x: 0, opacity: 1 }}
-              exit={{ x: '100%', opacity: 0 }}
-              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-            >
-              <Toast theme={toastTheme}>
-                <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
-                  <HiExclamation className="h-5 w-5" />
-                </div>
-                <div className="ml-3 text-sm font-normal text-red-600 dark:text-red-400">
-                  {toast.message}
-                </div>
-                <ToastToggle
-                  onDismiss={() => setToasts((prev) => prev.filter((t) => t.id !== toast.id))}
-                />
-              </Toast>
-            </motion.div>
-          ))}
-        </AnimatePresence>
-      </div>
-    </ToastContext.Provider>
+    <Toaster position="bottom-right" reverseOrder={false}>
+      {(t) => (
+        <motion.div
+          animate={t.visible ? { x: 0, opacity: 1 } : { x: '100%', opacity: 0 }}
+          initial={{ x: '100%', opacity: 0 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+          className="max-w-lg"
+        >
+          <Toast theme={toastTheme}>
+            <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
+              <HiExclamation className="h-5 w-5" />
+            </div>
+            <div className="ml-3 text-sm font-normal text-red-600 dark:text-red-400">
+              {resolveValue(t.message, t)}
+            </div>
+            <ToastToggle onDismiss={() => toast.dismiss(t.id)} />
+          </Toast>
+        </motion.div>
+      )}
+    </Toaster>
   );
-}
-
-export function useToast(): ToastContextType {
-  const context = useContext(ToastContext);
-  if (context === null) {
-    throw new Error('useToast must be used within <ToastProvider>');
-  }
-  return context;
 }

--- a/ui/src/providers/toast.tsx
+++ b/ui/src/providers/toast.tsx
@@ -50,6 +50,7 @@ export function ToastProvider(props: ToastProviderProps) {
           {toasts.map((toast) => (
             <motion.div
               key={toast.id}
+              layout
               className="max-w-lg"
               initial={{ x: '100%', opacity: 0 }}
               animate={{ x: 0, opacity: 1 }}

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -394,3 +394,31 @@ export async function getStorageUsage(token: string): Promise<UsageResponse> {
 
   return (await response.json()) as UsageResponse;
 }
+
+/**
+ * Extract a human-readable error message from an API error.
+ *
+ * The backend returns structured JSON like `{"code": 403, "message": "..."}`
+ * but the API client embeds it in a thrown Error: `"failed to ...: (403: {json})"`.
+ * This function parses the JSON body out of the Error message and returns the
+ * backend's `message` field. Falls back to the raw Error message if parsing fails.
+ */
+export function extractErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'An unknown error occurred';
+  }
+  // try to extract the JSON body from the API client's error format:
+  // "failed to ...: (STATUS: {json body})"
+  const match = error.message.match(/\{.*\}/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[0]);
+      if (typeof parsed.message === 'string') {
+        return parsed.message;
+      }
+    } catch {
+      // JSON parse failed — fall through to raw message
+    }
+  }
+  return error.message;
+}

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -1,6 +1,5 @@
 import { HiExclamation } from 'react-icons/hi';
 import { useState } from 'react';
-import { createPortal } from 'react-dom';
 
 import { Button, Spinner, Toast, ToastToggle, type ToastTheme } from 'flowbite-react';
 import { useSelector } from '@tanstack/react-store';
@@ -9,6 +8,11 @@ import { useUpdateRenderTotalCheckpoints } from '@/hooks/useRenderMutations';
 import { z } from 'zod';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { DeepPartial } from 'flowbite-react/types';
+
+type ToastItem = {
+  id: string;
+  message: string;
+};
 
 export type CheckpointLimitFormProps = {
   currentValue: number;
@@ -20,7 +24,16 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
   const { currentValue, currentCheckpointIteration, renderID } = props;
 
   const { mutate: updateCheckpoints, isPending } = useUpdateRenderTotalCheckpoints();
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  function createToast(message: string) {
+    const id = crypto.randomUUID();
+    setToasts((prev) => [...prev, { id, message }]);
+  }
+
+  function dismissToast(id: string) {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }
 
   const form = useAppForm({
     defaultValues: { total_checkpoints: currentValue },
@@ -45,7 +58,7 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
       { renderId: renderID, newTotalCheckpoints: value },
       {
         onError: (error) => {
-          setErrorMessage(error.message);
+          createToast(error.message);
         },
       },
     );
@@ -81,27 +94,30 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
         )}
       </Button>
 
-      <AnimatePresence>
-        {errorMessage !== null && (
-          <motion.div
-            className="fixed right-4 bottom-4 z-50"
-            initial={{ x: '100%', opacity: 0 }}
-            animate={{ x: 0, opacity: 1 }}
-            exit={{ x: '100%', opacity: 0 }}
-            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-          >
-            <Toast theme={toastTheme}>
-              <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
-                <HiExclamation className="h-5 w-5" />
-              </div>
-              <div className="ml-3 text-sm font-normal text-red-600 dark:text-red-400">
-                {errorMessage}
-              </div>
-              <ToastToggle onDismiss={() => setErrorMessage(null)} />
-            </Toast>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <div className="fixed right-4 bottom-4 z-50 flex flex-col gap-2">
+        <AnimatePresence>
+          {toasts.map((toast) => (
+            <motion.div
+              key={toast.id}
+              className="max-w-lg"
+              initial={{ x: '100%', opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              exit={{ x: '100%', opacity: 0 }}
+              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            >
+              <Toast theme={toastTheme}>
+                <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
+                  <HiExclamation className="h-5 w-5" />
+                </div>
+                <div className="ml-3 text-sm font-normal text-red-600 dark:text-red-400">
+                  {toast.message}
+                </div>
+                <ToastToggle onDismiss={() => dismissToast(toast.id)} />
+              </Toast>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
     </>
   );
 }

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -1,12 +1,14 @@
 import { HiExclamation } from 'react-icons/hi';
 import { useState } from 'react';
+import { createPortal } from 'react-dom';
 
-import { Button, Spinner, Toast, ToastToggle } from 'flowbite-react';
+import { Button, Spinner, Toast, ToastToggle, type ToastTheme } from 'flowbite-react';
 import { useSelector } from '@tanstack/react-store';
 import { useAppForm } from '@/hooks/useAppForm';
 import { useUpdateRenderTotalCheckpoints } from '@/hooks/useRenderMutations';
 import { z } from 'zod';
 import { motion, AnimatePresence } from 'framer-motion';
+import type { DeepPartial } from 'flowbite-react/types';
 
 export type CheckpointLimitFormProps = {
   currentValue: number;
@@ -49,6 +51,12 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
     );
   }
 
+  const toastTheme: DeepPartial<ToastTheme> = {
+    root: {
+      base: 'max-w-lg',
+    },
+  };
+
   return (
     <>
       <form.AppField name="total_checkpoints">
@@ -82,7 +90,7 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
             exit={{ x: '100%', opacity: 0 }}
             transition={{ type: 'spring', stiffness: 300, damping: 30 }}
           >
-            <Toast>
+            <Toast theme={toastTheme}>
               <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
                 <HiExclamation className="h-5 w-5" />
               </div>

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -2,7 +2,7 @@ import { useSelector } from '@tanstack/react-store';
 import { Button, Spinner } from 'flowbite-react';
 import { useAppForm } from '@/hooks/useAppForm';
 import { useUpdateRenderTotalCheckpoints } from '@/hooks/useRenderMutations';
-import { useToast } from '@/providers/ToastProvider';
+import { useToast } from '@/providers/toast';
 import { z } from 'zod';
 
 export type CheckpointLimitFormProps = {

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -2,8 +2,8 @@ import { useSelector } from '@tanstack/react-store';
 import { Button, Spinner } from 'flowbite-react';
 import { useAppForm } from '@/hooks/useAppForm';
 import { useUpdateRenderTotalCheckpoints } from '@/hooks/useRenderMutations';
-import { useToast } from '@/providers/toast';
 import { z } from 'zod';
+import toast from 'react-hot-toast';
 
 export type CheckpointLimitFormProps = {
   currentValue: number;
@@ -15,7 +15,6 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
   const { currentValue, currentCheckpointIteration, renderID } = props;
 
   const { mutate: updateCheckpoints, isPending } = useUpdateRenderTotalCheckpoints();
-  const { createToast } = useToast();
 
   const form = useAppForm({
     defaultValues: { total_checkpoints: currentValue },
@@ -40,7 +39,7 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
       { renderId: renderID, newTotalCheckpoints: value },
       {
         onError: (error) => {
-          createToast(error.message);
+          toast.error(error.message);
         },
       },
     );

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -6,6 +6,7 @@ import { useSelector } from '@tanstack/react-store';
 import { useAppForm } from '@/hooks/useAppForm';
 import { useUpdateRenderTotalCheckpoints } from '@/hooks/useRenderMutations';
 import { z } from 'zod';
+import { motion, AnimatePresence } from 'framer-motion';
 
 export type CheckpointLimitFormProps = {
   currentValue: number;
@@ -72,18 +73,27 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
         )}
       </Button>
 
-      {errorMessage !== null && (
-        <Toast className="fixed right-4 bottom-4 z-50 max-w-md">
-          {' '}
-          <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
-            <HiExclamation className="h-5 w-5" />
-          </div>
-          <div className="ml-3 text-sm font-normal text-red-600 dark:text-red-400">
-            {errorMessage}
-          </div>
-          <ToastToggle onDismiss={() => setErrorMessage(null)} />
-        </Toast>
-      )}
+      <AnimatePresence>
+        {errorMessage !== null && (
+          <motion.div
+            className="fixed right-4 bottom-4 z-50"
+            initial={{ x: '100%', opacity: 0 }}
+            animate={{ x: 0, opacity: 1 }}
+            exit={{ x: '100%', opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+          >
+            <Toast>
+              <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
+                <HiExclamation className="h-5 w-5" />
+              </div>
+              <div className="ml-3 text-sm font-normal text-red-600 dark:text-red-400">
+                {errorMessage}
+              </div>
+              <ToastToggle onDismiss={() => setErrorMessage(null)} />
+            </Toast>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -1,18 +1,9 @@
-import { HiExclamation } from 'react-icons/hi';
-import { useState } from 'react';
-
-import { Button, Spinner, Toast, ToastToggle, type ToastTheme } from 'flowbite-react';
 import { useSelector } from '@tanstack/react-store';
+import { Button, Spinner } from 'flowbite-react';
 import { useAppForm } from '@/hooks/useAppForm';
 import { useUpdateRenderTotalCheckpoints } from '@/hooks/useRenderMutations';
+import { useToast } from '@/providers/ToastProvider';
 import { z } from 'zod';
-import { motion, AnimatePresence } from 'framer-motion';
-import type { DeepPartial } from 'flowbite-react/types';
-
-type ToastItem = {
-  id: string;
-  message: string;
-};
 
 export type CheckpointLimitFormProps = {
   currentValue: number;
@@ -24,16 +15,7 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
   const { currentValue, currentCheckpointIteration, renderID } = props;
 
   const { mutate: updateCheckpoints, isPending } = useUpdateRenderTotalCheckpoints();
-  const [toasts, setToasts] = useState<ToastItem[]>([]);
-
-  function createToast(message: string) {
-    const id = crypto.randomUUID();
-    setToasts((prev) => [...prev, { id, message }]);
-  }
-
-  function dismissToast(id: string) {
-    setToasts((prev) => prev.filter((t) => t.id !== id));
-  }
+  const { createToast } = useToast();
 
   const form = useAppForm({
     defaultValues: { total_checkpoints: currentValue },
@@ -64,12 +46,6 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
     );
   }
 
-  const toastTheme: DeepPartial<ToastTheme> = {
-    root: {
-      base: 'max-w-lg',
-    },
-  };
-
   return (
     <>
       <form.AppField name="total_checkpoints">
@@ -93,31 +69,6 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
           'Update'
         )}
       </Button>
-
-      <div className="fixed right-4 bottom-4 z-50 flex flex-col gap-2">
-        <AnimatePresence>
-          {toasts.map((toast) => (
-            <motion.div
-              key={toast.id}
-              className="max-w-lg"
-              initial={{ x: '100%', opacity: 0 }}
-              animate={{ x: 0, opacity: 1 }}
-              exit={{ x: '100%', opacity: 0 }}
-              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-            >
-              <Toast theme={toastTheme}>
-                <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
-                  <HiExclamation className="h-5 w-5" />
-                </div>
-                <div className="ml-3 text-sm font-normal text-red-600 dark:text-red-400">
-                  {toast.message}
-                </div>
-                <ToastToggle onDismiss={() => dismissToast(toast.id)} />
-              </Toast>
-            </motion.div>
-          ))}
-        </AnimatePresence>
-      </div>
     </>
   );
 }

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -3,6 +3,7 @@ import { Button, Spinner } from 'flowbite-react';
 import { useAppForm } from '@/hooks/useAppForm';
 import { useUpdateRenderTotalCheckpoints } from '@/hooks/useRenderMutations';
 import { z } from 'zod';
+import { extractErrorMessage } from '@/utils/api';
 import toast from 'react-hot-toast';
 
 export type CheckpointLimitFormProps = {
@@ -39,7 +40,7 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
       { renderId: renderID, newTotalCheckpoints: value },
       {
         onError: (error) => {
-          toast.error(error.message);
+          toast.error(extractErrorMessage(error));
         },
       },
     );

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -1,10 +1,11 @@
-import { Button, Spinner } from 'flowbite-react';
+import { HiExclamation } from 'react-icons/hi';
 import { useState } from 'react';
+
+import { Button, Spinner, Toast, ToastToggle } from 'flowbite-react';
 import { useSelector } from '@tanstack/react-store';
 import { useAppForm } from '@/hooks/useAppForm';
+import { useUpdateRenderTotalCheckpoints } from '@/hooks/useRenderMutations';
 import { z } from 'zod';
-import { useAuth } from '@/providers/auth';
-import { updateRenderTotalCheckpoints } from '@/utils/api';
 
 export type CheckpointLimitFormProps = {
   currentValue: number;
@@ -15,8 +16,8 @@ export type CheckpointLimitFormProps = {
 export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
   const { currentValue, currentCheckpointIteration, renderID } = props;
 
-  const { mustGetToken } = useAuth();
-  const [isUpdating, setIsUpdating] = useState(false);
+  const { mutate: updateCheckpoints, isPending } = useUpdateRenderTotalCheckpoints();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const form = useAppForm({
     defaultValues: { total_checkpoints: currentValue },
@@ -35,11 +36,16 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
 
   const isFormValid = useSelector(form.store, (state) => state.isValid);
 
-  async function handleSubmit() {
+  function handleSubmit() {
     const value = form.state.values.total_checkpoints;
-    setIsUpdating(true);
-    await updateRenderTotalCheckpoints(mustGetToken(), renderID, value);
-    setIsUpdating(false);
+    updateCheckpoints(
+      { renderId: renderID, newTotalCheckpoints: value },
+      {
+        onError: (error) => {
+          setErrorMessage(error.message);
+        },
+      },
+    );
   }
 
   return (
@@ -55,8 +61,8 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
         )}
       </form.AppField>
 
-      <Button color="default" outline onClick={handleSubmit} disabled={isUpdating || !isFormValid}>
-        {isUpdating ? (
+      <Button color="default" outline onClick={handleSubmit} disabled={isPending || !isFormValid}>
+        {isPending ? (
           <span className="flex items-center justify-center">
             <Spinner size="sm" className="mr-2" />
             Updating...
@@ -65,6 +71,19 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
           'Update'
         )}
       </Button>
+
+      {errorMessage !== null && (
+        <Toast className="fixed right-4 bottom-4 z-50 max-w-md">
+          {' '}
+          <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 dark:bg-orange-700 dark:text-orange-200">
+            <HiExclamation className="h-5 w-5" />
+          </div>
+          <div className="ml-3 text-sm font-normal text-red-600 dark:text-red-400">
+            {errorMessage}
+          </div>
+          <ToastToggle onDismiss={() => setErrorMessage(null)} />
+        </Toast>
+      )}
     </>
   );
 }

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderControls.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderControls.tsx
@@ -1,16 +1,8 @@
 import { Button, Spinner } from 'flowbite-react';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRender } from '@/hooks/useRender';
-import { useAuth } from '@/providers/auth';
-import {
-  pauseRender,
-  resumeRender,
-  deleteRender,
-  isRenderStatePausing,
-  isRenderStatePaused,
-  isRenderStateRunning,
-} from '@/utils/api';
+import { usePauseRender, useResumeRender, useDeleteRender } from '@/hooks/useRenderMutations';
+import { isRenderStatePausing, isRenderStatePaused, isRenderStateRunning } from '@/utils/api';
 export type RenderControlsProps = {
   renderID: number;
 };
@@ -19,8 +11,6 @@ export function RenderControls(props: RenderControlsProps) {
   const { renderID } = props;
 
   const navigate = useNavigate();
-  const { mustGetToken } = useAuth();
-  const token = mustGetToken();
 
   const {
     data: render,
@@ -29,7 +19,9 @@ export function RenderControls(props: RenderControlsProps) {
     error: renderError,
   } = useRender({ renderID });
 
-  const [isPausingOrResuming, setIsPausingOrResuming] = useState(false);
+  const { mutate: pauseRender, isPending: isPausePending } = usePauseRender();
+  const { mutate: resumeRender, isPending: isResumePending } = useResumeRender();
+  const { mutate: deleteRender, isPending: isDeletePending } = useDeleteRender();
 
   if (isRenderLoading || !render) {
     return <Spinner size="md" className="fill-zinc-400" />;
@@ -45,19 +37,20 @@ export function RenderControls(props: RenderControlsProps) {
   const isPausing = isRenderStatePausing(render.state);
   const isRunning = isRenderStateRunning(render.state);
 
-  async function handlePauseOrResume() {
-    setIsPausingOrResuming(true);
+  function handlePauseOrResume() {
     if (isPaused || isPausing) {
-      await resumeRender(token, renderID);
+      resumeRender(renderID);
     } else if (isRunning) {
-      await pauseRender(token, renderID);
+      pauseRender(renderID);
     }
-    setIsPausingOrResuming(false);
   }
 
-  async function handleDelete() {
-    await deleteRender(token, renderID);
-    navigate('/renders');
+  function handleDelete() {
+    deleteRender(renderID, {
+      onSuccess: () => {
+        navigate('/renders');
+      },
+    });
   }
 
   return (
@@ -66,9 +59,9 @@ export function RenderControls(props: RenderControlsProps) {
         color={isPaused || isPausing ? 'default' : 'yellow'}
         outline
         onClick={handlePauseOrResume}
-        disabled={isPausingOrResuming || !(isPaused || isPausing || isRunning)}
+        disabled={isPausePending || isResumePending || !(isPaused || isPausing || isRunning)}
       >
-        {isPausingOrResuming ? (
+        {isPausePending || isResumePending ? (
           <span className="flex items-center justify-center">
             <Spinner size="sm" className="mr-2" />
             Processing...
@@ -80,8 +73,19 @@ export function RenderControls(props: RenderControlsProps) {
         )}
       </Button>
 
-      <Button color="red" onClick={handleDelete} disabled={isPausing || isRunning}>
-        Delete Render
+      <Button
+        color="red"
+        onClick={handleDelete}
+        disabled={isDeletePending || isPausing || isRunning}
+      >
+        {isDeletePending ? (
+          <span className="flex items-center justify-center">
+            <Spinner size="sm" className="mr-2" />
+            Deleting...
+          </span>
+        ) : (
+          'Delete Render'
+        )}
       </Button>
     </div>
   );

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderControls.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderControls.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { useRender } from '@/hooks/useRender';
 import { usePauseRender, useResumeRender, useDeleteRender } from '@/hooks/useRenderMutations';
 import { isRenderStatePausing, isRenderStatePaused, isRenderStateRunning } from '@/utils/api';
+import toast from 'react-hot-toast';
+import { extractErrorMessage } from '@/utils/api';
 export type RenderControlsProps = {
   renderID: number;
 };
@@ -39,16 +41,28 @@ export function RenderControls(props: RenderControlsProps) {
 
   function handlePauseOrResume() {
     if (isPaused || isPausing) {
-      resumeRender(renderID);
+      resumeRender(renderID, {
+        onError: (error) => {
+          toast.error(extractErrorMessage(error));
+        },
+      });
     } else if (isRunning) {
-      pauseRender(renderID);
+      pauseRender(renderID, {
+        onError: (error) => {
+          toast.error(extractErrorMessage(error));
+        },
+      });
     }
   }
 
   function handleDelete() {
     deleteRender(renderID, {
       onSuccess: () => {
+        toast.success('Render deleted');
         navigate('/renders');
+      },
+      onError: (error) => {
+        toast.error(extractErrorMessage(error));
       },
     });
   }

--- a/ui/src/views/renders/new/NewRenderSidebar/index.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/index.tsx
@@ -19,6 +19,8 @@ import { useRenders } from '@/hooks/useRenders';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { ViewConfigJSONButton } from './ViewConfigJSONButton';
 import { ConfigJSONModal } from '@/components/ViewRenderJSONButton/ConfigJSONModal';
+import toast from 'react-hot-toast';
+import { extractErrorMessage } from '@/utils/api';
 
 export interface NewRenderSidebarProps {
   form: RenderForm;
@@ -67,6 +69,9 @@ export function NewRenderSidebar({ form }: NewRenderSidebarProps) {
     createRender(form.state.values, {
       onSuccess: (response) => {
         navigate(`/renders/${response.id}`);
+      },
+      onError: (error) => {
+        toast.error(extractErrorMessage(error));
       },
     });
   };


### PR DESCRIPTION
Closes #109

## Summary

Every API error path now shows a toast notification so users always get feedback.

### What changed

- **Toast system** — Added `react-hot-toast` with a custom Flowbite-styled `LuxideToaster` (orange warning icon, red text, spring slide-in from right, stacking). No context or provider boilerplate — just `import toast from 'react-hot-toast'` and call `toast.error()`.
- **`extractErrorMessage` utility** — Parses the backend's JSON error body (`{"code": 403, "message": "..."}`) out of the API client's thrown Error string, so toasts show the clean backend message instead of the raw `"failed to ...: (422: {...})"` string.
- **Replaced 4 raw API calls with TanStack Query mutations** — `CheckpointLimitForm` (update), `RenderControls` (pause/resume/delete) now use their existing mutation hooks. This fixes the original "spinner stuck forever" bug (stale `useState` on error) and gives automatic query invalidation.
- **Error toasts wired up everywhere** — `onError` callbacks on all mutation calls (`CheckpointLimitForm`, `RenderControls` pause/resume/delete, `NewRenderSidebar` create) show `toast.error(extractErrorMessage(error))`.
- **Success toast for delete** — `toast.success('Render deleted')`.
- **`Delete Render` button gains loading state** — was missing spinner/disable during the deletion.
- **`AuthProvider` props convention** — Added `AuthProviderProps` type to match component conventions.

### Files changed (10 files, +167 −39)

| File | Change |
|------|--------|
| `providers/toast.tsx` | New — `LuxideToaster` (react-hot-toast + Flowbite + framer-motion) |
| `utils/api.ts` | New — `extractErrorMessage()` utility |
| `App.tsx` | Added `<LuxideToaster />` |
| `providers/auth.tsx` | Added `AuthProviderProps` type convention |
| `CheckpointLimitForm.tsx` | Mutation hook + error toast |
| `RenderControls.tsx` | 3 mutation hooks + error toasts + success toast + delete loading state |
| `NewRenderSidebar/index.tsx` | Error toast on render creation |
| `eslint.config.js` | Added `createToast` to allowExportNames |
| `package.json` | Added `react-hot-toast` |