### PR TITLE
fix: Show one decimal place on detail page progress percentage

### DIFF
--- a/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/ProgressState.tsx
+++ b/ui/src/views/renders/[id]/RenderDisplay/RenderProgress/ProgressState.tsx
@@ -28,7 +28,8 @@ export function ProgressState(props: ProgressStateProps) {
     <div className="w-full rounded-lg border border-zinc-700 bg-zinc-800/50 p-4">
       <div className="w-full">
         <Progress
-          progress={Math.round(progress * 100)}
+          // @ts-expect-error — toFixed returns a string but Flowbite handles the numeric coercion internally
+          progress={(Math.round(progress * 1_000) / 10).toFixed(1)}
           color={color}
           size="lg"
           labelProgress


### PR DESCRIPTION
Changes the detail page progress bar display from integer percentage (`Math.round(progress * 100)` → `42`) to one decimal place (`(Math.round(progress * 1_000) / 10).toFixed(1)` → `42.1`). With SSE streaming at 50ms, the progress bar updates frequently enough that sub-percent precision is useful.