### PR TITLE
feat: allow renaming renders after creation

### DIFF
--- a/.sqlx/query-ab3bb7aaec72e0f30e801f47aa4da6751d52c586a0ef53a96750ceeac1011fa5.json
+++ b/.sqlx/query-ab3bb7aaec72e0f30e801f47aa4da6751d52c586a0ef53a96750ceeac1011fa5.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE renders\n                SET config = jsonb_set(config, '{name}', $2::jsonb),\n                updated_at = $3\n                WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Jsonb",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ab3bb7aaec72e0f30e801f47aa4da6751d52c586a0ef53a96750ceeac1011fa5"
+}

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -49,6 +49,9 @@ pub use resume_render::*;
 mod update_render_total_checkpoints;
 pub use update_render_total_checkpoints::*;
 
+mod update_render_name;
+pub use update_render_name::*;
+
 use axum::{
     Json,
     http::StatusCode,

--- a/src/server/handlers/update_render_name.rs
+++ b/src/server/handlers/update_render_name.rs
@@ -1,0 +1,35 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+use crate::{
+    server::{Claims, LuxideState},
+    tracing::RenderID,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct UpdateRenderName {
+    pub name: String,
+}
+
+pub async fn update_render_name(
+    State(state): State<LuxideState>,
+    claims: Claims,
+    Path(id): Path<RenderID>,
+    Json(update_render_name): Json<UpdateRenderName>,
+) -> Response {
+    println!("Handling request for update_render_name (id: {})...", id);
+
+    match state
+        .render_manager
+        .update_render_name(id, update_render_name.name, claims.sub)
+        .await
+    {
+        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => e.into(),
+    }
+}

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -132,6 +132,7 @@ fn build_renders_router() -> Router<LuxideState> {
             "/{id}/parameters/total_checkpoints",
             put(handlers::update_render_total_checkpoints),
         )
+        .route("/{id}/name", put(handlers::update_render_name))
 }
 
 fn build_auth_router() -> Router<LuxideState> {

--- a/src/tracing/render_manager.rs
+++ b/src/tracing/render_manager.rs
@@ -879,6 +879,28 @@ impl RenderManager {
             .map_err(|e| e.into())
     }
 
+    pub async fn update_render_name(
+        &self,
+        id: RenderID,
+        new_name: String,
+        user_id: UserID,
+    ) -> Result<(), RenderManagerError> {
+        let _render = match self.get_render(id, user_id).await? {
+            Some(r) => r,
+            None => {
+                return Err(RenderManagerError::ClientError(
+                    StatusCode::NOT_FOUND,
+                    "Render not found".to_string(),
+                ));
+            }
+        };
+
+        self.storage
+            .update_render_name(id, new_name)
+            .await
+            .map_err(|e| e.into())
+    }
+
     pub async fn get_render_checkpoint_as_image(
         &self,
         id: RenderID,

--- a/src/tracing/storage.rs
+++ b/src/tracing/storage.rs
@@ -242,6 +242,12 @@ pub trait RenderStorage: Send + Sync + 'static {
         new_total_checkpoints: u32,
     ) -> Result<(), StorageError>;
 
+    async fn update_render_name(
+        &self,
+        render_id: RenderID,
+        new_name: String,
+    ) -> Result<(), StorageError>;
+
     async fn get_render_checkpoint(
         &self,
         render_id: RenderID,

--- a/src/tracing/storage/file.rs
+++ b/src/tracing/storage/file.rs
@@ -212,6 +212,23 @@ impl RenderStorage for FileStorage {
         }
     }
 
+    async fn update_render_name(&self, id: RenderID, new_name: String) -> Result<(), StorageError> {
+        match self
+            .renders
+            .write()
+            .await
+            .iter_mut()
+            .find_map(|(r, _)| if r.id == id { Some(r) } else { None })
+        {
+            Some(render) => {
+                render.config.name = new_name;
+                render.mark_updated();
+                Ok(())
+            }
+            None => Err(format!("Render with id {id} not found").into()),
+        }
+    }
+
     async fn get_render_checkpoint(
         &self,
         id: RenderID,

--- a/src/tracing/storage/in_memory.rs
+++ b/src/tracing/storage/in_memory.rs
@@ -168,6 +168,18 @@ impl RenderStorage for InMemoryStorage {
         Ok(())
     }
 
+    async fn update_render_name(&self, id: RenderID, new_name: String) -> Result<(), StorageError> {
+        let renders = self.renders.read().await;
+        let render = match renders.get(&id) {
+            Some(r) => r,
+            None => return Err(format!("render {id} not found").into()),
+        };
+        let mut render = render.write().await;
+        render.config.name = new_name;
+        render.mark_updated();
+        Ok(())
+    }
+
     async fn get_render_checkpoint(
         &self,
         id: RenderID,

--- a/src/tracing/storage/postgres.rs
+++ b/src/tracing/storage/postgres.rs
@@ -347,6 +347,26 @@ impl RenderStorage for PostgresStorage {
         Ok(())
     }
 
+    async fn update_render_name(&self, id: RenderID, new_name: String) -> Result<(), StorageError> {
+        sqlx::query!(
+            r#"
+                UPDATE renders
+                SET config = jsonb_set(config, '{name}', $2::jsonb),
+                updated_at = $3
+                WHERE id = $1
+            "#,
+            id as i32,
+            serde_json::to_value(&new_name)
+                .map_err(|e| format!("Failed to serialize render name for id {}: {}", id, e))?,
+            chrono::Utc::now(),
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| format!("Failed to update render name for id {}: {}", id, e))?;
+
+        Ok(())
+    }
+
     async fn get_render_checkpoint(
         &self,
         id: RenderID,

--- a/ui/src/hooks/useRenderMutations.ts
+++ b/ui/src/hooks/useRenderMutations.ts
@@ -5,6 +5,7 @@ import {
   resumeRender,
   deleteRender,
   updateRenderTotalCheckpoints,
+  updateRenderName,
 } from '../utils/api';
 import { useAuth } from '../providers/auth';
 import type { NormalizedRenderConfig } from '../utils/render/config';
@@ -81,6 +82,21 @@ export function useUpdateRenderTotalCheckpoints() {
       renderId: number;
       newTotalCheckpoints: number;
     }) => updateRenderTotalCheckpoints(token, renderId, newTotalCheckpoints),
+    onSuccess: (_data, { renderId }) => {
+      queryClient.invalidateQueries({ queryKey: ['renders'] });
+      queryClient.invalidateQueries({ queryKey: ['render', renderId] });
+    },
+  });
+}
+
+export function useUpdateRenderName() {
+  const { mustGetToken } = useAuth();
+  const token = mustGetToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ renderId, newName }: { renderId: number; newName: string }) =>
+      updateRenderName(token, renderId, newName),
     onSuccess: (_data, { renderId }) => {
       queryClient.invalidateQueries({ queryKey: ['renders'] });
       queryClient.invalidateQueries({ queryKey: ['render', renderId] });

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -271,6 +271,26 @@ export async function updateRenderTotalCheckpoints(
   }
 }
 
