### PR TITLE
fix: memoize queryKey to prevent infinite EventSource reconnect loop

### DIFF
--- a/ui/src/hooks/useRender.ts
+++ b/ui/src/hooks/useRender.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEventSource } from '@/hooks/useEventSource';
 import { getRender } from '@/utils/api';
@@ -21,7 +21,10 @@ export function useRenderQuery(options: UseRenderOptions) {
   const { targetUserID } = useAdminUserOverride();
   const queryClient = useQueryClient();
 
-  const queryKey = renderQueryKey(renderID, token, targetUserID);
+  const queryKey = useMemo(
+    () => renderQueryKey(renderID, token, targetUserID),
+    [renderID, token, targetUserID],
+  );
 
   const queryResult = useQuery({
     queryKey,

--- a/ui/src/hooks/useRenderStats.ts
+++ b/ui/src/hooks/useRenderStats.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRenderStats } from '@/utils/api';
 import type { RenderStats } from '@/utils/api';
@@ -19,7 +19,10 @@ export function useRenderStatsQuery(options: UseRenderStatsOptions) {
   const { targetUserID } = useAdminUserOverride();
   const queryClient = useQueryClient();
 
-  const queryKey = renderStatsQueryKey(renderID, token, targetUserID);
+  const queryKey = useMemo(
+    () => renderStatsQueryKey(renderID, token, targetUserID),
+    [renderID, token, targetUserID],
+  );
 
   const queryResult = useQuery({
     queryKey,

--- a/ui/src/hooks/useRenders.ts
+++ b/ui/src/hooks/useRenders.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEventSource } from '@/hooks/useEventSource';
 import { getAllRenders } from '@/utils/api';
@@ -20,7 +20,7 @@ export function useRendersQuery(options: UseRendersOptions = {}) {
   const { targetUserID } = useAdminUserOverride();
   const queryClient = useQueryClient();
 
-  const queryKey = rendersQueryKey(token, targetUserID);
+  const queryKey = useMemo(() => rendersQueryKey(token, targetUserID), [token, targetUserID]);
 
   const queryResult = useQuery({
     queryKey,


### PR DESCRIPTION
## Summary

Fixes an infinite SSE reconnect loop that produces an endless stream of `NS_BINDING_ABORTED` errors in the browser network tab when viewing a render detail page.

## Root cause

`queryKey` arrays (`['render', id, token, userId]`, etc.) in `useRenderQuery`, `useRenderStatsQuery`, and `useRendersQuery` were created as new array references on every render. Since these arrays were dependencies of `useCallback`-wrapped SSE handlers, the handlers were recreated every render. `useEventSource`'s `useEffect` depends on those handler references, so each render cycle tore down the existing EventSource and created a new one. The new EventSource would immediately receive an SSE update, trigger `setQueryData`, cause a re-render, and loop forever.

Loop path:
1. SSE event arrives → handler calls `setQueryData`
2. React Query notifies → component re-renders
3. `queryKey` = new array → `handleUpdate` = new function
4. `useEventSource` cleanup fires → `eventSource.close()` (NS_BINDING_ABORTED)
5. Effect re-runs → new EventSource created → GOTO 1

## Fix

Wrapped all three `queryKey` assignments in `useMemo` with the appropriate dependencies:

| Hook | Memo deps |
|---|---|
| `useRenderQuery` | `[renderID, token, targetUserID]` |
| `useRenderStatsQuery` | `[renderID, token, targetUserID]` |
| `useRendersQuery` | `[token, targetUserID]` |

With stable `queryKey` references, the existing `useCallback` wrappers now correctly stabilize the handler functions, and `useEventSource` keeps the SSE connection alive across renders.

## Verification

- TypeScript type-check: ✅ passes
- ESLint: ✅ passes