### PR TITLE
feat(ui): implement dielectric material preview in 3D canvas

### DIFF
--- a/ui/src/utils/render/material.ts
+++ b/ui/src/utils/render/material.ts
@@ -98,7 +98,7 @@ export function defaultMaterialForType(type: MaterialData['type']): MaterialData
         type: 'dielectric',
         reflectance_texture: '__white',
         emittance_texture: '__black',
-        index_of_refraction: 1,
+        index_of_refraction: 1.5,
       };
     case 'lambertian':
       return {

--- a/ui/src/views/renders/new/Controls/index.tsx
+++ b/ui/src/views/renders/new/Controls/index.tsx
@@ -167,8 +167,6 @@ export function Controls(props: ControlsProps) {
                   subtype: 'dielectric',
                   label: 'Dielectric Material',
                   description: 'Transparent material with refraction (glass, water).',
-                  disabled: true,
-                  disabledReason: 'Dielectric materials are not yet supported in the 3D preview.',
                 },
               ]}
               type="materials"

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -1,3 +1,4 @@
+import { MeshTransmissionMaterial } from '@react-three/drei';
 import { getMaterialDataSafe } from '@/utils/render/material';
 import { getTextureDataSafe } from '@/utils/render/texture';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
@@ -21,9 +22,39 @@ export function MaterialResolver(props: MaterialResolverProps) {
 
   switch (materialData.type) {
     case 'dielectric': {
-      console.warn('Dielectric material not yet supported');
-      return null;
+      const ior = materialData.index_of_refraction || 1.5;
+      switch (reflectanceTexture.type) {
+        case 'color': {
+          return (
+            <MeshTransmissionMaterial
+              attach="material"
+              color={reflectanceTexture.color}
+              thickness={0.5}
+              transmission={1.0}
+              ior={ior}
+              roughness={0}
+              {...(emissiveColor ? { emissive: emissiveColor } : {})}
+            />
+          );
+        }
+        case 'checker':
+        case 'image': {
+          console.warn(
+            `${reflectanceTexture.type} texture not yet supported for dielectric material`,
+          );
+          return (
+            <MeshTransmissionMaterial
+              attach="material"
+              color={[1, 1, 1]}
+              transmission={1.0}
+              ior={ior}
+              roughness={0}
+            />
+          );
+        }
+      }
     }
+    // eslint-disable-next-line no-fallthrough -- all inner branches return, TS confirms exhaustive
     case 'lambertian': {
       switch (reflectanceTexture.type) {
         case 'color': {


### PR DESCRIPTION
Closes #40.

## Summary

Enables rendering of dielectric (glass/transmissive) materials in the R3F 3D preview canvas. Previously, dielectric materials returned `null` in the material resolver (making them invisible) and the "Add Dielectric" option in the dropdown was disabled.

## Changes

### 1. `MaterialResolver.tsx` — Replace `return null` with `<MeshTransmissionMaterial>`
Following the exact same declarative R3F pattern as the existing lambertian (`meshLambertMaterial`) and specular (`meshStandardMaterial`) cases:
- Reads reflectance texture color (fallback to white for checker/image textures)
- Uses `materialData.index_of_refraction` to drive the `ior` prop
- Supports emissive color
- Sets `transmission={1.0}` and `roughness={0}` for clear glass

### 2. `Controls/index.tsx` — Enable dielectric in the Add Materials dropdown
Removed `disabled: true` and the `disabledReason` string from the dielectric option.

### 3. `material.ts` — Fix default IOR
Changed default `index_of_refraction` from `1` (air) to `1.5` (glass) for new dielectric materials.

## What was already in place
- `Environment` component in the scene (provides reflection/refraction backdrop)
- Form controls (IOR slider 1.0–10.0, reflectance/emittance texture pickers)
- Data types, Zod schemas, and normalization logic — all already complete