+export async function updateRenderName(
+  token: string,
+  renderID: number,
+  newName: string,
+): Promise<void> {
+  const response = await fetch(`${getAPIURL()}/renders/${renderID}/name`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'PUT',
+    body: JSON.stringify({ name: newName }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Error updating render name: ${response.status} ${body}`);
+  }
+}
+
 export type RenderCheckpointStats = {
   average_elapsed: Duration;
   min_elapsed: Duration;

--- a/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/CheckpointLimitEditor/CheckpointLimitForm.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from '@tanstack/react-store';
 import { Button, Spinner } from 'flowbite-react';
+import { HiCheck } from 'react-icons/hi2';
 import { useAppForm } from '@/hooks/useAppForm';
 import { useUpdateRenderTotalCheckpoints } from '@/hooks/useRenderMutations';
 import { z } from 'zod';
@@ -50,25 +51,26 @@ export function CheckpointLimitForm(props: CheckpointLimitFormProps) {
     <>
       <form.AppField name="total_checkpoints">
         {(field) => (
-          <field.FormTextField
-            type="number"
-            valueLabel="Checkpoint Limit"
-            required
-            className="w-full"
-          />
+          <div className="flex items-end gap-2">
+            <field.FormTextField
+              type="number"
+              valueLabel="Checkpoint Limit"
+              required
+              className="flex-1"
+            />
+            <Button
+              title="Update Checkpoint Limit"
+              size="sm"
+              outline
+              color="gray"
+              onClick={handleSubmit}
+              disabled={isPending || !isFormValid}
+            >
+              {isPending ? <Spinner size="sm" /> : <HiCheck className="h-4 w-4" />}
+            </Button>
+          </div>
         )}
       </form.AppField>
-
-      <Button color="default" outline onClick={handleSubmit} disabled={isPending || !isFormValid}>
-        {isPending ? (
-          <span className="flex items-center justify-center">
-            <Spinner size="sm" className="mr-2" />
-            Updating...
-          </span>
-        ) : (
-          'Update'
-        )}
-      </Button>
     </>
   );
 }

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderNameEditor/RenameForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderNameEditor/RenameForm.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from '@tanstack/react-store';
 import { Button, Spinner } from 'flowbite-react';
+import { HiCheck } from 'react-icons/hi2';
 import { useAppForm } from '@/hooks/useAppForm';
 import { useUpdateRenderName } from '@/hooks/useRenderMutations';
 import { z } from 'zod';
@@ -43,20 +44,21 @@ export function RenameForm(props: RenameFormProps) {
     <>
       <form.AppField name="name">
         {(field) => (
-          <field.FormTextField type="text" valueLabel="Render Name" required className="w-full" />
+          <div className="flex items-end gap-2">
+            <field.FormTextField type="text" valueLabel="Render Name" required className="flex-1" />
+            <Button
+              title="Update Render Name"
+              size="sm"
+              outline
+              color="gray"
+              onClick={handleSubmit}
+              disabled={isPending || !isFormValid}
+            >
+              {isPending ? <Spinner size="sm" /> : <HiCheck className="h-4 w-4" />}
+            </Button>
+          </div>
         )}
       </form.AppField>
-
-      <Button color="default" outline onClick={handleSubmit} disabled={isPending || !isFormValid}>
-        {isPending ? (
-          <span className="flex items-center justify-center">
-            <Spinner size="sm" className="mr-2" />
-            Updating...
-          </span>
-        ) : (
-          'Update'
-        )}
-      </Button>
     </>
   );
 }

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderNameEditor/RenameForm.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderNameEditor/RenameForm.tsx
@@ -1,0 +1,62 @@
+import { useSelector } from '@tanstack/react-store';
+import { Button, Spinner } from 'flowbite-react';
+import { useAppForm } from '@/hooks/useAppForm';
+import { useUpdateRenderName } from '@/hooks/useRenderMutations';
+import { z } from 'zod';
+import { extractErrorMessage } from '@/utils/api';
+import toast from 'react-hot-toast';
+
+export type RenameFormProps = {
+  currentName: string;
+  renderID: number;
+};
+
+export function RenameForm(props: RenameFormProps) {
+  const { currentName, renderID } = props;
+
+  const { mutate: updateName, isPending } = useUpdateRenderName();
+
+  const form = useAppForm({
+    defaultValues: { name: currentName },
+    validators: {
+      onChange: z.object({
+        name: z.string().min(1, 'Name is required'),
+      }),
+    },
+  });
+
+  const isFormValid = useSelector(form.store, (state) => state.isValid);
+
+  function handleSubmit() {
+    const { name } = form.state.values;
+    updateName(
+      { renderId: renderID, newName: name },
+      {
+        onError: (error) => {
+          toast.error(extractErrorMessage(error));
+        },
+      },
+    );
+  }
+
+  return (
+    <>
+      <form.AppField name="name">
+        {(field) => (
+          <field.FormTextField type="text" valueLabel="Render Name" required className="w-full" />
+        )}
+      </form.AppField>
+
+      <Button color="default" outline onClick={handleSubmit} disabled={isPending || !isFormValid}>
+        {isPending ? (
+          <span className="flex items-center justify-center">
+            <Spinner size="sm" className="mr-2" />
+            Updating...
+          </span>
+        ) : (
+          'Update'
+        )}
+      </Button>
+    </>
+  );
+}

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderNameEditor/index.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderNameEditor/index.tsx
@@ -1,0 +1,32 @@
+import { Spinner } from 'flowbite-react';
+import { useRender } from '@/hooks/useRender';
+import { RenameForm } from './RenameForm';
+
+export type RenderNameEditorProps = {
+  renderID: number;
+};
+
+export function RenderNameEditor(props: RenderNameEditorProps) {
+  const { renderID } = props;
+
+  const {
+    data: render,
+    isLoading: isRenderLoading,
+    isError: isRenderError,
+    error: renderError,
+  } = useRender({ renderID });
+
+  if (isRenderLoading) {
+    return <Spinner size="md" className="fill-zinc-400" />;
+  }
+
+  if (isRenderError) {
+    return <p className="text-sm text-red-500">Error loading render: {renderError.message}</p>;
+  }
+
+  if (!render) {
+    return null;
+  }
+
+  return <RenameForm currentName={render.config.name} renderID={renderID} />;
+}

--- a/ui/src/views/renders/[id]/RenderSidebar/index.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/index.tsx
@@ -1,6 +1,8 @@
 import { RenderInfo } from './RenderInfo';
+import { RenderNameEditor } from './RenderNameEditor';
 import { CheckpointLimitEditor } from './CheckpointLimitEditor';
 import { RenderControls } from './RenderControls';
+import { Separator } from '@/components/Separator';
 
 export type RenderSidebarProps = {
   renderID: number;
@@ -12,6 +14,8 @@ export function RenderSidebar(props: RenderSidebarProps) {
   return (
     <div className="flex h-full flex-col items-stretch gap-4 p-4">
       <RenderInfo renderID={renderID} />
+      <RenderNameEditor renderID={renderID} />
+      <Separator />
       <CheckpointLimitEditor renderID={renderID} />
       <span className="mt-auto w-full border-b border-zinc-600" />
       <RenderControls renderID={renderID} />


### PR DESCRIPTION
## Summary

Adds the ability to rename a render after creation via a new `PUT /api/v1/renders/{id}/name` endpoint and a `RenderNameEditor` component in the render detail sidebar.

Closes #106

## Changes

### Backend
- **`RenderStorage` trait** — added `update_render_name(render_id, new_name)` method
- **Postgres** — updates via `jsonb_set(config, '{name}')`
- **File / InMemory** — direct field mutation on `render.config.name`
- **RenderManager** — `update_render_name` with ownership check via `self.get_render()`
- **Handler** — `update_render_name.rs`, registers `PUT /{id}/name`, returns 204
- **Router** — wired into `build_renders_router()`

### Frontend
- **API client** — `updateRenderName(token, renderID, newName)` function
- **Mutation hook** — `useUpdateRenderName` invalidates `['renders']` + `['render', id]` on success
- **RenderNameEditor** component — wrapper with `useRender` (loading/error/null states) + `RenameForm` with `useAppForm` + Zod validation
- **Sidebar** — wired between RenderInfo and CheckpointLimitEditor
- **Inline icon buttons** — both CheckpointLimit and Rename editors use compact `size="sm" outline color="gray"` icon buttons matching the download button style

### Verification
- ✅ cargo check, clippy, tests (10/10)
- ✅ ESLint, Prettier, TypeScript type-check