### PR TITLE
Spectral color rendering with hero wavelengths and Sellmeier dispersion

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -5,14 +5,14 @@ use luxide::{
     camera::Camera,
     deserialization::RenderConfig,
     geometry::{
-        Geometric, Point, Vector,
+        Geometric, Point, Vector3,
         compounds::{AxisAlignedPBox, Bvh, List},
         instances::{RotateYAxis, Translate},
         primitives::{Parallelogram, Sphere},
         volumes,
     },
     shading::{
-        Color, Texture,
+        ColorRgb, ColorSpectrum, Texture,
         materials::{Dielectric, Lambertian, Material, Specular},
         textures::{Checker, Image8Bit, Noise, SolidColor},
     },
@@ -131,7 +131,7 @@ fn final_scene() -> Scene {
         Arc::new(Image8Bit::from_filename("./texture_images/8k_earth_daymap.jpg", 2.0).unwrap());
 
     //perlin noise
-    let input_fn = |p: Point| Point::from_vector(0.1 * p.0);
+    let input_fn = |p: Point| Point::from_vector3(0.1 * p.0);
     // let output_fn = |n: f64, p: Point| 0.5 * (1.0 + (p.0.z + 10.0 * n).sin());
     let output_fn = |n: f64, p: Point| 0.5 * (1.0 + (p.0.z + 2.0 * n).sin());
     // let output_fn = |n: f64, p: Point| n;
@@ -209,15 +209,15 @@ fn final_scene() -> Scene {
 
     let light_panel = Arc::new(Parallelogram::new(
         Point::new(123.0, 554.0, 147.0),
-        Vector::new(300.0, 0.0, 0.0),
-        Vector::new(0.0, 0.0, 265.0),
+        Vector3::new(300.0, 0.0, 0.0),
+        Vector3::new(0.0, 0.0, 265.0),
         false,
         Arc::clone(&lambertian_light),
     ));
     world.push(light_panel);
 
     let center1 = Point::new(400.0, 400.0, 200.0);
-    let center2 = center1 + Vector::new(30.0, 0.0, 0.0);
+    let center2 = center1 + Vector3::new(30.0, 0.0, 0.0);
     let motion_sphere = Arc::new(Sphere::new_in_motion(
         center1,
         center2,
@@ -278,7 +278,7 @@ fn final_scene() -> Scene {
     let mut sphere_box = List::new();
     for _ in 0..1000 {
         sphere_box.push(Arc::new(Sphere::new(
-            Point::from_vector(Vector::random_range(0.0, 165.0)),
+            Point::from_vector3(Vector3::random_range(0.0, 165.0)),
             10.0,
             Arc::clone(&lambertian_light_grey),
         )))
@@ -291,7 +291,7 @@ fn final_scene() -> Scene {
     ));
     let sphere_box = Arc::new(Translate::new(
         sphere_box,
-        Vector::new(-100.0, 270.0, 395.0),
+        Vector3::new(-100.0, 270.0, 395.0),
     ));
     world.push(sphere_box);
 
@@ -302,7 +302,7 @@ fn final_scene() -> Scene {
     let vertical_field_of_view_degrees = 40.0;
     let eye_location = Point::new(478.0, 278.0, -600.0);
     let target_location = Point::new(278.0, 278.0, 0.0);
-    let view_up = Vector::UP;
+    let view_up = Vector3::UP;
 
     let defocus_angle_degrees = 0.0;
     let focus_distance = 1.0;
@@ -320,14 +320,14 @@ fn final_scene() -> Scene {
         // name: "final_scene".to_string(),
         camera,
         world: SceneWorld::from_world_without_importance_sampling(world),
-        background_color: Color::BLACK,
+        background_color: ColorSpectrum::ZERO,
     }
 }
 
 #[allow(dead_code)]
 fn cornell_box() -> Scene {
     // Textures
-    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::BLACK));
+    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ZERO));
     let solid_white: Arc<dyn Texture> = Arc::new(SolidColor::from_rgb(0.73, 0.73, 0.73));
     let solid_red: Arc<dyn Texture> = Arc::new(SolidColor::from_rgb(0.65, 0.05, 0.05));
     let solid_green: Arc<dyn Texture> = Arc::new(SolidColor::from_rgb(0.12, 0.45, 0.15));
@@ -356,48 +356,48 @@ fn cornell_box() -> Scene {
     // left wall (green)
     world.push(Arc::new(Parallelogram::new(
         Point::new(0.0, 0.0, 0.0),
-        Vector::new(0.0, 0.0, -1.0),
-        Vector::new(0.0, 1.0, 0.0),
+        Vector3::new(0.0, 0.0, -1.0),
+        Vector3::new(0.0, 1.0, 0.0),
         true,
         Arc::clone(&lambertian_green),
     )));
     // right wall (red)
     world.push(Arc::new(Parallelogram::new(
         Point::new(1.0, 0.0, -1.0),
-        Vector::new(0.0, 0.0, 1.0),
-        Vector::new(0.0, 1.0, 0.0),
+        Vector3::new(0.0, 0.0, 1.0),
+        Vector3::new(0.0, 1.0, 0.0),
         true,
         Arc::clone(&lambertian_red),
     )));
     // floor (white)
     world.push(Arc::new(Parallelogram::new(
         Point::new(0.0, 0.0, 0.0),
-        Vector::new(1.0, 0.0, 0.0),
-        Vector::new(0.0, 0.0, -1.0),
+        Vector3::new(1.0, 0.0, 0.0),
+        Vector3::new(0.0, 0.0, -1.0),
         true,
         Arc::clone(&lambertian_white),
     )));
     // ceiling (white)
     world.push(Arc::new(Parallelogram::new(
         Point::new(0.0, 1.0, -1.0),
-        Vector::new(1.0, 0.0, 0.0),
-        Vector::new(0.0, 0.0, 1.0),
+        Vector3::new(1.0, 0.0, 0.0),
+        Vector3::new(0.0, 0.0, 1.0),
         true,
         Arc::clone(&lambertian_white),
     )));
     // back wall (white)
     world.push(Arc::new(Parallelogram::new(
         Point::new(0.0, 0.0, -1.0),
-        Vector::new(1.0, 0.0, 0.0),
-        Vector::new(0.0, 1.0, 0.0),
+        Vector3::new(1.0, 0.0, 0.0),
+        Vector3::new(0.0, 1.0, 0.0),
         true,
         Arc::clone(&lambertian_white),
     )));
     // ceiling light
     world.push(Arc::new(Parallelogram::new(
         Point::new(1.0 - (343.0 / 555.0), 554.0 / 555.0, -332.0 / 555.0),
-        Vector::new(130.0 / 555.0, 0.0, 0.0),
-        Vector::new(0.0, 0.0, 105.0 / 555.0),
+        Vector3::new(130.0 / 555.0, 0.0, 0.0),
+        Vector3::new(0.0, 0.0, 105.0 / 555.0),
         false,
         Arc::clone(&lambertian_white_light),
     )));
@@ -405,7 +405,7 @@ fn cornell_box() -> Scene {
     // far left box
     let far_left_box = Arc::new(AxisAlignedPBox::new(
         Point::ZERO,
-        Point::ZERO + Vector::new(-165.0, 330.0, -165.0) / 555.0,
+        Point::ZERO + Vector3::new(-165.0, 330.0, -165.0) / 555.0,
         false,
         Arc::clone(&lambertian_white),
     ));
@@ -416,7 +416,7 @@ fn cornell_box() -> Scene {
     ));
     let far_left_box = Arc::new(Translate::new(
         far_left_box,
-        Vector::new(1.0 - (265.0 / 555.0), 0.0, -295.0 / 555.0),
+        Vector3::new(1.0 - (265.0 / 555.0), 0.0, -295.0 / 555.0),
     ));
     let far_left_box = Arc::new(volumes::Constant::new(
         far_left_box,
@@ -428,7 +428,7 @@ fn cornell_box() -> Scene {
     // near right box
     let near_right_box = Arc::new(AxisAlignedPBox::new(
         Point::ZERO,
-        Point::ZERO + Vector::new(-165.0, 165.0, -165.0) / 555.0,
+        Point::ZERO + Vector3::new(-165.0, 165.0, -165.0) / 555.0,
         false,
         Arc::clone(&lambertian_white),
     ));
@@ -439,7 +439,7 @@ fn cornell_box() -> Scene {
     ));
     let near_right_box = Arc::new(Translate::new(
         near_right_box,
-        Vector::new(1.0 - (130.0 / 555.0), 0.0, -65.0 / 555.0),
+        Vector3::new(1.0 - (130.0 / 555.0), 0.0, -65.0 / 555.0),
     ));
     let near_right_box = Arc::new(volumes::Constant::new(
         near_right_box,
@@ -452,7 +452,7 @@ fn cornell_box() -> Scene {
     let vertical_field_of_view_degrees = 40.0;
     let eye_location = Point::new(0.5, 0.5, 1.44144);
     let target_location = Point::new(0.5, 0.5, 0.0);
-    let view_up = Vector::new(0.0, 1.0, 0.0);
+    let view_up = Vector3::new(0.0, 1.0, 0.0);
 
     let defocus_angle_degrees = 0.0;
     let focus_distance = 1.0;
@@ -470,17 +470,17 @@ fn cornell_box() -> Scene {
         // name: "cornell_box".to_string(),
         camera,
         world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
-        background_color: Color::BLACK,
+        background_color: ColorSpectrum::ZERO,
     }
 }
 
 #[allow(dead_code)]
 fn simple_light() -> Scene {
     // Textures
-    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::BLACK));
-    let solid_white_light: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::WHITE * 4.0));
+    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ZERO));
+    let solid_white_light: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ONE * 4.0));
 
-    let input_fn = |p: Point| Point::from_vector(4.0 * p.0);
+    let input_fn = |p: Point| Point::from_vector3(4.0 * p.0);
     // let output_fn = |n: f64, p: Point| 0.5 * (1.0 + (p.0.z + 10.0 * n).sin());
     let output_fn = |n: f64, p: Point| 0.5 * (1.0 + (p.0.z + 3.0 * n).sin());
     // let output_fn = |n: f64, p: Point| n;
@@ -520,8 +520,8 @@ fn simple_light() -> Scene {
     )));
     world.push(Arc::new(Parallelogram::new(
         Point::new(3.0, 1.0, -2.0),
-        Vector::new(2.0, 0.0, 0.0),
-        Vector::new(0.0, 2.0, 0.0),
+        Vector3::new(2.0, 0.0, 0.0),
+        Vector3::new(0.0, 2.0, 0.0),
         true,
         Arc::clone(&lambertian_light),
     )));
@@ -535,7 +535,7 @@ fn simple_light() -> Scene {
     let vertical_field_of_view_degrees = 20.0;
     let eye_location = Point::new(26.0, 3.0, 6.0);
     let target_location = Point::new(0.0, 2.0, 0.0);
-    let view_up = Vector::new(0.0, 1.0, 0.0);
+    let view_up = Vector3::new(0.0, 1.0, 0.0);
 
     let defocus_angle_degrees = 0.0;
     let focus_distance = 1.0;
@@ -553,19 +553,19 @@ fn simple_light() -> Scene {
         // name: "simple_light".to_string(),
         camera,
         world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
-        background_color: Color::BLACK,
+        background_color: ColorSpectrum::ZERO,
     }
 }
 
 #[allow(dead_code)]
 fn quads() -> Scene {
     // Textures
-    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::BLACK));
-    let solid_red: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::new(1.0, 0.2, 0.2)));
-    let solid_green: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::new(0.2, 1.0, 0.2)));
-    let solid_blue: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::new(0.2, 0.2, 1.0)));
-    let solid_orange: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::new(1.0, 0.5, 0.0)));
-    let solid_teal: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::new(0.2, 0.8, 0.8)));
+    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ZERO));
+    let solid_red: Arc<dyn Texture> = Arc::new(SolidColor::from(ColorRgb::new(1.0, 0.2, 0.2)));
+    let solid_green: Arc<dyn Texture> = Arc::new(SolidColor::from(ColorRgb::new(0.2, 1.0, 0.2)));
+    let solid_blue: Arc<dyn Texture> = Arc::new(SolidColor::from(ColorRgb::new(0.2, 0.2, 1.0)));
+    let solid_orange: Arc<dyn Texture> = Arc::new(SolidColor::from(ColorRgb::new(1.0, 0.5, 0.0)));
+    let solid_teal: Arc<dyn Texture> = Arc::new(SolidColor::from(ColorRgb::new(0.2, 0.8, 0.8)));
 
     // Materials
     let lambertian_red: Arc<dyn Material> = Arc::new(Lambertian::new(
@@ -594,36 +594,36 @@ fn quads() -> Scene {
     let mut world = List::new();
     world.push(Arc::new(Parallelogram::new(
         Point::new(-3.0, -2.0, 5.0),
-        Vector::new(0.0, 0.0, -4.0),
-        Vector::new(0.0, 4.0, 0.0),
+        Vector3::new(0.0, 0.0, -4.0),
+        Vector3::new(0.0, 4.0, 0.0),
         is_culled,
         Arc::clone(&lambertian_red),
     )));
     world.push(Arc::new(Parallelogram::new(
         Point::new(-2.0, -2.0, 0.0),
-        Vector::new(4.0, 0.0, 0.0),
-        Vector::new(0.0, 4.0, 0.0),
+        Vector3::new(4.0, 0.0, 0.0),
+        Vector3::new(0.0, 4.0, 0.0),
         is_culled,
         Arc::clone(&lambertian_green),
     )));
     world.push(Arc::new(Parallelogram::new(
         Point::new(3.0, -2.0, 1.0),
-        Vector::new(0.0, 0.0, 4.0),
-        Vector::new(0.0, 4.0, 0.0),
+        Vector3::new(0.0, 0.0, 4.0),
+        Vector3::new(0.0, 4.0, 0.0),
         is_culled,
         Arc::clone(&lambertian_blue),
     )));
     world.push(Arc::new(Parallelogram::new(
         Point::new(-2.0, 3.0, 1.0),
-        Vector::new(4.0, 0.0, 0.0),
-        Vector::new(0.0, 0.0, 4.0),
+        Vector3::new(4.0, 0.0, 0.0),
+        Vector3::new(0.0, 0.0, 4.0),
         is_culled,
         Arc::clone(&lambertian_orange),
     )));
     world.push(Arc::new(Parallelogram::new(
         Point::new(-2.0, -3.0, 5.0),
-        Vector::new(4.0, 0.0, 0.0),
-        Vector::new(0.0, 0.0, -4.0),
+        Vector3::new(4.0, 0.0, 0.0),
+        Vector3::new(0.0, 0.0, -4.0),
         is_culled,
         Arc::clone(&lambertian_teal),
     )));
@@ -632,7 +632,7 @@ fn quads() -> Scene {
     let vertical_field_of_view_degrees = 80.0;
     let eye_location = Point::new(0.0, 0.0, 9.0);
     let target_location = Point::new(0.0, 0.0, 0.0);
-    let view_up = Vector::new(0.0, 1.0, 0.0);
+    let view_up = Vector3::new(0.0, 1.0, 0.0);
 
     let defocus_angle_degrees = 0.0;
     let focus_distance = 1.0;
@@ -650,16 +650,16 @@ fn quads() -> Scene {
         // name: "quads".to_string(),
         camera,
         world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
-        background_color: Color::new(0.7, 0.8, 1.0),
+        background_color: ColorRgb::new(0.7, 0.8, 1.0).into(),
     }
 }
 
 #[allow(dead_code)]
 fn two_perlin_spheres() -> Scene {
     // Textures
-    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::BLACK));
+    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ZERO));
 
-    let input_fn = |p: Point| Point::from_vector(4.0 * p.0);
+    let input_fn = |p: Point| Point::from_vector3(4.0 * p.0);
     // let output_fn = |n: f64, p: Point| 0.5 * (1.0 + (p.0.z + 10.0 * n).sin());
     let output_fn = |n: f64, p: Point| 0.5 * (1.0 + (p.0.z + 2.0 * n).sin());
     // let output_fn = |n: f64, p: Point| n;
@@ -698,7 +698,7 @@ fn two_perlin_spheres() -> Scene {
     let vertical_field_of_view_degrees = 20.0;
     let eye_location = Point::new(13.0, 2.0, 3.0);
     let target_location = Point::new(0.0, 0.0, 0.0);
-    let view_up = Vector::new(0.0, 1.0, 0.0);
+    let view_up = Vector3::new(0.0, 1.0, 0.0);
 
     let defocus_angle_degrees = 0.0;
     let focus_distance = 1.0;
@@ -716,14 +716,14 @@ fn two_perlin_spheres() -> Scene {
         // name: "two_perlin_spheres".to_string(),
         camera,
         world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
-        background_color: Color::new(0.7, 0.8, 1.0),
+        background_color: ColorRgb::new(0.7, 0.8, 1.0).into(),
     }
 }
 
 #[allow(dead_code)]
 fn earth() -> Scene {
     // Textures
-    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::BLACK));
+    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ZERO));
     let image_earth_day: Arc<dyn Texture> =
         Arc::new(Image8Bit::from_filename("./texture_images/8k_earth_daymap.jpg", 2.0).unwrap());
     // let image_earth_night: Arc<dyn Texture> =
@@ -732,7 +732,7 @@ fn earth() -> Scene {
         Arc::new(Image8Bit::from_filename("./texture_images/8k_moon.jpg", 2.0).unwrap());
     // let image_stars_milky_way =
     //     Arc::new(Image8Bit::from_filename("./texture_images/8k_stars_milky_way.jpg", 2.0).unwrap());
-    let solid_white: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::WHITE));
+    let solid_white: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ONE));
 
     // Materials
     let lambertian_earth_day: Arc<dyn Material> = Arc::new(Lambertian::new(
@@ -776,7 +776,7 @@ fn earth() -> Scene {
     let vertical_field_of_view_degrees = 30.0;
     let eye_location = Point::new(0.0, 0.0, 12.0);
     let target_location = Point::new(0.0, 0.0, 0.0);
-    let view_up = Vector::new(0.0, 1.0, 0.0);
+    let view_up = Vector3::new(0.0, 1.0, 0.0);
 
     let defocus_angle_degrees = 0.0;
     let focus_distance = 1.0;
@@ -794,18 +794,18 @@ fn earth() -> Scene {
         // name: "earth".to_string(),
         camera,
         world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
-        background_color: Color::new(0.7, 0.8, 1.0),
+        background_color: ColorRgb::new(0.7, 0.8, 1.0).into(),
     }
 }
 
 #[allow(dead_code)]
 fn two_spheres() -> Scene {
     // Materials
-    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::BLACK));
+    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ZERO));
     let checker: Arc<dyn Texture> = Arc::new(Checker::from_colors(
         0.5,
-        Color::new(0.2, 0.1, 0.1),
-        Color::new(0.9, 0.9, 0.9),
+        ColorRgb::new(0.2, 0.1, 0.1).into(),
+        ColorRgb::new(0.9, 0.9, 0.9).into(),
     ));
     let lambertian_checker: Arc<dyn Material> = Arc::new(Lambertian::new(
         Arc::clone(&checker),
@@ -829,7 +829,7 @@ fn two_spheres() -> Scene {
     let vertical_field_of_view_degrees = 40.0;
     let eye_location = Point::new(13.0, 2.0, 3.0);
     let target_location = Point::new(0.0, 0.0, 0.0);
-    let view_up = Vector::new(0.0, 1.0, 0.0);
+    let view_up = Vector3::new(0.0, 1.0, 0.0);
 
     let defocus_angle_degrees = 0.0;
     let focus_distance = 1.0;
@@ -847,23 +847,25 @@ fn two_spheres() -> Scene {
         // name: "two_spheres".to_string(),
         world: SceneWorld::from_world_without_importance_sampling(Arc::new(world)),
         camera,
-        background_color: Color::new(0.7, 0.8, 1.0),
+        background_color: ColorRgb::new(0.7, 0.8, 1.0).into(),
     }
 }
 
 #[allow(dead_code)]
 fn random_spheres() -> Scene {
     // Textures
-    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::BLACK));
-    let solid_white: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::WHITE));
-    let solid_brown: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::new(0.4, 0.2, 0.1)));
-    let solid_amber: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::new(0.7, 0.6, 0.5)));
+    let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ZERO));
+    let solid_white: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ONE));
+    let solid_brown: Arc<dyn Texture> =
+        Arc::new(SolidColor::new(ColorRgb::new(0.4, 0.2, 0.1).into()));
+    let solid_amber: Arc<dyn Texture> =
+        Arc::new(SolidColor::new(ColorRgb::new(0.7, 0.6, 0.5).into()));
 
     // Materials
     let checker: Arc<dyn Texture> = Arc::new(Checker::from_colors(
         0.32,
-        Color::new(0.2, 0.3, 0.1),
-        Color::new(0.9, 0.9, 0.9),
+        ColorRgb::new(0.2, 0.3, 0.1).into(),
+        ColorRgb::new(0.9, 0.9, 0.9).into(),
     ));
     let lambertian_checker: Arc<dyn Material> = Arc::new(Lambertian::new(
         Arc::clone(&checker),
@@ -908,18 +910,24 @@ fn random_spheres() -> Scene {
                 let choose_mat = rand::random::<f64>();
                 if choose_mat < 0.8 {
                     // lambertian
-                    let reflectance = Color::random() * Color::random();
-                    let reflectance = Arc::new(SolidColor::new(reflectance));
+                    let reflectance = ColorRgb::random() * ColorRgb::random();
+                    let rgb: [f64; 3] = reflectance.into();
+                    let reflectance = Arc::new(SolidColor::new(
+                        ColorRgb::new(rgb[0], rgb[1], rgb[2]).into(),
+                    ));
                     let lambertian =
                         Arc::new(Lambertian::new(reflectance, Arc::clone(&solid_black)));
-                    let center_2 = center + Vector::new(0.0, 0.5 * rand::random::<f64>(), 0.0);
+                    let center_2 = center + Vector3::new(0.0, 0.5 * rand::random::<f64>(), 0.0);
                     world_list.push(Arc::new(Sphere::new_in_motion(
                         center, center_2, 0.2, lambertian,
                     )));
                 } else if choose_mat < 0.95 {
                     // specular
-                    let albedo = Color::random_range(0.5, 1.0);
-                    let albedo: Arc<dyn Texture> = Arc::new(SolidColor::new(albedo));
+                    let albedo = ColorRgb::random_range(0.5, 1.0);
+                    let rgb: [f64; 3] = albedo.into();
+                    let albedo: Arc<dyn Texture> = Arc::new(SolidColor::new(
+                        ColorRgb::new(rgb[0], rgb[1], rgb[2]).into(),
+                    ));
                     let roughness = 0.5 * rand::random::<f64>();
                     let specular = Arc::new(Specular::new(
                         Arc::clone(&albedo),
@@ -929,7 +937,7 @@ fn random_spheres() -> Scene {
                     world_list.push(Arc::new(Sphere::new(center, 0.2, specular)));
                 } else {
                     // dielectric
-                    let albedo: Arc<dyn Texture> = Arc::new(SolidColor::new(Color::WHITE));
+                    let albedo: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ONE));
                     let dielectric = Arc::new(Dielectric::new(
                         Arc::clone(&albedo),
                         Arc::clone(&solid_black),
@@ -966,7 +974,7 @@ fn random_spheres() -> Scene {
     let vertical_field_of_view_degrees = 20.0;
     let eye_location = Point::new(13.0, 2.0, 3.0);
     let target_location = Point::new(0.0, 0.0, 0.0);
-    let view_up = Vector::new(0.0, 1.0, 0.0);
+    let view_up = Vector3::new(0.0, 1.0, 0.0);
 
     let defocus_angle_degrees = 0.06;
     let focus_distance = 10.0;
@@ -984,6 +992,6 @@ fn random_spheres() -> Scene {
         // name: "random_spheres".to_string(),
         world: SceneWorld::from_world_without_importance_sampling(world),
         camera,
-        background_color: Color::new(0.7, 0.8, 1.0),
+        background_color: ColorRgb::new(0.7, 0.8, 1.0).into(),
     }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -5,8 +5,11 @@ use rand::RngExt;
 use crate::{
     geometry::{Point, Ray, Vector, Vector3},
     shading::{
-        ColorRgb, ColorSpectrum, HeroWavelengths, color_spectrum::SPECTRAL_SAMPLE_COUNT,
-        hero_wavelengths::HERO_WAVELENGTH_COUNT, materials::ScatterRecord, pdf::Pdf,
+        ColorRgb, ColorSpectrum, HeroWavelengths,
+        color_spectrum::SPECTRAL_SAMPLE_COUNT,
+        hero_wavelengths::HERO_WAVELENGTH_COUNT,
+        materials::{ScatterRecord, SpectralScatter},
+        pdf::Pdf,
     },
     tracing::{BouncesConfig, ImportanceSamplingConfig, RenderParameters, Scene, SceneWorld},
     utils::{Angle, Interval},
@@ -164,18 +167,24 @@ impl Camera {
         x_offset + y_offset
     }
 
-    pub fn ray_color(&self, mut ray: Ray, scene_world: &SceneWorld) -> ColorRgb {
+    /// Trace a ray through the scene, accumulating spectral radiance at
+    /// each of the N hero wavelengths. For `N = 4`, this is the shared-
+    /// geometry path. For `N = 1`, this is a single-wavelength sub-path
+    /// used after a dispersive dielectric split.
+    fn trace_spectral<const N: usize>(
+        &self,
+        mut ray: Ray,
+        hw: &HeroWavelengths<N>,
+        scene_world: &SceneWorld,
+        mut bounces: u32,
+    ) -> Vector<N> {
         let mut rng = rand::rng();
 
-        // pick 4 stratified random hero wavelengths for this camera ray
-        let hero_wavelengths = HeroWavelengths::new_distributed();
+        // per-wavelength accumulated radiance
+        let mut accumulated = Vector::<N>::ZERO;
+        // per-wavelength attenuation throughput
+        let mut attenuation = Vector::<N>::ONE;
 
-        // per-wavelength accumulated radiance (scalar)
-        let mut accumulated = Vector::<HERO_WAVELENGTH_COUNT>::ZERO;
-        // per-wavelength attenuation throughput (scalar)
-        let mut attenuation = Vector::<HERO_WAVELENGTH_COUNT>::ONE;
-
-        let mut bounces = 0;
         while let Some(ray_hit) = scene_world
             .world
             .intersect(ray, Interval::new(0.001, f64::INFINITY))
@@ -184,11 +193,10 @@ impl Camera {
             let emittance = ray_hit
                 .material
                 .emittance(ray_hit.u, ray_hit.v, ray_hit.point);
-            accumulated += attenuation * emittance.sample(&hero_wavelengths);
+            accumulated += attenuation * emittance.sample(hw);
 
             if bounces >= self.bounces.max {
-                // convert accumulated spectral samples to RGB and return
-                return hero_wavelengths.to_color_rgb(accumulated);
+                return accumulated;
             }
 
             // early termination: if surface absorbs all light at all wavelengths
@@ -196,24 +204,51 @@ impl Camera {
                 .material
                 .reflectance(ray_hit.u, ray_hit.v, ray_hit.point);
             if reflectance.is_black() {
-                return hero_wavelengths.to_color_rgb(accumulated);
+                return accumulated;
             }
 
-            let Some(srec) = ray_hit.material.scatter(ray, &ray_hit) else {
-                return hero_wavelengths.to_color_rgb(accumulated);
+            // Build a 4-wavelength set from the generic N-wavelength `hw`.
+            // For N=4 this is an identity; for N=1 this fills all 4 slots
+            // with the same wavelength (non-dispersive case for sub-paths).
+            let scatter_hw = {
+                let mut data = [0.0; HERO_WAVELENGTH_COUNT];
+                for i in 0..HERO_WAVELENGTH_COUNT {
+                    data[i] = hw[i % N];
+                }
+                HeroWavelengths::new(data)
+            };
+            let Some(srec) = ray_hit.material.scatter(ray, &ray_hit, &scatter_hw) else {
+                return accumulated;
             };
 
             let outgoing_direction = (-ray.direction).unit_vector();
 
             match srec {
+                ScatterRecord::Spectral(ss) => {
+                    let SpectralScatter { rays, reflectance } = *ss;
+                    // dispersive dielectric — trace each hero wavelength independently
+                    for i in 0..N {
+                        if let Some(refracted) = rays[i] {
+                            let single_hw = HeroWavelengths::new([hw[i]; 1]);
+                            let contrib = self.trace_spectral::<1>(
+                                refracted,
+                                &single_hw,
+                                scene_world,
+                                bounces + 1,
+                            );
+                            accumulated[i] += attenuation[i] * reflectance[i] * contrib[0];
+                        }
+                    }
+                    return accumulated;
+                }
                 ScatterRecord::Delta { scattered } => {
-                    // specular / dielectric — attenuation scales by reflectance at each wavelength
+                    // specular — attenuation scales by reflectance at each wavelength
                     let reflectance =
                         ray_hit
                             .material
                             .reflectance(ray_hit.u, ray_hit.v, ray_hit.point);
-                    attenuation *= reflectance.sample(&hero_wavelengths);
-                    ray = scattered
+                    attenuation *= reflectance.sample(hw);
+                    ray = scattered;
                 }
                 ScatterRecord::Pdf(scatter_pdf) => {
                     let pdf = build_mixture_pdf(
@@ -240,22 +275,21 @@ impl Camera {
                         let mis_weight = pdf.power_heuristic(incident_direction, index_of_strategy);
 
                         if pdf_val <= 0.0 {
-                            return hero_wavelengths.to_color_rgb(accumulated);
+                            return accumulated;
                         }
 
-                        attenuation *=
-                            brdf_val.sample(&hero_wavelengths) * (cos_theta * mis_weight / pdf_val);
+                        attenuation *= brdf_val.sample(hw) * (cos_theta * mis_weight / pdf_val);
                     } else {
                         let pdf_val = pdf.density(incident_direction);
 
                         if pdf_val <= 0.0 {
-                            return hero_wavelengths.to_color_rgb(accumulated);
+                            return accumulated;
                         }
 
-                        attenuation *= brdf_val.sample(&hero_wavelengths) * (cos_theta / pdf_val);
+                        attenuation *= brdf_val.sample(hw) * (cos_theta / pdf_val);
                     }
 
-                    ray = Ray::new(ray_hit.point, incident_direction, ray.time)
+                    ray = Ray::new(ray_hit.point, incident_direction, ray.time);
                 }
             }
 
@@ -267,16 +301,22 @@ impl Camera {
             {
                 let p = attenuation.iter().fold(0.0_f64, |a, &b| a.max(b)).min(1.0);
                 if rng.random::<f64>() > p {
-                    return hero_wavelengths.to_color_rgb(accumulated);
+                    return accumulated;
                 }
                 attenuation /= p;
             }
         }
 
         // ray missed — add background contribution
-        accumulated += attenuation * self.background_color.sample(&hero_wavelengths);
+        accumulated += attenuation * self.background_color.sample(hw);
 
-        hero_wavelengths.to_color_rgb(accumulated)
+        accumulated
+    }
+
+    pub fn ray_color(&self, ray: Ray, scene_world: &SceneWorld) -> ColorRgb {
+        let hw = HeroWavelengths::<HERO_WAVELENGTH_COUNT>::new_distributed();
+        let accumulated = self.trace_spectral::<HERO_WAVELENGTH_COUNT>(ray, &hw, scene_world, 0);
+        hw.to_color_rgb(accumulated)
     }
 }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -3,8 +3,11 @@ use std::{f64::consts::PI, sync::Arc};
 use rand::RngExt;
 
 use crate::{
-    geometry::{Point, Ray, Vector},
-    shading::{Color, materials::ScatterRecord, pdf::Pdf},
+    geometry::{Point, Ray, Vector, Vector3},
+    shading::{
+        ColorRgb, ColorSpectrum, HeroWavelengths, color_spectrum::SPECTRAL_SAMPLE_COUNT,
+        hero_wavelengths::HERO_WAVELENGTH_COUNT, materials::ScatterRecord, pdf::Pdf,
+    },
     tracing::{BouncesConfig, ImportanceSamplingConfig, RenderParameters, Scene, SceneWorld},
     utils::{Angle, Interval},
 };
@@ -14,26 +17,26 @@ pub struct Camera {
     // "public" fields
     eye_location: Point,
     target_location: Point,
-    view_up: Vector,
+    view_up: Vector3,
     vertical_field_of_view_degrees: f64,
 
     defocus_angle_degrees: f64,
     focus_distance: f64,
 
     // "private" fields
-    background_color: Color,
+    background_color: ColorSpectrum<SPECTRAL_SAMPLE_COUNT>,
     image_height: u32,
     center: Point,
     importance_sampling: ImportanceSamplingConfig,
     bounces: BouncesConfig,
     pixel_00_location: Point,
-    pixel_delta_u: Vector,
-    pixel_delta_v: Vector,
-    u: Vector,
-    v: Vector,
-    w: Vector,
-    defocus_disk_u: Vector,
-    defocus_disk_v: Vector,
+    pixel_delta_u: Vector3,
+    pixel_delta_v: Vector3,
+    u: Vector3,
+    v: Vector3,
+    w: Vector3,
+    defocus_disk_u: Vector3,
+    defocus_disk_v: Vector3,
 }
 
 impl Camera {
@@ -41,7 +44,7 @@ impl Camera {
         vertical_field_of_view_degrees: f64,
         eye_location: Point,
         target_location: Point,
-        view_up: Vector,
+        view_up: Vector3,
         defocus_angle_degrees: f64,
         focus_distance: f64,
     ) -> Self {
@@ -145,14 +148,14 @@ impl Camera {
     }
 
     fn defocus_disk_sample(&self) -> Point {
-        let disk_unit_vector = &Vector::random_in_unit_disk();
+        let disk_unit_vector = &Vector3::random_in_unit_disk();
 
         self.center
             + self.defocus_disk_u * disk_unit_vector.x
             + self.defocus_disk_v * disk_unit_vector.y
     }
 
-    fn pixel_sample_square(&self) -> Vector {
+    fn pixel_sample_square(&self) -> Vector3 {
         let mut rng = rand::rng();
 
         let x_offset = self.pixel_delta_u * rng.random_range(-0.5..0.5);
@@ -161,61 +164,55 @@ impl Camera {
         x_offset + y_offset
     }
 
-    pub fn ray_color(&self, mut ray: Ray, scene_world: &SceneWorld) -> Color {
+    pub fn ray_color(&self, mut ray: Ray, scene_world: &SceneWorld) -> ColorRgb {
         let mut rng = rand::rng();
 
-        // accumulated color contributions of each geometric we intersect along the rays' paths.
-        let mut accumulated_color = Color::BLACK;
-        // accumulated attentuation (color) of surfaces we encounter.
-        // unless we find a dual reflective/emissive surface, this is will always deteriorate in value,
-        // which represents that only a portion of the light received from that point will be reflected instead of absorbed.
-        let mut attentuation_strength = Color::WHITE;
+        // pick 4 stratified random hero wavelengths for this camera ray
+        let hero_wavelengths = HeroWavelengths::new_distributed();
 
-        // iterate over geometrics until we fail to intersect, reach max bounces, or find a non-reflective surface
+        // per-wavelength accumulated radiance (scalar)
+        let mut accumulated = Vector::<HERO_WAVELENGTH_COUNT>::ZERO;
+        // per-wavelength attenuation throughput (scalar)
+        let mut attenuation = Vector::<HERO_WAVELENGTH_COUNT>::ONE;
+
         let mut bounces = 0;
         while let Some(ray_hit) = scene_world
             .world
             .intersect(ray, Interval::new(0.001, f64::INFINITY))
         {
+            // emissive contribution at each hero wavelength
             let emittance = ray_hit
                 .material
                 .emittance(ray_hit.u, ray_hit.v, ray_hit.point);
-
-            // update our accumulated color
-            accumulated_color += attentuation_strength * emittance;
+            accumulated += attenuation * emittance.sample(&hero_wavelengths);
 
             if bounces >= self.bounces.max {
-                return accumulated_color;
+                // convert accumulated spectral samples to RGB and return
+                return hero_wavelengths.to_color_rgb(accumulated);
             }
 
-            // early termination: if the surface absorbs all light, skip scatter
-            if ray_hit
+            // early termination: if surface absorbs all light at all wavelengths
+            let reflectance = ray_hit
                 .material
-                .reflectance(ray_hit.u, ray_hit.v, ray_hit.point)
-                == Color::BLACK
-            {
-                return accumulated_color;
+                .reflectance(ray_hit.u, ray_hit.v, ray_hit.point);
+            if reflectance.is_black() {
+                return hero_wavelengths.to_color_rgb(accumulated);
             }
 
             let Some(srec) = ray_hit.material.scatter(ray, &ray_hit) else {
-                return accumulated_color;
+                return hero_wavelengths.to_color_rgb(accumulated);
             };
 
-            // unit vector from surface toward the camera (outgoing direction for BRDF)
             let outgoing_direction = (-ray.direction).unit_vector();
 
             match srec {
                 ScatterRecord::Delta { scattered } => {
-                    // specular or dielectric materials, which really only have a discrete scatter direction, and not a distribution over 3D space.
-                    //
-                    // essentially, this is a special case that sidesteps the BRDF + PDF evaluation
+                    // specular / dielectric — attenuation scales by reflectance at each wavelength
                     let reflectance =
                         ray_hit
                             .material
                             .reflectance(ray_hit.u, ray_hit.v, ray_hit.point);
-
-                    attentuation_strength *= reflectance;
-
+                    attenuation *= reflectance.sample(&hero_wavelengths);
                     ray = scattered
                 }
                 ScatterRecord::Pdf(scatter_pdf) => {
@@ -242,21 +239,20 @@ impl Camera {
                         let pdf_val = pdf.strategy_density(incident_direction, index_of_strategy);
                         let mis_weight = pdf.power_heuristic(incident_direction, index_of_strategy);
 
-                        // degenerate sample from grazing-angle/proximity rejection in geometric direction_pdf
                         if pdf_val <= 0.0 {
-                            return accumulated_color;
+                            return hero_wavelengths.to_color_rgb(accumulated);
                         }
 
-                        attentuation_strength *= brdf_val * cos_theta * mis_weight / pdf_val;
+                        attenuation *=
+                            brdf_val.sample(&hero_wavelengths) * (cos_theta * mis_weight / pdf_val);
                     } else {
                         let pdf_val = pdf.density(incident_direction);
 
-                        // degenerate sample from grazing-angle/proximity rejection in geometric direction_pdf
                         if pdf_val <= 0.0 {
-                            return accumulated_color;
+                            return hero_wavelengths.to_color_rgb(accumulated);
                         }
 
-                        attentuation_strength *= brdf_val * cos_theta / pdf_val;
+                        attenuation *= brdf_val.sample(&hero_wavelengths) * (cos_theta / pdf_val);
                     }
 
                     ray = Ray::new(ray_hit.point, incident_direction, ray.time)
@@ -265,35 +261,22 @@ impl Camera {
 
             bounces += 1;
 
-            // Russian roulette: probabilistically terminate paths with low remaining
-            // throughput once we're past the configured threshold. The survival
-            // probability p is the largest RGB component of the current attenuation
-            // (max-component luminance heuristic), clamped to [0, 1].
-            // Survivors are scaled by 1/p to maintain an unbiased estimator.
+            // Russian roulette: use max attenuation across all hero wavelengths
             if let Some(after) = self.bounces.use_russian_roulette_after
                 && bounces > after
             {
-                let p = attentuation_strength.max_component().min(1.0);
+                let p = attenuation.iter().fold(0.0_f64, |a, &b| a.max(b)).min(1.0);
                 if rng.random::<f64>() > p {
-                    return accumulated_color;
+                    return hero_wavelengths.to_color_rgb(accumulated);
                 }
-                attentuation_strength /= p;
+                attenuation /= p;
             }
         }
 
-        // at this point, we must have failed to intersect.
-        //
-        // normally, we could just return the background color.
-        // however, because of a design decision I made, it is completely possible
-        // to have a material be both reflective and emissive. this means we need to
-        // account for cases where the accumulated_color is non-zero due to emissive
-        // materials AND the ray is reflected.
+        // ray missed — add background contribution
+        accumulated += attenuation * self.background_color.sample(&hero_wavelengths);
 
-        // first, update our accumulated color to account for a non-black background
-        accumulated_color += attentuation_strength * self.background_color;
-
-        // then, we can finally return the accumulated color
-        accumulated_color
+        hero_wavelengths.to_color_rgb(accumulated)
     }
 }
 

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -10,7 +10,7 @@ use textures::TextureRefOrInline;
 use crate::{
     camera::Camera,
     geometry::Geometric,
-    shading::{Color, Texture, materials::Material},
+    shading::{ColorRgb, Texture, materials::Material},
     tracing::{RenderParameters, Scene},
     utils::{Angle, Around},
 };
@@ -350,19 +350,19 @@ fn prefix_builtin_key(key: &str) -> String {
 fn get_builtin_textures() -> IndexMap<String, TextureData> {
     indexmap! {
         prefix_builtin_key("white") => TextureData::SolidColor {
-            color: Color::WHITE.into()
+            color: ColorRgb::WHITE.into()
          },
         prefix_builtin_key("black") => TextureData::SolidColor {
-            color: Color::BLACK.into()
+            color: ColorRgb::BLACK.into()
         },
         prefix_builtin_key("red") => TextureData::SolidColor {
-             color: Color::RED.into()
+             color: ColorRgb::RED.into()
             },
         prefix_builtin_key("green") => TextureData::SolidColor {
-            color: Color::GREEN.into()
+            color: ColorRgb::GREEN.into()
          },
         prefix_builtin_key("blue") => TextureData::SolidColor {
-            color: Color::BLUE.into()
+            color: ColorRgb::BLUE.into()
         },
         // cornell box colors
         prefix_builtin_key("cornell_box_white") => TextureData::SolidColor {

--- a/src/deserialization/scenes.rs
+++ b/src/deserialization/scenes.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::shading::ColorRgb;
 use crate::tracing::{Scene, SceneWorld};
 
 use super::{Build, Builts, cameras::CameraRefOrInline, geometrics::GeometricRefOrInline};
@@ -55,7 +56,7 @@ impl Build<Scene> for SceneData {
         let scene = Scene {
             world: SceneWorld::from_geometrics(&world, &world_virtual, self.use_bvh),
             camera,
-            background_color: self.background_color.into(),
+            background_color: ColorRgb::from(self.background_color).into(),
         };
 
         Ok(scene)

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -21,5 +21,8 @@ pub use ray_hit::RayHit;
 mod ray;
 pub use ray::Ray;
 
-mod vector;
+mod vector3;
 pub use vector::Vector;
+pub use vector3::Vector3;
+
+mod vector;

--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -3,7 +3,7 @@ use std::ops::{Index, IndexMut};
 use auto_ops::{impl_op_ex, impl_op_ex_commutative};
 
 use crate::{
-    geometry::{Point, Ray, Vector},
+    geometry::{Point, Ray, Vector3},
     utils::Interval,
 };
 
@@ -139,7 +139,7 @@ impl IndexMut<usize> for Aabb {
     }
 }
 
-impl_op_ex_commutative!(+ |a: &Aabb, b: &Vector| -> Aabb {
+impl_op_ex_commutative!(+ |a: &Aabb, b: &Vector3| -> Aabb {
     Aabb {
         x_interval: a.x_interval + b.x,
         y_interval: a.y_interval + b.y,
@@ -147,13 +147,13 @@ impl_op_ex_commutative!(+ |a: &Aabb, b: &Vector| -> Aabb {
     }
 });
 
-impl_op_ex!(+= |a: &mut Aabb, b: &Vector| {
+impl_op_ex!(+= |a: &mut Aabb, b: &Vector3| {
     a.x_interval += b.x;
     a.y_interval += b.y;
     a.z_interval += b.z;
 });
 
-impl_op_ex!(-|a: &Aabb, b: &Vector| -> Aabb {
+impl_op_ex!(-|a: &Aabb, b: &Vector3| -> Aabb {
     Aabb {
         x_interval: a.x_interval - b.x,
         y_interval: a.y_interval - b.y,
@@ -161,7 +161,7 @@ impl_op_ex!(-|a: &Aabb, b: &Vector| -> Aabb {
     }
 });
 
-impl_op_ex!(-= |a: &mut Aabb, b: &Vector|  {
+impl_op_ex!(-= |a: &mut Aabb, b: &Vector3|  {
     a.x_interval -= b.x;
     a.y_interval -= b.y;
     a.z_interval -= b.z;

--- a/src/geometry/compounds/axis_aligned_pbox.rs
+++ b/src/geometry/compounds/axis_aligned_pbox.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector, primitives::Parallelogram},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3, primitives::Parallelogram},
     shading::materials::Material,
     utils::Interval,
 };
@@ -16,9 +16,9 @@ impl AxisAlignedPBox {
         let min = a.min_components_point(b);
         let max = a.max_components_point(b);
 
-        let dx = Vector::new(max.0.x - min.0.x, 0.0, 0.0);
-        let dy = Vector::new(0.0, max.0.y - min.0.y, 0.0);
-        let dz = Vector::new(0.0, 0.0, max.0.z - min.0.z);
+        let dx = Vector3::new(max.0.x - min.0.x, 0.0, 0.0);
+        let dy = Vector3::new(0.0, max.0.y - min.0.y, 0.0);
+        let dz = Vector3::new(0.0, 0.0, max.0.z - min.0.z);
 
         let mut faces = List::new();
         // front
@@ -103,11 +103,11 @@ impl Geometric for AxisAlignedPBox {
         self.0.bounding_box()
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         self.0.sample_direction_from(origin)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         self.0.direction_pdf(origin, dir)
     }
 }

--- a/src/geometry/compounds/bvh.rs
+++ b/src/geometry/compounds/bvh.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, sync::Arc};
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     utils::Interval,
 };
 
@@ -157,14 +157,14 @@ impl Geometric for Bvh {
         self.bounding_box
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         match &self.tree {
             BvhNode::Branch { left, right } => {
                 let left_area = left.surface_area();
                 let right_area = right.surface_area();
                 let total = left_area + right_area;
                 if total <= 0.0 {
-                    return Vector::random_unit();
+                    return Vector3::random_unit();
                 }
                 if rand::random::<f64>() * total <= left_area {
                     left.sample_direction_from(origin)
@@ -173,11 +173,11 @@ impl Geometric for Bvh {
                 }
             }
             BvhNode::Leaf(item) => item.sample_direction_from(origin),
-            BvhNode::Empty => Vector::random_unit(),
+            BvhNode::Empty => Vector3::random_unit(),
         }
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         match &self.tree {
             BvhNode::Branch { left, right } => {
                 let total = left.surface_area() + right.surface_area();

--- a/src/geometry/compounds/list.rs
+++ b/src/geometry/compounds/list.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     utils::Interval,
 };
 
@@ -106,10 +106,10 @@ impl Geometric for List {
         self.bounding_box
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         let total_area = self.surface_area();
         if total_area <= 0.0 {
-            return Vector::random_unit();
+            return Vector3::random_unit();
         }
         let mut threshold: f64 = rand::random::<f64>() * total_area;
         for item in &self.items {
@@ -123,7 +123,7 @@ impl Geometric for List {
         self.items.last().unwrap().sample_direction_from(origin)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         let total_area = self.surface_area();
         if total_area <= 0.0 {
             return 0.0;

--- a/src/geometry/compounds/model_obj.rs
+++ b/src/geometry/compounds/model_obj.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector, primitives::Triangle},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3, primitives::Triangle},
     shading::materials::Material,
     utils::Interval,
 };
@@ -78,7 +78,7 @@ impl ModelObj {
                 let a_normal = if recalculate_normals {
                     a.to(b).cross(a.to(c)).unit_vector()
                 } else {
-                    Vector::new(
+                    Vector3::new(
                         mesh.normals[a_index * 3] as f64,
                         mesh.normals[a_index * 3 + 1] as f64,
                         mesh.normals[a_index * 3 + 2] as f64,
@@ -88,7 +88,7 @@ impl ModelObj {
                 let b_normal = if recalculate_normals {
                     a.to(b).cross(a.to(c)).unit_vector()
                 } else {
-                    Vector::new(
+                    Vector3::new(
                         mesh.normals[b_index * 3] as f64,
                         mesh.normals[b_index * 3 + 1] as f64,
                         mesh.normals[b_index * 3 + 2] as f64,
@@ -98,7 +98,7 @@ impl ModelObj {
                 let c_normal = if recalculate_normals {
                     a.to(b).cross(a.to(c)).unit_vector()
                 } else {
-                    Vector::new(
+                    Vector3::new(
                         mesh.normals[c_index * 3] as f64,
                         mesh.normals[c_index * 3 + 1] as f64,
                         mesh.normals[c_index * 3 + 2] as f64,
@@ -106,9 +106,9 @@ impl ModelObj {
                     .unit_vector()
                 };
 
-                let transformed_a = Point::from_vector(a.0 * scale) + offset;
-                let transformed_b = Point::from_vector(b.0 * scale) + offset;
-                let transformed_c = Point::from_vector(c.0 * scale) + offset;
+                let transformed_a = Point::from_vector3(a.0 * scale) + offset;
+                let transformed_b = Point::from_vector3(b.0 * scale) + offset;
+                let transformed_c = Point::from_vector3(c.0 * scale) + offset;
 
                 triangles.push(Arc::new(Triangle::new_with_normals(
                     transformed_a,
@@ -162,11 +162,11 @@ impl Geometric for ModelObj {
         self.geometric.bounding_box()
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         self.geometric.sample_direction_from(origin)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         self.geometric.direction_pdf(origin, dir)
     }
 }
@@ -227,14 +227,14 @@ impl Geometric for ListOrBvh {
         }
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         match self {
             ListOrBvh::List(list) => list.sample_direction_from(origin),
             ListOrBvh::Bvh(bvh) => bvh.sample_direction_from(origin),
         }
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         match self {
             ListOrBvh::List(list) => list.direction_pdf(origin, dir),
             ListOrBvh::Bvh(bvh) => bvh.direction_pdf(origin, dir),

--- a/src/geometry/compounds/virtual.rs
+++ b/src/geometry/compounds/virtual.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     utils::Interval,
 };
 
@@ -58,11 +58,11 @@ impl Geometric for Virtual {
         self.inner.bounding_box()
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         self.inner.sample_direction_from(origin)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         self.inner.direction_pdf(origin, dir)
     }
 }

--- a/src/geometry/geometric.rs
+++ b/src/geometry/geometric.rs
@@ -1,5 +1,5 @@
 use crate::{
-    geometry::{Point, Vector},
+    geometry::{Point, Vector3},
     utils::Interval,
 };
 
@@ -26,7 +26,7 @@ pub trait Geometric: std::fmt::Debug + Sync + Send {
 
     /// Sample a random direction from `origin` toward a point on this object's
     /// surface, chosen uniformly by area. The returned direction is a unit vector.
-    fn sample_direction_from(&self, origin: Point) -> Vector;
+    fn sample_direction_from(&self, origin: Point) -> Vector3;
     /// The solid-angle probability density that [`sample_direction_from`] would
     /// assign to `dir`. Returns 0.0 if `dir` does not intersect this object.
     ///
@@ -40,7 +40,7 @@ pub trait Geometric: std::fmt::Debug + Sync + Send {
     /// where `distance` is the ray parameter at the hit point, `cos(θ_light)`
     /// is the absolute cosine between the direction and the surface normal at
     /// the hit, and `area` is the total surface area.
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64;
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64;
 
     /// Whether this geometric is "virtual" — excluded from ray intersections
     /// but included in importance sampling for faster convergence.

--- a/src/geometry/instances/rotate_x_axis.rs
+++ b/src/geometry/instances/rotate_x_axis.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     utils::{Angle, Around, Interval},
 };
 
 #[derive(Clone, Debug)]
 pub struct RotateXAxis {
     geometric: Arc<dyn Geometric>,
-    translation: Vector,
+    translation: Vector3,
     sin_theta: f64,
     cos_theta: f64,
     bounding_box: Aabb,
@@ -58,25 +58,25 @@ impl RotateXAxis {
     }
 
     fn world_to_local_point(&self, v: Point) -> Point {
-        Point::from_vector(self.world_to_local_vector(v.0 - self.translation)) + self.translation
+        Point::from_vector3(self.world_to_local_vector(v.0 - self.translation)) + self.translation
     }
 
-    fn world_to_local_vector(&self, v: Vector) -> Vector {
+    fn world_to_local_vector(&self, v: Vector3) -> Vector3 {
         let y = self.cos_theta * v.y + self.sin_theta * v.z;
         let z = -self.sin_theta * v.y + self.cos_theta * v.z;
 
-        Vector::new(v.x, y, z)
+        Vector3::new(v.x, y, z)
     }
 
     fn local_to_world_point(&self, v: Point) -> Point {
-        Point::from_vector(self.local_to_world_vector(v.0 - self.translation)) + self.translation
+        Point::from_vector3(self.local_to_world_vector(v.0 - self.translation)) + self.translation
     }
 
-    fn local_to_world_vector(&self, v: Vector) -> Vector {
+    fn local_to_world_vector(&self, v: Vector3) -> Vector3 {
         let y = self.cos_theta * v.y - self.sin_theta * v.z;
         let z = self.sin_theta * v.y + self.cos_theta * v.z;
 
-        Vector::new(v.x, y, z)
+        Vector3::new(v.x, y, z)
     }
 }
 
@@ -121,13 +121,13 @@ impl Geometric for RotateXAxis {
         self.bounding_box
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         let local_origin = self.world_to_local_point(origin);
         let local_dir = self.geometric.sample_direction_from(local_origin);
         self.local_to_world_vector(local_dir)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         let local_origin = self.world_to_local_point(origin);
         let local_dir = self.world_to_local_vector(dir);
         // PDF is invariant under rigid transforms

--- a/src/geometry/instances/rotate_y_axis.rs
+++ b/src/geometry/instances/rotate_y_axis.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     utils::{Angle, Around, Interval},
 };
 
 #[derive(Clone, Debug)]
 pub struct RotateYAxis {
     geometric: Arc<dyn Geometric>,
-    translation: Vector,
+    translation: Vector3,
     sin_theta: f64,
     cos_theta: f64,
     bounding_box: Aabb,
@@ -58,25 +58,25 @@ impl RotateYAxis {
     }
 
     fn world_to_local_point(&self, v: Point) -> Point {
-        Point::from_vector(self.world_to_local_vector(v.0 - self.translation)) + self.translation
+        Point::from_vector3(self.world_to_local_vector(v.0 - self.translation)) + self.translation
     }
 
-    fn world_to_local_vector(&self, v: Vector) -> Vector {
+    fn world_to_local_vector(&self, v: Vector3) -> Vector3 {
         let x = self.cos_theta * v.x - self.sin_theta * v.z;
         let z = self.sin_theta * v.x + self.cos_theta * v.z;
 
-        Vector::new(x, v.y, z)
+        Vector3::new(x, v.y, z)
     }
 
     fn local_to_world_point(&self, v: Point) -> Point {
-        Point::from_vector(self.local_to_world_vector(v.0 - self.translation)) + self.translation
+        Point::from_vector3(self.local_to_world_vector(v.0 - self.translation)) + self.translation
     }
 
-    fn local_to_world_vector(&self, v: Vector) -> Vector {
+    fn local_to_world_vector(&self, v: Vector3) -> Vector3 {
         let x = self.cos_theta * v.x + self.sin_theta * v.z;
         let z = -self.sin_theta * v.x + self.cos_theta * v.z;
 
-        Vector::new(x, v.y, z)
+        Vector3::new(x, v.y, z)
     }
 }
 
@@ -121,13 +121,13 @@ impl Geometric for RotateYAxis {
         self.bounding_box
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         let local_origin = self.world_to_local_point(origin);
         let local_dir = self.geometric.sample_direction_from(local_origin);
         self.local_to_world_vector(local_dir)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         let local_origin = self.world_to_local_point(origin);
         let local_dir = self.world_to_local_vector(dir);
         // PDF is invariant under rigid transforms

--- a/src/geometry/instances/rotate_z_axis.rs
+++ b/src/geometry/instances/rotate_z_axis.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     utils::{Angle, Around, Interval},
 };
 
 #[derive(Clone, Debug)]
 pub struct RotateZAxis {
     geometric: Arc<dyn Geometric>,
-    translation: Vector,
+    translation: Vector3,
     sin_theta: f64,
     cos_theta: f64,
     bounding_box: Aabb,
@@ -58,25 +58,25 @@ impl RotateZAxis {
     }
 
     fn world_to_local_point(&self, v: Point) -> Point {
-        Point::from_vector(self.world_to_local_vector(v.0 - self.translation)) + self.translation
+        Point::from_vector3(self.world_to_local_vector(v.0 - self.translation)) + self.translation
     }
 
-    fn world_to_local_vector(&self, v: Vector) -> Vector {
+    fn world_to_local_vector(&self, v: Vector3) -> Vector3 {
         let x = self.cos_theta * v.x + self.sin_theta * v.y;
         let y = -self.sin_theta * v.x + self.cos_theta * v.y;
 
-        Vector::new(x, y, v.z)
+        Vector3::new(x, y, v.z)
     }
 
     fn local_to_world_point(&self, v: Point) -> Point {
-        Point::from_vector(self.local_to_world_vector(v.0 - self.translation)) + self.translation
+        Point::from_vector3(self.local_to_world_vector(v.0 - self.translation)) + self.translation
     }
 
-    fn local_to_world_vector(&self, v: Vector) -> Vector {
+    fn local_to_world_vector(&self, v: Vector3) -> Vector3 {
         let x = self.cos_theta * v.x - self.sin_theta * v.y;
         let y = self.sin_theta * v.x + self.cos_theta * v.y;
 
-        Vector::new(x, y, v.z)
+        Vector3::new(x, y, v.z)
     }
 }
 
@@ -121,13 +121,13 @@ impl Geometric for RotateZAxis {
         self.bounding_box
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         let local_origin = self.world_to_local_point(origin);
         let local_dir = self.geometric.sample_direction_from(local_origin);
         self.local_to_world_vector(local_dir)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         let local_origin = self.world_to_local_point(origin);
         let local_dir = self.world_to_local_vector(dir);
         // PDF is invariant under rigid transforms

--- a/src/geometry/instances/translate.rs
+++ b/src/geometry/instances/translate.rs
@@ -1,19 +1,19 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     utils::Interval,
 };
 
 #[derive(Clone, Debug)]
 pub struct Translate {
     geometric: Arc<dyn Geometric>,
-    translation: Vector,
+    translation: Vector3,
     bounding_box: Aabb,
 }
 
 impl Translate {
-    pub fn new(geometric: Arc<dyn Geometric>, translation: Vector) -> Self {
+    pub fn new(geometric: Arc<dyn Geometric>, translation: Vector3) -> Self {
         let bounding_box = geometric.bounding_box() + translation;
         Self {
             geometric: Arc::clone(&geometric),
@@ -22,11 +22,11 @@ impl Translate {
         }
     }
 
-    fn world_to_local(&self, v: Vector) -> Vector {
+    fn world_to_local(&self, v: Vector3) -> Vector3 {
         v - self.translation
     }
 
-    fn local_to_world(&self, v: Vector) -> Vector {
+    fn local_to_world(&self, v: Vector3) -> Vector3 {
         v + self.translation
     }
 }
@@ -67,14 +67,14 @@ impl Geometric for Translate {
         self.bounding_box
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
-        let local_origin = Point::from_vector(self.world_to_local(origin.0));
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
+        let local_origin = Point::from_vector3(self.world_to_local(origin.0));
         // direction is invariant under translation
         self.geometric.sample_direction_from(local_origin)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
-        let local_origin = Point::from_vector(self.world_to_local(origin.0));
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
+        let local_origin = Point::from_vector3(self.world_to_local(origin.0));
         // direction is invariant under translation; PDF is invariant
         self.geometric.direction_pdf(local_origin, dir)
     }

--- a/src/geometry/onb.rs
+++ b/src/geometry/onb.rs
@@ -1,4 +1,4 @@
-use crate::geometry::vector::Vector;
+use crate::geometry::Vector3;
 
 /// An orthonormal basis {u, v, w} for orienting Z-axis-relative
 /// direction vectors to an arbitrary surface normal.
@@ -7,9 +7,9 @@ use crate::geometry::vector::Vector;
 /// tangent plane perpendicular to `w`.
 #[derive(Debug, Clone, Copy)]
 pub struct Onb {
-    pub u: Vector,
-    pub v: Vector,
-    pub w: Vector,
+    pub u: Vector3,
+    pub v: Vector3,
+    pub w: Vector3,
 }
 
 impl Onb {
@@ -18,17 +18,17 @@ impl Onb {
     /// Picks an auxiliary vector that is not parallel to `normal`,
     /// then builds `u`, `v` via cross products so that `{u, v, w}`
     /// forms a right-handed orthonormal basis.
-    pub fn from_w(normal: Vector) -> Self {
+    pub fn from_w(normal: Vector3) -> Self {
         let w = normal.unit_vector();
         let a = if w.x.abs() > 0.9 {
             // normal is nearly parallel to +X — use +Y as auxiliary
-            Vector {
+            Vector3 {
                 x: 0.0,
                 y: 1.0,
                 z: 0.0,
             }
         } else {
-            Vector {
+            Vector3 {
                 x: 1.0,
                 y: 0.0,
                 z: 0.0,
@@ -45,7 +45,7 @@ impl Onb {
     /// For example, feeding this a cosine-weighted direction (biased
     /// toward +Z) produces a direction biased toward the surface normal
     /// in world space.
-    pub fn to_world(&self, v: Vector) -> Vector {
+    pub fn to_world(&self, v: Vector3) -> Vector3 {
         v.x * self.u + v.y * self.v + v.z * self.w
     }
 }

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -2,23 +2,23 @@ use std::ops::{Index, IndexMut, Neg};
 
 use auto_ops::impl_op_ex;
 
-use super::Vector;
+use super::Vector3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub struct Point(pub Vector);
+pub struct Point(pub Vector3);
 
 impl Point {
-    pub const ZERO: Point = Self(Vector::ZERO);
-    pub const ONE: Point = Self(Vector::ONE);
+    pub const ZERO: Point = Self(Vector3::ZERO);
+    pub const ONE: Point = Self(Vector3::ONE);
     pub const ORIGIN: Point = Self::ZERO;
-    pub const INFINITY: Point = Self(Vector::INFINITY);
+    pub const INFINITY: Point = Self(Vector3::INFINITY);
 
     pub fn new(x: f64, y: f64, z: f64) -> Self {
-        Self(Vector::new(x, y, z))
+        Self(Vector3::new(x, y, z))
     }
 
-    pub fn from_vector(vector: Vector) -> Self {
-        Self(vector)
+    pub fn from_vector3(vector3: Vector3) -> Self {
+        Self(vector3)
     }
 
     pub fn min_components_point(&self, other: Self) -> Point {
@@ -55,22 +55,22 @@ impl Point {
             .fold(-Point::INFINITY, |a, b| a.max_components_point(*b))
     }
 
-    pub fn to(&self, other: Self) -> Vector {
+    pub fn to(&self, other: Self) -> Vector3 {
         other - self
     }
 
-    pub fn from(&self, other: Self) -> Vector {
+    pub fn from(&self, other: Self) -> Vector3 {
         self - other
     }
 
-    pub fn as_vector(&self) -> Vector {
+    pub fn as_vector3(&self) -> Vector3 {
         self.0
     }
 }
 
 impl From<[f64; 3]> for Point {
     fn from(v: [f64; 3]) -> Self {
-        Self(Vector::new(v[0], v[1], v[2]))
+        Self(Vector3::new(v[0], v[1], v[2]))
     }
 }
 
@@ -78,7 +78,7 @@ impl Neg for Point {
     type Output = Point;
 
     fn neg(self) -> Self::Output {
-        Point::from_vector(self.0 * -1.0)
+        Point::from_vector3(self.0 * -1.0)
     }
 }
 
@@ -96,18 +96,18 @@ impl IndexMut<usize> for Point {
     }
 }
 
-impl_op_ex!(+ |a: &Point, b: &Vector| -> Point {
+impl_op_ex!(+ |a: &Point, b: &Vector3| -> Point {
     Point(a.0 + b)
 });
 
-impl_op_ex!(+= |a: &mut Point, b: &Vector| {
+impl_op_ex!(+= |a: &mut Point, b: &Vector3| {
     a.0 += b;
 });
 
-impl_op_ex!(-|a: &Point, b: &Point| -> Vector { a.0 - b.0 });
+impl_op_ex!(-|a: &Point, b: &Point| -> Vector3 { a.0 - b.0 });
 
-impl_op_ex!(-|a: &Point, b: &Vector| -> Point { Point(a.0 - b) });
+impl_op_ex!(-|a: &Point, b: &Vector3| -> Point { Point(a.0 - b) });
 
-impl_op_ex!(-= |a: &mut Point, b: &Vector|  {
+impl_op_ex!(-= |a: &mut Point, b: &Vector3|  {
     a.0 -= b;
 });

--- a/src/geometry/primitives/parallelogram.rs
+++ b/src/geometry/primitives/parallelogram.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     shading::materials::{Lambertian, Material},
     utils::Interval,
 };
@@ -9,12 +9,12 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct Parallelogram {
     lower_left: Point,
-    u: Vector,
-    v: Vector,
-    normal: Vector,
+    u: Vector3,
+    v: Vector3,
+    normal: Vector3,
     is_culled: bool,
     plane_d: f64,
-    w: Vector,
+    w: Vector3,
     material: Arc<dyn Material>,
     bounding_box: Aabb,
     area: f64, // cache this because it's used quite often in sampling
@@ -23,8 +23,8 @@ pub struct Parallelogram {
 impl Parallelogram {
     pub fn new(
         lower_left: Point,
-        u: Vector,
-        v: Vector,
+        u: Vector3,
+        v: Vector3,
         is_culled: bool,
         material: Arc<dyn Material>,
     ) -> Self {
@@ -47,8 +47,8 @@ impl Parallelogram {
     pub fn unit() -> Self {
         Self::new(
             Point::new(-0.5, -0.5, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             true,
             Arc::new(Lambertian::white()),
         )
@@ -131,7 +131,7 @@ impl Geometric for Parallelogram {
         self.bounding_box
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         let alpha: f64 = rand::random();
         let beta: f64 = rand::random();
         let p = self.lower_left + alpha * self.u + beta * self.v;
@@ -139,7 +139,7 @@ impl Geometric for Parallelogram {
         origin.to(p).unit_vector()
     }
 
-    fn direction_pdf(&self, origin: Point, direction: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, direction: Vector3) -> f64 {
         // go from the origin to the hit point
         let ray = Ray::new(origin, direction, 0.0);
 
@@ -170,20 +170,20 @@ mod tests {
     fn hits_unculled_front_center() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             false,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(0.5, 0.5, 1.0), Vector::new(0.0, 0.0, -1.0), 0.0);
+        let ray = Ray::new(Point::new(0.5, 0.5, 1.0), Vector3::new(0.0, 0.0, -1.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
         assert!(opt_hit.is_some());
         let hit = opt_hit.unwrap();
 
-        assert_eq!(hit.normal, Vector::new(0.0, 0.0, 1.0));
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, 1.0));
         assert_eq!(hit.u, 0.5);
         assert_eq!(hit.v, 0.5);
         assert_eq!(hit.point, Point::new(0.5, 0.5, 0.0));
@@ -194,20 +194,20 @@ mod tests {
     fn hits_unculled_back_center() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             false,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(0.5, 0.5, -1.0), Vector::new(0.0, 0.0, 1.0), 0.0);
+        let ray = Ray::new(Point::new(0.5, 0.5, -1.0), Vector3::new(0.0, 0.0, 1.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
         assert!(opt_hit.is_some());
         let hit = opt_hit.unwrap();
 
-        assert_eq!(hit.normal, Vector::new(0.0, 0.0, -1.0));
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, -1.0));
         assert_eq!(hit.u, 0.5);
         assert_eq!(hit.v, 0.5);
         assert_eq!(hit.point, Point::new(0.5, 0.5, 0.0));
@@ -218,20 +218,20 @@ mod tests {
     fn hits_culled_front_center() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             true,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(0.5, 0.5, 1.0), Vector::new(0.0, 0.0, -1.0), 0.0);
+        let ray = Ray::new(Point::new(0.5, 0.5, 1.0), Vector3::new(0.0, 0.0, -1.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
         assert!(opt_hit.is_some());
         let hit = opt_hit.unwrap();
 
-        assert_eq!(hit.normal, Vector::new(0.0, 0.0, 1.0));
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, 1.0));
         assert_eq!(hit.u, 0.5);
         assert_eq!(hit.v, 0.5);
         assert_eq!(hit.point, Point::new(0.5, 0.5, 0.0));
@@ -242,13 +242,13 @@ mod tests {
     fn misses_culled_back_center() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             true,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(0.5, 0.5, -1.0), Vector::new(0.0, 0.0, 1.0), 0.0);
+        let ray = Ray::new(Point::new(0.5, 0.5, -1.0), Vector3::new(0.0, 0.0, 1.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
@@ -259,13 +259,13 @@ mod tests {
     fn misses_to_right() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             false,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(1.5, 0.5, 1.0), Vector::new(0.0, 0.0, -1.0), 0.0);
+        let ray = Ray::new(Point::new(1.5, 0.5, 1.0), Vector3::new(0.0, 0.0, -1.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
@@ -276,13 +276,13 @@ mod tests {
     fn misses_above() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             false,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(0.5, 1.5, 1.0), Vector::new(0.0, 0.0, -1.0), 0.0);
+        let ray = Ray::new(Point::new(0.5, 1.5, 1.0), Vector3::new(0.0, 0.0, -1.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
@@ -293,13 +293,13 @@ mod tests {
     fn misses_off_plane_parallel() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             false,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(0.5, 0.5, 1.0), Vector::new(1.0, 0.0, 0.0), 0.0);
+        let ray = Ray::new(Point::new(0.5, 0.5, 1.0), Vector3::new(1.0, 0.0, 0.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
@@ -310,13 +310,13 @@ mod tests {
     fn misses_on_plane_parallel() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             false,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(0.5, 0.5, 0.0), Vector::new(1.0, 0.0, 0.0), 0.0);
+        let ray = Ray::new(Point::new(0.5, 0.5, 0.0), Vector3::new(1.0, 0.0, 0.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
@@ -327,20 +327,20 @@ mod tests {
     fn hits_edge() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             true,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(0.0, 0.5, 1.0), Vector::new(0.0, 0.0, -1.0), 0.0);
+        let ray = Ray::new(Point::new(0.0, 0.5, 1.0), Vector3::new(0.0, 0.0, -1.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
         assert!(opt_hit.is_some());
         let hit = opt_hit.unwrap();
 
-        assert_eq!(hit.normal, Vector::new(0.0, 0.0, 1.0));
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, 1.0));
         assert_eq!(hit.u, 0.0);
         assert_eq!(hit.v, 0.5);
         assert_eq!(hit.point, Point::new(0.0, 0.5, 0.0));
@@ -351,20 +351,20 @@ mod tests {
     fn hits_corner() {
         let p = Parallelogram::new(
             Point::new(0.0, 0.0, 0.0),
-            Vector::new(1.0, 0.0, 0.0),
-            Vector::new(0.0, 1.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             true,
             Arc::new(Lambertian::white()),
         );
 
-        let ray = Ray::new(Point::new(0.0, 0.0, 1.0), Vector::new(0.0, 0.0, -1.0), 0.0);
+        let ray = Ray::new(Point::new(0.0, 0.0, 1.0), Vector3::new(0.0, 0.0, -1.0), 0.0);
         let ray_t = Interval::new(0.0, f64::INFINITY);
 
         let opt_hit = p.intersect(ray, ray_t);
         assert!(opt_hit.is_some());
         let hit = opt_hit.unwrap();
 
-        assert_eq!(hit.normal, Vector::new(0.0, 0.0, 1.0));
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, 1.0));
         assert_eq!(hit.u, 0.0);
         assert_eq!(hit.v, 0.0);
         assert_eq!(hit.point, Point::new(0.0, 0.0, 0.0));

--- a/src/geometry/primitives/sphere.rs
+++ b/src/geometry/primitives/sphere.rs
@@ -1,7 +1,7 @@
 use std::{f64::consts::PI, sync::Arc};
 
 use crate::{
-    geometry::{Aabb, Geometric, Onb, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Onb, Point, Ray, RayHit, Vector3},
     shading::materials::{Lambertian, Material},
     utils::Interval,
 };
@@ -9,7 +9,7 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct Sphere {
     center_1: Point,
-    center_vector: Option<Vector>,
+    center_vector: Option<Vector3>,
     radius: f64,
     material: Arc<dyn Material>,
     bounding_box: Aabb,
@@ -17,7 +17,7 @@ pub struct Sphere {
 
 impl Sphere {
     pub fn new(center: Point, radius: f64, material: Arc<dyn Material>) -> Self {
-        let radius_vector = Vector::new(radius, radius, radius);
+        let radius_vector = Vector3::new(radius, radius, radius);
         Self {
             center_1: center,
             center_vector: None,
@@ -33,7 +33,7 @@ impl Sphere {
         radius: f64,
         material: Arc<dyn Material>,
     ) -> Self {
-        let radius_vector = Vector::new(radius, radius, radius);
+        let radius_vector = Vector3::new(radius, radius, radius);
         let bounding_box_1 =
             Aabb::from_points(&[center_1 - radius_vector, center_1 + radius_vector]);
         let bounding_box_2 =
@@ -65,14 +65,14 @@ impl Sphere {
     /// Generate a random direction within the cone that subtends the sphere
     /// from a point at `distance_squared` away. The result is in the local
     /// frame where +Z points toward the sphere center.
-    fn random_to_sphere(radius: f64, distance_squared: f64) -> Vector {
+    fn random_to_sphere(radius: f64, distance_squared: f64) -> Vector3 {
         let r1: f64 = rand::random();
         let r2: f64 = rand::random();
         let cos_theta_max = (1.0 - radius * radius / distance_squared).sqrt();
         let z = 1.0 + r2 * (cos_theta_max - 1.0);
         let phi = 2.0 * PI * r1;
         let sin_theta = (1.0 - z * z).sqrt();
-        Vector::new(phi.cos() * sin_theta, phi.sin() * sin_theta, z)
+        Vector3::new(phi.cos() * sin_theta, phi.sin() * sin_theta, z)
     }
 
     fn uv(unit_point: Point) -> (f64, f64) {
@@ -114,7 +114,7 @@ impl Geometric for Sphere {
         }
 
         let point = ray.at(root);
-        let (u, v) = Self::uv(Point::from_vector(center.to(point).unit_vector()));
+        let (u, v) = Self::uv(Point::from_vector3(center.to(point).unit_vector()));
 
         Some(RayHit {
             t: root,
@@ -150,7 +150,7 @@ impl Geometric for Sphere {
         self.bounding_box
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         // sample the sphere as a cone from origin:
         // build an ONB with w pointing toward the sphere center,
         // then sample a direction uniformly within the cone subtended
@@ -161,7 +161,7 @@ impl Geometric for Sphere {
 
         // degenerate: origin inside the sphere — sample the full sphere
         if distance_squared <= self.radius * self.radius {
-            return Vector::random_unit();
+            return Vector3::random_unit();
         }
 
         let onb = Onb::from_w(to_center.unit_vector());
@@ -169,7 +169,7 @@ impl Geometric for Sphere {
         onb.to_world(local_dir)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         // go from origin to the hit point
         let ray = Ray::new(origin, dir, 0.0);
 

--- a/src/geometry/primitives/triangle.rs
+++ b/src/geometry/primitives/triangle.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     shading::materials::Material,
     utils::Interval,
 };
@@ -11,9 +11,9 @@ pub struct Triangle {
     a: Point,
     b: Point,
     c: Point,
-    a_normal: Vector,
-    b_normal: Vector,
-    c_normal: Vector,
+    a_normal: Vector3,
+    b_normal: Vector3,
+    c_normal: Vector3,
     is_culled: bool,
     material: Arc<dyn Material>,
     bounding_box: Aabb,
@@ -41,9 +41,9 @@ impl Triangle {
         a: Point,
         b: Point,
         c: Point,
-        a_normal: Option<Vector>,
-        b_normal: Option<Vector>,
-        c_normal: Option<Vector>,
+        a_normal: Option<Vector3>,
+        b_normal: Option<Vector3>,
+        c_normal: Option<Vector3>,
         is_culled: bool,
         material: Arc<dyn Material>,
     ) -> Self {
@@ -61,9 +61,9 @@ impl Triangle {
         a: Point,
         b: Point,
         c: Point,
-        a_normal: Vector,
-        b_normal: Vector,
-        c_normal: Vector,
+        a_normal: Vector3,
+        b_normal: Vector3,
+        c_normal: Vector3,
         is_culled: bool,
         material: Arc<dyn Material>,
     ) -> Self {
@@ -151,7 +151,7 @@ impl Triangle {
         barycentric_alpha: f64,
         barycentric_beta: f64,
         barycentric_gamma: f64,
-    ) -> Vector {
+    ) -> Vector3 {
         (barycentric_alpha * self.a_normal
             + barycentric_beta * self.b_normal
             + barycentric_gamma * self.c_normal)
@@ -188,7 +188,7 @@ impl Geometric for Triangle {
         self.bounding_box
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         // uniform sampling on a triangle using barycentric coordinates
         // with sqrt to correct for area concentration
         let r1: f64 = rand::random();
@@ -204,7 +204,7 @@ impl Geometric for Triangle {
         origin.to(p).unit_vector()
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         // go from the origin to the hit point
         let ray = Ray::new(origin, dir, 0.0);
 

--- a/src/geometry/ray.rs
+++ b/src/geometry/ray.rs
@@ -1,14 +1,14 @@
-use super::{Point, Vector};
+use super::{Point, Vector3};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Ray {
     pub origin: Point,
-    pub direction: Vector,
+    pub direction: Vector3,
     pub time: f64,
 }
 
 impl Ray {
-    pub fn new(origin: Point, direction: Vector, time: f64) -> Self {
+    pub fn new(origin: Point, direction: Vector3, time: f64) -> Self {
         Self {
             origin,
             direction,

--- a/src/geometry/ray_hit.rs
+++ b/src/geometry/ray_hit.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use crate::shading::materials::Material;
 
-use super::{Point, Vector};
+use super::{Point, Vector3};
 
 #[derive(Clone, Debug)]
 pub struct RayHit {
     pub t: f64,
     pub point: Point,
-    pub normal: Vector,
+    pub normal: Vector3,
     pub material: Arc<dyn Material>,
     pub u: f64,
     pub v: f64,

--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -1,342 +1,215 @@
-use std::{
-    f64::consts::PI,
-    ops::{Index, IndexMut, Neg},
-};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-use auto_ops::{impl_op_ex, impl_op_ex_commutative};
-use bincode::{Decode, Encode};
-use rand::RngExt;
+/// A fixed-size numeric array with element-wise arithmetic.
+///
+/// Unlike the geometric `Vector3`, this type has no geometric interpretation —
+/// no cross product, no normalization, no spatial semantics. It is purely
+/// for arithmetic on fixed-size arrays of scalars.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Vector<const N: usize>(pub [f64; N]);
 
-use crate::utils::Angle;
-
-#[derive(Debug, Copy, Clone, PartialEq, Default, Encode, Decode)]
-pub struct Vector {
-    pub x: f64,
-    pub y: f64,
-    pub z: f64,
-}
-
-impl Vector {
-    pub const ZERO: Self = Self {
-        x: 0.0,
-        y: 0.0,
-        z: 0.0,
-    };
-
-    pub const ONE: Self = Self {
-        x: 1.0,
-        y: 1.0,
-        z: 1.0,
-    };
-
-    pub const INFINITY: Self = Self {
-        x: f64::INFINITY,
-        y: f64::INFINITY,
-        z: f64::INFINITY,
-    };
-
-    pub const RIGHT: Self = Self {
-        x: 1.0,
-        y: 0.0,
-        z: 0.0,
-    };
-    pub const UNIT_X: Self = Self::RIGHT;
-
-    pub const UP: Self = Self {
-        x: 0.0,
-        y: 1.0,
-        z: 0.0,
-    };
-    pub const UNIT_Y: Self = Self::UP;
-
-    pub const FORWARD: Self = Self {
-        x: 0.0,
-        y: 0.0,
-        z: -1.0,
-    };
-
-    pub const UNIT_Z: Self = Self {
-        x: 0.0,
-        y: 0.0,
-        z: 1.0,
-    };
-
-    pub fn new(x: f64, y: f64, z: f64) -> Self {
-        Self { x, y, z }
-    }
-
-    pub fn random() -> Self {
-        Self::random_range(0.0, 1.0)
-    }
-
-    pub fn random_range(min: f64, max: f64) -> Self {
-        let mut rng = rand::rng();
-        Self {
-            x: rng.random_range(min..max),
-            y: rng.random_range(min..max),
-            z: rng.random_range(min..max),
-        }
-    }
-
-    pub fn random_in_unit_sphere() -> Self {
-        loop {
-            let p = Self::random_in_unit_cube();
-            if p.squared_length() < 1.0 {
-                return p;
-            }
-        }
-    }
-
-    pub fn random_in_unit_cube() -> Self {
-        let mut rng = rand::rng();
-        Self {
-            x: rng.random_range(-1.0..1.0),
-            y: rng.random_range(-1.0..1.0),
-            z: rng.random_range(-1.0..1.0),
-        }
-    }
-
-    pub fn random_in_unit_disk() -> Self {
-        let mut rng = rand::rng();
-        loop {
-            let p = Self {
-                x: rng.random_range(-1.0..1.0),
-                y: rng.random_range(-1.0..1.0),
-                z: 0.0,
-            };
-            if p.squared_length() < 1.0 {
-                return p;
-            }
-        }
-    }
-
-    pub fn random_unit() -> Self {
-        Self::random_in_unit_sphere().unit_vector()
-    }
-
-    pub fn random_on_hemisphere(normal: Self) -> Self {
-        let on_unit_sphere = Self::random_unit();
-        if on_unit_sphere.dot(normal) > 0.0 {
-            on_unit_sphere
-        } else {
-            -on_unit_sphere
-        }
-    }
-
-    /// generates a random unit direction on the +Z hemisphere with a
-    /// cosine-weighted distribution.  the direction is relative to +Z
-    /// (`z > 0` by construction), not world-space.  use an `Onb` to orient
-    /// the result to an arbitrary surface normal.
-    ///
-    /// implemented via malley's method: uniformly sample the unit disk and
-    /// project onto the hemisphere.
-    pub fn random_cosine_weighted_direction() -> Self {
-        let r1 = rand::random::<f64>();
-        let r2 = rand::random::<f64>();
-        let phi = 2.0 * PI * r1;
-        let sqrt_r2 = r2.sqrt();
-        Self {
-            x: phi.cos() * sqrt_r2,
-            y: phi.sin() * sqrt_r2,
-            z: (1.0 - r2).sqrt(),
-        }
-    }
-
-    pub fn length(&self) -> f64 {
-        self.squared_length().sqrt()
-    }
-
-    pub fn squared_length(&self) -> f64 {
-        self.x * self.x + self.y * self.y + self.z * self.z
-    }
-
-    pub fn de_nan(&self) -> Self {
-        Self {
-            x: if self.x.is_nan() { 0.0 } else { self.x },
-            y: if self.y.is_nan() { 0.0 } else { self.y },
-            z: if self.z.is_nan() { 0.0 } else { self.z },
-        }
-    }
-
-    pub fn normalize(&mut self) {
-        *self /= self.length();
-    }
-
-    pub fn unit_vector(&self) -> Self {
-        self / self.length()
-    }
-
-    pub fn is_near_zero(&self) -> bool {
-        let s = 1e-8;
-        self.x.abs() < s && self.y.abs() < s && self.z.abs() < s
-    }
-
-    pub fn angle(&self, other: Self) -> Angle {
-        Angle::Radians((self.dot(other) / (self.length() * other.length())).acos())
-    }
-
-    pub fn dot(&self, other: Self) -> f64 {
-        self.x * other.x + self.y * other.y + self.z * other.z
-    }
-
-    pub fn cross(&self, other: Self) -> Self {
-        Self {
-            x: self.y * other.z - self.z * other.y,
-            y: self.z * other.x - self.x * other.z,
-            z: self.x * other.y - self.y * other.x,
-        }
-    }
-
-    pub fn reflect_around(&self, normal: Self) -> Self {
-        self - 2.0 * self.dot(normal) * normal
-    }
-
-    pub fn refract_around(&self, normal: Self, etai_over_etat: f64) -> Self {
-        let cos_theta = (-*self).dot(normal).min(1.0);
-        let perpendicular_component = etai_over_etat * (self + cos_theta * normal);
-        let parallel_component = -((1.0 - perpendicular_component.squared_length())
-            .abs()
-            .sqrt())
-            * normal;
-        perpendicular_component + parallel_component
-    }
-
-    pub fn scale_down(&self, scale: f64) -> Self {
-        let max = self.x.max(self.y).max(self.z);
-        if max > scale {
-            *self / (max / scale)
-        } else {
-            *self
-        }
-    }
-
-    pub fn max_component(&self) -> f64 {
-        self.x.max(self.y).max(self.z)
+impl<const N: usize> Default for Vector<N> {
+    fn default() -> Self {
+        Self::ZERO
     }
 }
 
-impl From<[f64; 3]> for Vector {
-    fn from(v: [f64; 3]) -> Self {
-        Self {
-            x: v[0],
-            y: v[1],
-            z: v[2],
+impl<const N: usize> Vector<N> {
+    /// All elements set to zero.
+    pub const ZERO: Self = Self([0.0; N]);
+
+    /// All elements set to zero.
+    pub const ONE: Self = Self([1.0; N]);
+
+    /// Create from an array.
+    pub fn new(data: [f64; N]) -> Self {
+        Self(data)
+    }
+
+    /// Iterate over the elements by reference.
+    pub fn iter(&self) -> std::slice::Iter<'_, f64> {
+        self.0.iter()
+    }
+
+    /// Iterate over the elements mutably.
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, f64> {
+        self.0.iter_mut()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Element-wise operators (Vector<N> × Vector<N>)
+// ---------------------------------------------------------------------------
+
+impl<const N: usize> Add<&Vector<N>> for &Vector<N> {
+    type Output = Vector<N>;
+    fn add(self, rhs: &Vector<N>) -> Vector<N> {
+        let mut data = self.0;
+        for (x, &y) in data.iter_mut().zip(rhs.0.iter()) {
+            *x += y;
+        }
+        Vector(data)
+    }
+}
+
+impl<const N: usize> AddAssign<&Vector<N>> for Vector<N> {
+    fn add_assign(&mut self, rhs: &Vector<N>) {
+        for (x, &y) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *x += y;
         }
     }
 }
 
-impl Neg for Vector {
-    type Output = Vector;
-
-    fn neg(self) -> Self::Output {
-        self * -1.0
+impl<const N: usize> AddAssign<Vector<N>> for Vector<N> {
+    fn add_assign(&mut self, rhs: Vector<N>) {
+        for (x, y) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *x += *y;
+        }
     }
 }
 
-impl Index<usize> for Vector {
+impl<const N: usize> Sub<&Vector<N>> for &Vector<N> {
+    type Output = Vector<N>;
+    fn sub(self, rhs: &Vector<N>) -> Vector<N> {
+        let mut data = self.0;
+        for (x, &y) in data.iter_mut().zip(rhs.0.iter()) {
+            *x -= y;
+        }
+        Vector(data)
+    }
+}
+
+impl<const N: usize> SubAssign<&Vector<N>> for Vector<N> {
+    fn sub_assign(&mut self, rhs: &Vector<N>) {
+        for (x, &y) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *x -= y;
+        }
+    }
+}
+
+impl<const N: usize> Mul<&Vector<N>> for &Vector<N> {
+    type Output = Vector<N>;
+    fn mul(self, rhs: &Vector<N>) -> Vector<N> {
+        let mut data = self.0;
+        for (x, &y) in data.iter_mut().zip(rhs.0.iter()) {
+            *x *= y;
+        }
+        Vector(data)
+    }
+}
+
+impl<const N: usize> Mul<Vector<N>> for Vector<N> {
+    type Output = Vector<N>;
+    fn mul(self, rhs: Vector<N>) -> Vector<N> {
+        &self * &rhs
+    }
+}
+
+impl<const N: usize> MulAssign<&Vector<N>> for Vector<N> {
+    fn mul_assign(&mut self, rhs: &Vector<N>) {
+        for (x, &y) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *x *= y;
+        }
+    }
+}
+
+impl<const N: usize> MulAssign<Vector<N>> for Vector<N> {
+    fn mul_assign(&mut self, rhs: Vector<N>) {
+        for (x, y) in self.0.iter_mut().zip(rhs.0.iter()) {
+            *x *= *y;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scalar operators (Vector<N> × f64)
+// ---------------------------------------------------------------------------
+
+impl<const N: usize> Mul<f64> for &Vector<N> {
+    type Output = Vector<N>;
+    fn mul(self, rhs: f64) -> Vector<N> {
+        let mut data = self.0;
+        for x in &mut data {
+            *x *= rhs;
+        }
+        Vector(data)
+    }
+}
+
+impl<const N: usize> Mul<f64> for Vector<N> {
+    type Output = Vector<N>;
+    fn mul(self, rhs: f64) -> Vector<N> {
+        let mut data = self.0;
+        for x in &mut data {
+            *x *= rhs;
+        }
+        Vector(data)
+    }
+}
+
+impl<const N: usize> Mul<&Vector<N>> for f64 {
+    type Output = Vector<N>;
+    fn mul(self, rhs: &Vector<N>) -> Vector<N> {
+        rhs * self
+    }
+}
+
+impl<const N: usize> MulAssign<f64> for Vector<N> {
+    fn mul_assign(&mut self, rhs: f64) {
+        for x in &mut self.0 {
+            *x *= rhs;
+        }
+    }
+}
+
+impl<const N: usize> Div<f64> for &Vector<N> {
+    type Output = Vector<N>;
+    fn div(self, rhs: f64) -> Vector<N> {
+        let mut data = self.0;
+        for x in &mut data {
+            *x /= rhs;
+        }
+        Vector(data)
+    }
+}
+
+impl<const N: usize> DivAssign<f64> for Vector<N> {
+    fn div_assign(&mut self, rhs: f64) {
+        for x in &mut self.0 {
+            *x /= rhs;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Indexing
+// ---------------------------------------------------------------------------
+
+impl<const N: usize> std::ops::Index<usize> for Vector<N> {
     type Output = f64;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        match index {
-            0 => &self.x,
-            1 => &self.y,
-            2 => &self.z,
-            _ => panic!("Index out of bounds"),
-        }
+    fn index(&self, index: usize) -> &f64 {
+        &self.0[index]
     }
 }
 
-impl IndexMut<usize> for Vector {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        match index {
-            0 => &mut self.x,
-            1 => &mut self.y,
-            2 => &mut self.z,
-            _ => panic!("Index out of bounds"),
-        }
+impl<const N: usize> std::ops::IndexMut<usize> for Vector<N> {
+    fn index_mut(&mut self, index: usize) -> &mut f64 {
+        &mut self.0[index]
     }
 }
 
-impl_op_ex!(+ |a: &Vector, b: &Vector| -> Vector {
-    Vector {
-        x: a.x + b.x,
-        y: a.y + b.y,
-        z: a.z + b.z,
+impl<'a, const N: usize> IntoIterator for &'a Vector<N> {
+    type Item = &'a f64;
+    type IntoIter = std::slice::Iter<'a, f64>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
     }
-});
+}
 
-impl_op_ex!(+= |a: &mut Vector, b: &Vector| {
-    a.x += b.x;
-    a.y += b.y;
-    a.z += b.z;
-});
-
-impl_op_ex!(-|a: &Vector, b: &Vector| -> Vector {
-    Vector {
-        x: a.x - b.x,
-        y: a.y - b.y,
-        z: a.z - b.z,
+impl<'a, const N: usize> IntoIterator for &'a mut Vector<N> {
+    type Item = &'a mut f64;
+    type IntoIter = std::slice::IterMut<'a, f64>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
     }
-});
-
-impl_op_ex!(-= |a: &mut Vector, b: &Vector|  {
-    a.x -= b.x;
-    a.y -= b.y;
-    a.z -= b.z;
-});
-
-impl_op_ex!(*|a: &Vector, b: &Vector| -> Vector {
-    Vector {
-        x: a.x * b.x,
-        y: a.y * b.y,
-        z: a.z * b.z,
-    }
-});
-
-impl_op_ex_commutative!(*|a: &Vector, b: &f64| -> Vector {
-    Vector {
-        x: a.x * b,
-        y: a.y * b,
-        z: a.z * b,
-    }
-});
-
-impl_op_ex!(*= |a: &mut Vector, b: &Vector| {
-    a.x *= b.x;
-    a.y *= b.y;
-    a.z *= b.z;
-});
-
-impl_op_ex!(*= |a: &mut Vector, b: &f64| {
-    a.x *= b;
-    a.y *= b;
-    a.z *= b;
-});
-
-impl_op_ex!(/|a: &Vector, b: &Vector| -> Vector {
-    Vector {
-        x: a.x / b.x,
-        y: a.y / b.y,
-        z: a.z / b.z,
-    }
-});
-
-impl_op_ex_commutative!(/|a: &Vector, b: &f64| -> Vector {
-    Vector {
-        x: a.x / b,
-        y: a.y / b,
-        z: a.z / b,
-    }
-});
-
-impl_op_ex!(/= |a: &mut Vector, b: &Vector| {
-    a.x /= b.x;
-    a.y /= b.y;
-    a.z /= b.z;
-});
-
-impl_op_ex!(/= |a: &mut Vector, b: &f64| {
-    a.x /= b;
-    a.y /= b;
-    a.z /= b;
-});
+}

--- a/src/geometry/vector3.rs
+++ b/src/geometry/vector3.rs
@@ -1,0 +1,342 @@
+use std::{
+    f64::consts::PI,
+    ops::{Index, IndexMut, Neg},
+};
+
+use auto_ops::{impl_op_ex, impl_op_ex_commutative};
+use bincode::{Decode, Encode};
+use rand::RngExt;
+
+use crate::utils::Angle;
+
+#[derive(Debug, Copy, Clone, PartialEq, Default, Encode, Decode)]
+pub struct Vector3 {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+impl Vector3 {
+    pub const ZERO: Self = Self {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+
+    pub const ONE: Self = Self {
+        x: 1.0,
+        y: 1.0,
+        z: 1.0,
+    };
+
+    pub const INFINITY: Self = Self {
+        x: f64::INFINITY,
+        y: f64::INFINITY,
+        z: f64::INFINITY,
+    };
+
+    pub const RIGHT: Self = Self {
+        x: 1.0,
+        y: 0.0,
+        z: 0.0,
+    };
+    pub const UNIT_X: Self = Self::RIGHT;
+
+    pub const UP: Self = Self {
+        x: 0.0,
+        y: 1.0,
+        z: 0.0,
+    };
+    pub const UNIT_Y: Self = Self::UP;
+
+    pub const FORWARD: Self = Self {
+        x: 0.0,
+        y: 0.0,
+        z: -1.0,
+    };
+
+    pub const UNIT_Z: Self = Self {
+        x: 0.0,
+        y: 0.0,
+        z: 1.0,
+    };
+
+    pub fn new(x: f64, y: f64, z: f64) -> Self {
+        Self { x, y, z }
+    }
+
+    pub fn random() -> Self {
+        Self::random_range(0.0, 1.0)
+    }
+
+    pub fn random_range(min: f64, max: f64) -> Self {
+        let mut rng = rand::rng();
+        Self {
+            x: rng.random_range(min..max),
+            y: rng.random_range(min..max),
+            z: rng.random_range(min..max),
+        }
+    }
+
+    pub fn random_in_unit_sphere() -> Self {
+        loop {
+            let p = Self::random_in_unit_cube();
+            if p.squared_length() < 1.0 {
+                return p;
+            }
+        }
+    }
+
+    pub fn random_in_unit_cube() -> Self {
+        let mut rng = rand::rng();
+        Self {
+            x: rng.random_range(-1.0..1.0),
+            y: rng.random_range(-1.0..1.0),
+            z: rng.random_range(-1.0..1.0),
+        }
+    }
+
+    pub fn random_in_unit_disk() -> Self {
+        let mut rng = rand::rng();
+        loop {
+            let p = Self {
+                x: rng.random_range(-1.0..1.0),
+                y: rng.random_range(-1.0..1.0),
+                z: 0.0,
+            };
+            if p.squared_length() < 1.0 {
+                return p;
+            }
+        }
+    }
+
+    pub fn random_unit() -> Self {
+        Self::random_in_unit_sphere().unit_vector()
+    }
+
+    pub fn random_on_hemisphere(normal: Self) -> Self {
+        let on_unit_sphere = Self::random_unit();
+        if on_unit_sphere.dot(normal) > 0.0 {
+            on_unit_sphere
+        } else {
+            -on_unit_sphere
+        }
+    }
+
+    /// generates a random unit direction on the +Z hemisphere with a
+    /// cosine-weighted distribution.  the direction is relative to +Z
+    /// (`z > 0` by construction), not world-space.  use an `Onb` to orient
+    /// the result to an arbitrary surface normal.
+    ///
+    /// implemented via malley's method: uniformly sample the unit disk and
+    /// project onto the hemisphere.
+    pub fn random_cosine_weighted_direction() -> Self {
+        let r1 = rand::random::<f64>();
+        let r2 = rand::random::<f64>();
+        let phi = 2.0 * PI * r1;
+        let sqrt_r2 = r2.sqrt();
+        Self {
+            x: phi.cos() * sqrt_r2,
+            y: phi.sin() * sqrt_r2,
+            z: (1.0 - r2).sqrt(),
+        }
+    }
+
+    pub fn length(&self) -> f64 {
+        self.squared_length().sqrt()
+    }
+
+    pub fn squared_length(&self) -> f64 {
+        self.x * self.x + self.y * self.y + self.z * self.z
+    }
+
+    pub fn de_nan(&self) -> Self {
+        Self {
+            x: if self.x.is_nan() { 0.0 } else { self.x },
+            y: if self.y.is_nan() { 0.0 } else { self.y },
+            z: if self.z.is_nan() { 0.0 } else { self.z },
+        }
+    }
+
+    pub fn normalize(&mut self) {
+        *self /= self.length();
+    }
+
+    pub fn unit_vector(&self) -> Self {
+        self / self.length()
+    }
+
+    pub fn is_near_zero(&self) -> bool {
+        let s = 1e-8;
+        self.x.abs() < s && self.y.abs() < s && self.z.abs() < s
+    }
+
+    pub fn angle(&self, other: Self) -> Angle {
+        Angle::Radians((self.dot(other) / (self.length() * other.length())).acos())
+    }
+
+    pub fn dot(&self, other: Self) -> f64 {
+        self.x * other.x + self.y * other.y + self.z * other.z
+    }
+
+    pub fn cross(&self, other: Self) -> Self {
+        Self {
+            x: self.y * other.z - self.z * other.y,
+            y: self.z * other.x - self.x * other.z,
+            z: self.x * other.y - self.y * other.x,
+        }
+    }
+
+    pub fn reflect_around(&self, normal: Self) -> Self {
+        self - 2.0 * self.dot(normal) * normal
+    }
+
+    pub fn refract_around(&self, normal: Self, etai_over_etat: f64) -> Self {
+        let cos_theta = (-*self).dot(normal).min(1.0);
+        let perpendicular_component = etai_over_etat * (self + cos_theta * normal);
+        let parallel_component = -((1.0 - perpendicular_component.squared_length())
+            .abs()
+            .sqrt())
+            * normal;
+        perpendicular_component + parallel_component
+    }
+
+    pub fn scale_down(&self, scale: f64) -> Self {
+        let max = self.x.max(self.y).max(self.z);
+        if max > scale {
+            *self / (max / scale)
+        } else {
+            *self
+        }
+    }
+
+    pub fn max_component(&self) -> f64 {
+        self.x.max(self.y).max(self.z)
+    }
+}
+
+impl From<[f64; 3]> for Vector3 {
+    fn from(v: [f64; 3]) -> Self {
+        Self {
+            x: v[0],
+            y: v[1],
+            z: v[2],
+        }
+    }
+}
+
+impl Neg for Vector3 {
+    type Output = Vector3;
+
+    fn neg(self) -> Self::Output {
+        self * -1.0
+    }
+}
+
+impl Index<usize> for Vector3 {
+    type Output = f64;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        match index {
+            0 => &self.x,
+            1 => &self.y,
+            2 => &self.z,
+            _ => panic!("Index out of bounds"),
+        }
+    }
+}
+
+impl IndexMut<usize> for Vector3 {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            2 => &mut self.z,
+            _ => panic!("Index out of bounds"),
+        }
+    }
+}
+
+impl_op_ex!(+ |a: &Vector3, b: &Vector3| -> Vector3 {
+    Vector3 {
+        x: a.x + b.x,
+        y: a.y + b.y,
+        z: a.z + b.z,
+    }
+});
+
+impl_op_ex!(+= |a: &mut Vector3, b: &Vector3| {
+    a.x += b.x;
+    a.y += b.y;
+    a.z += b.z;
+});
+
+impl_op_ex!(-|a: &Vector3, b: &Vector3| -> Vector3 {
+    Vector3 {
+        x: a.x - b.x,
+        y: a.y - b.y,
+        z: a.z - b.z,
+    }
+});
+
+impl_op_ex!(-= |a: &mut Vector3, b: &Vector3|  {
+    a.x -= b.x;
+    a.y -= b.y;
+    a.z -= b.z;
+});
+
+impl_op_ex!(*|a: &Vector3, b: &Vector3| -> Vector3 {
+    Vector3 {
+        x: a.x * b.x,
+        y: a.y * b.y,
+        z: a.z * b.z,
+    }
+});
+
+impl_op_ex_commutative!(*|a: &Vector3, b: &f64| -> Vector3 {
+    Vector3 {
+        x: a.x * b,
+        y: a.y * b,
+        z: a.z * b,
+    }
+});
+
+impl_op_ex!(*= |a: &mut Vector3, b: &Vector3| {
+    a.x *= b.x;
+    a.y *= b.y;
+    a.z *= b.z;
+});
+
+impl_op_ex!(*= |a: &mut Vector3, b: &f64| {
+    a.x *= b;
+    a.y *= b;
+    a.z *= b;
+});
+
+impl_op_ex!(/|a: &Vector3, b: &Vector3| -> Vector3 {
+    Vector3 {
+        x: a.x / b.x,
+        y: a.y / b.y,
+        z: a.z / b.z,
+    }
+});
+
+impl_op_ex_commutative!(/|a: &Vector3, b: &f64| -> Vector3 {
+    Vector3 {
+        x: a.x / b,
+        y: a.y / b,
+        z: a.z / b,
+    }
+});
+
+impl_op_ex!(/= |a: &mut Vector3, b: &Vector3| {
+    a.x /= b.x;
+    a.y /= b.y;
+    a.z /= b.z;
+});
+
+impl_op_ex!(/= |a: &mut Vector3, b: &f64| {
+    a.x /= b;
+    a.y /= b;
+    a.z /= b;
+});

--- a/src/geometry/volumes/constant.rs
+++ b/src/geometry/volumes/constant.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rand::RngExt;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector},
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     shading::{
         Texture,
         materials::{Isotropic, Material},
@@ -77,7 +77,7 @@ impl Geometric for Constant {
         Some(RayHit {
             t,
             point: ray.at(t),
-            normal: Vector::RIGHT, // arbitrary
+            normal: Vector3::RIGHT, // arbitrary
             material: Arc::clone(&self.phase_function),
             u: 0.0, // arbitrary
             v: 0.0, // arbitrary
@@ -108,11 +108,11 @@ impl Geometric for Constant {
         self.geometric.bounding_box()
     }
 
-    fn sample_direction_from(&self, origin: Point) -> Vector {
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
         self.geometric.sample_direction_from(origin)
     }
 
-    fn direction_pdf(&self, origin: Point, dir: Vector) -> f64 {
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
         self.geometric.direction_pdf(origin, dir)
     }
 }

--- a/src/shading.rs
+++ b/src/shading.rs
@@ -1,5 +1,11 @@
-mod color;
-pub use color::Color;
+mod color_rgb;
+pub use color_rgb::ColorRgb;
+
+pub mod color_spectrum;
+pub use color_spectrum::ColorSpectrum;
+
+pub mod hero_wavelengths;
+pub use hero_wavelengths::HeroWavelengths;
 
 pub mod materials;
 pub mod pdf;

--- a/src/shading/color_rgb.rs
+++ b/src/shading/color_rgb.rs
@@ -2,36 +2,36 @@ use auto_ops::{impl_op_ex, impl_op_ex_commutative};
 use bincode::{Decode, Encode};
 use image::Rgba;
 
-use crate::geometry::Vector;
+use crate::geometry::Vector3;
 
 #[derive(Debug, Copy, Clone, PartialEq, Default, Encode, Decode)]
-pub struct Color(Vector);
+pub struct ColorRgb(Vector3);
 
-impl Color {
-    pub const BLACK: Color = Self(Vector::ZERO);
-    pub const WHITE: Color = Self(Vector::ONE);
-    pub const RED: Color = Self(Vector::UNIT_X);
-    pub const GREEN: Color = Self(Vector::UNIT_Y);
-    pub const BLUE: Color = Self(Vector::UNIT_Z);
+impl ColorRgb {
+    pub const BLACK: ColorRgb = Self(Vector3::ZERO);
+    pub const WHITE: ColorRgb = Self(Vector3::ONE);
+    pub const RED: ColorRgb = Self(Vector3::UNIT_X);
+    pub const GREEN: ColorRgb = Self(Vector3::UNIT_Y);
+    pub const BLUE: ColorRgb = Self(Vector3::UNIT_Z);
 
     pub fn new(r: f64, g: f64, b: f64) -> Self {
-        Self(Vector::new(r, g, b))
+        Self(Vector3::new(r, g, b))
     }
 
     pub fn random() -> Self {
-        Self(Vector::random())
+        Self(Vector3::random())
     }
 
     pub fn random_range(min: f64, max: f64) -> Self {
-        Self(Vector::random_range(min, max))
+        Self(Vector3::random_range(min, max))
     }
 
-    pub fn from_vector(vector: Vector) -> Self {
+    pub fn from_vector(vector: Vector3) -> Self {
         Self(vector)
     }
 
     pub fn from_rgba_u8(rgba: &Rgba<u8>) -> Self {
-        Self(Vector::new(
+        Self(Vector3::new(
             rgba.0[0] as f64 / u8::MAX as f64,
             rgba.0[1] as f64 / u8::MAX as f64,
             rgba.0[2] as f64 / u8::MAX as f64,
@@ -39,7 +39,7 @@ impl Color {
     }
 
     pub fn from_gamma_corrected_rgba_u8(rgba: &Rgba<u8>, decoding_gamma: f64) -> Self {
-        Self(Vector::new(
+        Self(Vector3::new(
             (rgba.0[0] as f64 / u8::MAX as f64).powf(decoding_gamma),
             (rgba.0[1] as f64 / u8::MAX as f64).powf(decoding_gamma),
             (rgba.0[2] as f64 / u8::MAX as f64).powf(decoding_gamma),
@@ -81,46 +81,46 @@ impl Color {
     }
 }
 
-impl From<[f64; 3]> for Color {
+impl From<[f64; 3]> for ColorRgb {
     fn from(v: [f64; 3]) -> Self {
         Self::new(v[0], v[1], v[2])
     }
 }
 
-impl From<Color> for [f64; 3] {
-    fn from(value: Color) -> Self {
+impl From<ColorRgb> for [f64; 3] {
+    fn from(value: ColorRgb) -> Self {
         [value.0.x, value.0.y, value.0.z]
     }
 }
 
-impl_op_ex!(+|a: &Color, b: &Color| -> Color { Color(a.0 + b.0) });
+impl_op_ex!(+|a: &ColorRgb, b: &ColorRgb| -> ColorRgb { ColorRgb(a.0 + b.0) });
 
-impl_op_ex!(+= |a: &mut Color, b: &Color| {
+impl_op_ex!(+= |a: &mut ColorRgb, b: &ColorRgb| {
     a.0 += b.0;
 });
 
-impl_op_ex!(-|a: &Color, b: &Color| -> Color { Color(a.0 - b.0) });
+impl_op_ex!(-|a: &ColorRgb, b: &ColorRgb| -> ColorRgb { ColorRgb(a.0 - b.0) });
 
-impl_op_ex!(-= |a: &mut Color, b: &Color| {
+impl_op_ex!(-= |a: &mut ColorRgb, b: &ColorRgb| {
     a.0 -= b.0;
 });
 
-impl_op_ex!(*|a: &Color, b: &Color| -> Color { Color(a.0 * b.0) });
+impl_op_ex!(*|a: &ColorRgb, b: &ColorRgb| -> ColorRgb { ColorRgb(a.0 * b.0) });
 
-impl_op_ex_commutative!(*|a: &Color, b: &f64| -> Color { Color(a.0 * b) });
+impl_op_ex_commutative!(*|a: &ColorRgb, b: &f64| -> ColorRgb { ColorRgb(a.0 * b) });
 
-impl_op_ex!(*= |a: &mut Color, b: &Color| {
+impl_op_ex!(*= |a: &mut ColorRgb, b: &ColorRgb| {
     a.0 *= b.0;
 });
 
-impl_op_ex!(*= |a: &mut Color, b: &f64| {
+impl_op_ex!(*= |a: &mut ColorRgb, b: &f64| {
     a.0 *= b;
 });
 
-impl_op_ex_commutative!(/|a: &Color, b: &f64| -> Color {
-    Color(a.0 / b)
+impl_op_ex_commutative!(/|a: &ColorRgb, b: &f64| -> ColorRgb {
+    ColorRgb(a.0 / b)
 });
 
-impl_op_ex!(/= |a: &mut Color, b: &f64| {
+impl_op_ex!(/= |a: &mut ColorRgb, b: &f64| {
     a.0 /= b;
 });

--- a/src/shading/color_spectrum.rs
+++ b/src/shading/color_spectrum.rs
@@ -1,0 +1,690 @@
+use std::sync::OnceLock;
+
+use crate::geometry::{Vector, Vector3};
+use crate::shading::{ColorRgb, HeroWavelengths};
+
+/// Number of spectral samples from 380nm to 780nm (57nm spacing).
+///
+/// 8 samples is the standard trade-off in spectral rendering: linear interpolation
+/// between adjacent samples captures smooth reflectance curves with < 1% perceptual
+/// error (ΔE). Measured material reflectance spectra lack narrow features — they're
+/// determined by broad electron band-gap absorption, so 57nm resolution is sufficient.
+///
+/// Below 8 samples, Smits basis reconstruction accuracy degrades on saturated
+/// primaries. Above 8, the 8×8 basis computation cost grows quadratically with no
+/// meaningful perceptual gain for surface reflectance. PBRT v4 uses this resolution.
+pub const SPECTRAL_SAMPLE_COUNT: usize = 8;
+
+/// Minimum visible wavelength in nanometers.
+pub const LAMBDA_MIN: f64 = 380.0;
+
+/// Maximum visible wavelength in nanometers.
+pub const LAMBDA_MAX: f64 = 780.0;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct ColorSpectrum<const N: usize>(pub Vector<N>);
+
+impl<const N: usize> Default for ColorSpectrum<N> {
+    fn default() -> Self {
+        Self(Vector::ZERO)
+    }
+}
+
+/// Precomputed Smits basis spectra.
+#[derive(Debug, Clone)]
+struct SmitsBasis<const N: usize> {
+    white: Vector<N>,
+    red: Vector<N>,
+    green: Vector<N>,
+    blue: Vector<N>,
+    cyan: Vector<N>,
+    magenta: Vector<N>,
+    yellow: Vector<N>,
+}
+
+static SMITS_BASIS: OnceLock<SmitsBasis<SPECTRAL_SAMPLE_COUNT>> = OnceLock::new();
+
+/// Raw CIE integration of a flat [1.0; N] spectrum.
+/// Used to normalize to_rgb() and hero_samples_to_color() so that
+/// a flat unit spectrum maps to sRGB (1, 1, 1).
+pub static CIE_WHITE_NORM: OnceLock<Vector3> = OnceLock::new();
+
+pub fn compute_cie_white_norm<const N: usize>() -> Vector3 {
+    let step = (LAMBDA_MAX - LAMBDA_MIN) / (N - 1) as f64;
+    let mut x = 0.0;
+    let mut y = 0.0;
+    let mut z = 0.0;
+    for i in 0..N {
+        let lambda = LAMBDA_MIN + i as f64 * step;
+        let (cx, cy, cz) = cie_1931_xyz(lambda);
+        x += cx * step;
+        y += cy * step;
+        z += cz * step;
+    }
+    Vector3::new(x, y, z)
+}
+
+impl<const N: usize> ColorSpectrum<N> {
+    /// All spectral samples set to zero.
+    pub const ZERO: ColorSpectrum<N> = ColorSpectrum(Vector::ZERO);
+
+    /// All spectral samples set to one.
+    pub const ONE: ColorSpectrum<N> = ColorSpectrum(Vector::ONE);
+
+    /// Sample the spectrum at an arbitrary wavelength via linear interpolation
+    /// between the nearest two spectral bins.
+    pub fn sample_wavelength(&self, wavelength_nm: f64) -> f64 {
+        let t = (wavelength_nm - LAMBDA_MIN) / (LAMBDA_MAX - LAMBDA_MIN) * (N - 1) as f64;
+        let t = t.clamp(0.0, (N - 1) as f64);
+
+        let index = t.floor() as usize;
+        if index + 1 >= N {
+            return self.0.0[N - 1];
+        }
+
+        let fractional = t - index as f64;
+        self.0.0[index] * (1.0 - fractional) + self.0.0[index + 1] * fractional
+    }
+
+    /// Sample the spectrum at each of the given hero wavelengths,
+    /// returning a `Vector<N>` suitable for per-wavelength
+    /// arithmetic in the integrator.
+    pub fn sample<const M: usize>(&self, hero_wavelengths: &HeroWavelengths<M>) -> Vector<M> {
+        use crate::geometry::Vector;
+        let mut data = Vector::ZERO;
+        for (d, &lambda) in data.iter_mut().zip(hero_wavelengths.iter()) {
+            *d = self.sample_wavelength(lambda);
+        }
+        data
+    }
+
+    /// Returns `true` if all spectral samples are zero.
+    pub fn is_black(&self) -> bool {
+        self.0.iter().all(|&s| s == 0.0)
+    }
+
+    /// Largest value across all spectral samples.
+    pub fn max_component(&self) -> f64 {
+        self.0.iter().cloned().fold(f64::NEG_INFINITY, f64::max)
+    }
+
+    /// Scale all samples proportionally so the maximum equals `limit`.
+    /// If the maximum is already at or below `limit`, returns `self` unchanged.
+    pub fn scale_down(&self, limit: f64) -> Self {
+        let max = self.max_component();
+        if max > limit {
+            let factor = limit / max;
+            let mut samples = self.0;
+            for s in &mut samples {
+                *s *= factor;
+            }
+            Self(samples)
+        } else {
+            *self
+        }
+    }
+
+    /// Replace any NaN values with 0.0 in all spectral samples.
+    pub fn de_nan(&self) -> Self {
+        let mut samples = self.0;
+        for s in &mut samples {
+            if s.is_nan() {
+                *s = 0.0;
+            }
+        }
+        Self(samples)
+    }
+}
+
+impl<const N: usize> From<ColorRgb> for ColorSpectrum<N> {
+    /// Convert an sRGB color to a reflectance spectrum using the
+    /// Smits (1999) method with 7 basis spectra.
+    fn from(rgb: ColorRgb) -> Self {
+        let basis = SMITS_BASIS.get_or_init(compute_smits_basis);
+        let arr: [f64; 3] = rgb.into();
+        let (r, g, b) = (arr[0], arr[1], arr[2]);
+
+        // Smits decomposition into 7 components
+        let w = r.min(g).min(b);
+        let c = g.min(b) - w;
+        let m = r.min(b) - w;
+        let y = r.min(g) - w;
+        let rp = r - w - y - m;
+        let gp = g - w - y - c;
+        let bp = b - w - m - c;
+
+        let mut s = [0.0_f64; N];
+        for (i, item) in s.iter_mut().enumerate() {
+            *item = w * basis.white[i]
+                + c * basis.cyan[i]
+                + m * basis.magenta[i]
+                + y * basis.yellow[i]
+                + rp * basis.red[i]
+                + gp * basis.green[i]
+                + bp * basis.blue[i];
+        }
+        ColorSpectrum(Vector::new(s))
+    }
+}
+
+impl<const N: usize> From<ColorSpectrum<N>> for ColorRgb {
+    /// Integrate the spectrum against the CIE 1931 matching functions
+    /// and convert to linear sRGB.
+    fn from(spectrum: ColorSpectrum<N>) -> Self {
+        let step = (LAMBDA_MAX - LAMBDA_MIN) / (N - 1) as f64;
+        let mut x = 0.0;
+        let mut y = 0.0;
+        let mut z = 0.0;
+        for i in 0..N {
+            let lambda = LAMBDA_MIN + i as f64 * step;
+            let sample = spectrum.0[i];
+            let (x_bar, y_bar, z_bar) = cie_1931_xyz(lambda);
+            x += sample * x_bar * step;
+            y += sample * y_bar * step;
+            z += sample * z_bar * step;
+        }
+        let cie_norm = CIE_WHITE_NORM.get_or_init(compute_cie_white_norm::<N>);
+        let srgb_white_xyz = [0.95047, 1.0, 1.08883];
+        x = x / cie_norm[0] * srgb_white_xyz[0];
+        y = y / cie_norm[1] * srgb_white_xyz[1];
+        z = z / cie_norm[2] * srgb_white_xyz[2];
+        let r = (3.2406 * x - 1.5372 * y - 0.4986 * z).max(0.0);
+        let g = (-0.9689 * x + 1.8758 * y + 0.0415 * z).max(0.0);
+        let b = (0.0557 * x - 0.2040 * y + 1.0570 * z).max(0.0);
+        ColorRgb::new(r, g, b)
+    }
+}
+
+/// Compute the 7 Smits basis spectra by solving a regularized linear
+/// system for each target. The spectra are optimized for smoothness
+/// while satisfying the CIE integration constraints.
+fn compute_smits_basis<const N: usize>() -> SmitsBasis<N> {
+    let step = (LAMBDA_MAX - LAMBDA_MIN) / (N - 1) as f64;
+
+    // Build the CIE integration matrix C (3 rows × N cols)
+    // C[k][i] = cie_value(λ_i) * Δλ  for k in {0:x̄, 1:ȳ, 2:z̄}
+    //
+    // precompute CIE integration values at each wavelength
+    let (x_vals, y_vals, z_vals) = {
+        let mut xv = [0.0_f64; N];
+        let mut yv = [0.0_f64; N];
+        let mut zv = [0.0_f64; N];
+        for (i, ((x, y), z)) in xv
+            .iter_mut()
+            .zip(yv.iter_mut())
+            .zip(zv.iter_mut())
+            .enumerate()
+        {
+            let lambda = LAMBDA_MIN + i as f64 * step;
+            let (x_bar, y_bar, z_bar) = cie_1931_xyz(lambda);
+            *x = x_bar * step;
+            *y = y_bar * step;
+            *z = z_bar * step;
+        }
+        (xv, yv, zv)
+    };
+    let c_mat = [x_vals, y_vals, z_vals];
+
+    // Build the regularized system matrix: A = C^T C + λ L^T L
+    // where L is the second-difference (Laplacian) matrix
+    let lambda_reg = 0.1; // regularization strength
+
+    let mut a = [[0.0_f64; N]; N];
+
+    // A += C^T C
+    for (i, row) in a.iter_mut().enumerate() {
+        for (j, cell) in row.iter_mut().enumerate() {
+            let mut sum = 0.0;
+            for row in &c_mat {
+                sum += row[i] * row[j];
+            }
+            *cell = sum;
+        }
+    }
+
+    // A += λ L^T L  where L is second-difference matrix (6×8)
+    // L[i][i]=1, L[i][i+1]=-2, L[i][i+2]=1 for i=0..5
+    for (i, row) in a.iter_mut().enumerate() {
+        for (j, cell) in row.iter_mut().enumerate() {
+            let mut lap_sum = 0.0;
+            for k in 0..(N - 2) {
+                // contribution of L[k] to (i,j) of L^T L
+                let li = if k == i {
+                    1.0
+                } else if k + 1 == i {
+                    -2.0
+                } else if k + 2 == i {
+                    1.0
+                } else {
+                    0.0
+                };
+                let lj = if k == j {
+                    1.0
+                } else if k + 1 == j {
+                    -2.0
+                } else if k + 2 == j {
+                    1.0
+                } else {
+                    0.0
+                };
+                lap_sum += li * lj;
+            }
+            *cell += lambda_reg * lap_sum;
+        }
+    }
+
+    // sRGB linear → XYZ matrix
+    let srgb_to_xyz = |r: f64, g: f64, b: f64| -> [f64; 3] {
+        [
+            0.4124 * r + 0.3576 * g + 0.1805 * b,
+            0.2126 * r + 0.7152 * g + 0.0722 * b,
+            0.0193 * r + 0.1192 * g + 0.9505 * b,
+        ]
+    };
+
+    let cie_norm = CIE_WHITE_NORM.get_or_init(compute_cie_white_norm::<N>);
+    // sRGB white point XYZ
+    let srgb_white_xyz = [0.95047, 1.0, 1.08883];
+
+    // Solve for a single target: solve A * s = C^T * target_xyz
+    // Returns spectrum clamped to [0, 1]
+    let solve = |target_xyz: [f64; 3]| -> Vector<N> {
+        // Convert from normalized sRGB XYZ to raw CIE integration space
+        let scaled_target: [f64; 3] = [
+            target_xyz[0] * cie_norm[0] / srgb_white_xyz[0],
+            target_xyz[1] * cie_norm[1] / srgb_white_xyz[1],
+            target_xyz[2] * cie_norm[2] / srgb_white_xyz[2],
+        ];
+
+        // Build RHS: b = C^T * scaled_target
+        let mut b = [0.0_f64; N];
+        for (i, b_item) in b.iter_mut().enumerate() {
+            let mut sum = 0.0;
+            for k in 0..3 {
+                sum += c_mat[k][i] * scaled_target[k];
+            }
+            *b_item = sum;
+        }
+
+        // Solve A * x = b using Gaussian elimination with partial pivoting
+        let x = gauss_solve(&a, &b);
+
+        // Clamp to [0, 1]
+        let mut clamped = [0.0_f64; N];
+        for (i, c) in clamped.iter_mut().enumerate() {
+            *c = x[i].clamp(0.0, 1.0);
+        }
+        Vector::new(clamped)
+    };
+
+    SmitsBasis {
+        white: Vector::ONE, // flat white — no solving needed
+        red: solve(srgb_to_xyz(1.0, 0.0, 0.0)),
+        green: solve(srgb_to_xyz(0.0, 1.0, 0.0)),
+        blue: solve(srgb_to_xyz(0.0, 0.0, 1.0)),
+        cyan: solve(srgb_to_xyz(0.0, 1.0, 1.0)),
+        magenta: solve(srgb_to_xyz(1.0, 0.0, 1.0)),
+        yellow: solve(srgb_to_xyz(1.0, 1.0, 0.0)),
+    }
+}
+
+/// Solve an N×N linear system Ax = b using Gaussian elimination
+/// with partial pivoting.
+#[allow(clippy::needless_range_loop)]
+fn gauss_solve<const N: usize>(a: &[[f64; N]; N], b: &[f64; N]) -> [f64; N] {
+    let n = N;
+
+    // Separate coefficient matrix and right-hand side
+    let mut m = *a;
+    let mut b_vec = *b;
+
+    // Forward elimination with partial pivoting
+    for col in 0..n {
+        // Find pivot
+        let mut max_val = m[col][col].abs();
+        let mut max_row = col;
+        for row in (col + 1)..n {
+            if m[row][col].abs() > max_val {
+                max_val = m[row][col].abs();
+                max_row = row;
+            }
+        }
+        // Swap rows in both coefficient matrix and rhs
+        if max_row != col {
+            m.swap(col, max_row);
+            b_vec.swap(col, max_row);
+        }
+        // Eliminate below
+        for row in (col + 1)..n {
+            let factor = m[row][col] / m[col][col];
+            for j in col..n {
+                m[row][j] -= factor * m[col][j];
+            }
+            b_vec[row] -= factor * b_vec[col];
+        }
+    }
+
+    // Back substitution
+    let mut x = [0.0_f64; N];
+    for i in (0..n).rev() {
+        let mut sum = b_vec[i];
+        for j in (i + 1)..n {
+            sum -= m[i][j] * x[j];
+        }
+        x[i] = sum / m[i][i];
+    }
+    x
+}
+
+/// CIE 1931 2-degree color matching functions evaluated at an arbitrary
+/// wavelength via linear interpolation of the 5nm-interval table.
+pub fn cie_1931_xyz(lambda_nm: f64) -> (f64, f64, f64) {
+    // CIE 1931 2-degree color matching functions at 5nm intervals (380..=780)
+    // x_bar, y_bar, z_bar values from CIE standard
+    static CIE_TABLE: [(f64, f64, f64); 81] = [
+        (0.001368, 0.000039, 0.006450), // 380 nm
+        (0.002236, 0.000064, 0.010550), // 385 nm
+        (0.004243, 0.000120, 0.020050), // 390 nm
+        (0.007650, 0.000217, 0.036210), // 395 nm
+        (0.014310, 0.000396, 0.067850), // 400 nm
+        (0.023190, 0.000640, 0.110200), // 405 nm
+        (0.043510, 0.001210, 0.207400), // 410 nm
+        (0.077630, 0.002180, 0.371300), // 415 nm
+        (0.134380, 0.004000, 0.645600), // 420 nm
+        (0.214770, 0.007300, 1.039050), // 425 nm
+        (0.283900, 0.011600, 1.385600), // 430 nm
+        (0.328500, 0.016840, 1.622960), // 435 nm
+        (0.348280, 0.023000, 1.747060), // 440 nm
+        (0.348060, 0.029800, 1.782600), // 445 nm
+        (0.336200, 0.038000, 1.772110), // 450 nm
+        (0.318700, 0.048000, 1.744100), // 455 nm
+        (0.290800, 0.060000, 1.669200), // 460 nm
+        (0.251100, 0.073900, 1.528100), // 465 nm
+        (0.195360, 0.090980, 1.287640), // 470 nm
+        (0.142100, 0.112600, 1.041900), // 475 nm
+        (0.095640, 0.139020, 0.812950), // 480 nm
+        (0.057950, 0.169300, 0.616200), // 485 nm
+        (0.032010, 0.208020, 0.465180), // 490 nm
+        (0.014700, 0.258600, 0.353300), // 495 nm
+        (0.004900, 0.323000, 0.272000), // 500 nm
+        (0.002400, 0.407300, 0.212300), // 505 nm
+        (0.009300, 0.503000, 0.158200), // 510 nm
+        (0.029100, 0.608200, 0.111700), // 515 nm
+        (0.063270, 0.710000, 0.078250), // 520 nm
+        (0.109600, 0.793200, 0.057250), // 525 nm
+        (0.165500, 0.862000, 0.042160), // 530 nm
+        (0.225750, 0.914850, 0.029840), // 535 nm
+        (0.290400, 0.954000, 0.020300), // 540 nm
+        (0.359700, 0.980300, 0.013400), // 545 nm
+        (0.433450, 0.994950, 0.008750), // 550 nm
+        (0.512050, 1.000000, 0.005750), // 555 nm
+        (0.594500, 0.995000, 0.003900), // 560 nm
+        (0.678400, 0.978600, 0.002750), // 565 nm
+        (0.762100, 0.952000, 0.002100), // 570 nm
+        (0.842500, 0.915400, 0.001800), // 575 nm
+        (0.916300, 0.870000, 0.001650), // 580 nm
+        (0.978600, 0.816300, 0.001400), // 585 nm
+        (1.026300, 0.757000, 0.001100), // 590 nm
+        (1.056700, 0.694900, 0.001000), // 595 nm
+        (1.062200, 0.631000, 0.000800), // 600 nm
+        (1.045600, 0.566800, 0.000600), // 605 nm
+        (1.002600, 0.503000, 0.000340), // 610 nm
+        (0.938400, 0.441200, 0.000240), // 615 nm
+        (0.854450, 0.381000, 0.000190), // 620 nm
+        (0.751400, 0.321000, 0.000100), // 625 nm
+        (0.642400, 0.265000, 0.000050), // 630 nm
+        (0.541900, 0.217000, 0.000030), // 635 nm
+        (0.447900, 0.175000, 0.000020), // 640 nm
+        (0.360800, 0.138200, 0.000010), // 645 nm
+        (0.283500, 0.107000, 0.000000), // 650 nm
+        (0.218700, 0.081600, 0.000000), // 655 nm
+        (0.164900, 0.061000, 0.000000), // 660 nm
+        (0.121200, 0.044580, 0.000000), // 665 nm
+        (0.087400, 0.032000, 0.000000), // 670 nm
+        (0.063600, 0.023200, 0.000000), // 675 nm
+        (0.046770, 0.017000, 0.000000), // 680 nm
+        (0.032900, 0.011920, 0.000000), // 685 nm
+        (0.022700, 0.008210, 0.000000), // 690 nm
+        (0.015840, 0.005723, 0.000000), // 695 nm
+        (0.011359, 0.004102, 0.000000), // 700 nm
+        (0.008111, 0.002929, 0.000000), // 705 nm
+        (0.005790, 0.002091, 0.000000), // 710 nm
+        (0.004109, 0.001484, 0.000000), // 715 nm
+        (0.002899, 0.001047, 0.000000), // 720 nm
+        (0.002049, 0.000740, 0.000000), // 725 nm
+        (0.001440, 0.000520, 0.000000), // 730 nm
+        (0.001000, 0.000361, 0.000000), // 735 nm
+        (0.000690, 0.000249, 0.000000), // 740 nm
+        (0.000476, 0.000172, 0.000000), // 745 nm
+        (0.000332, 0.000120, 0.000000), // 750 nm
+        (0.000235, 0.000085, 0.000000), // 755 nm
+        (0.000166, 0.000060, 0.000000), // 760 nm
+        (0.000117, 0.000042, 0.000000), // 765 nm
+        (0.000083, 0.000030, 0.000000), // 770 nm
+        (0.000059, 0.000021, 0.000000), // 775 nm
+        (0.000042, 0.000015, 0.000000), // 780 nm
+    ];
+
+    let continuous_index = ((lambda_nm - 380.0) / 5.0).clamp(0.0, 80.0);
+    let index = continuous_index.floor() as usize;
+    if index >= 80 {
+        return CIE_TABLE[80];
+    }
+
+    let fractional = continuous_index - index as f64;
+    let (x0, y0, z0) = CIE_TABLE[index];
+    let (x1, y1, z1) = CIE_TABLE[index + 1];
+
+    // linear interpolation
+    (
+        x0 + (x1 - x0) * fractional,
+        y0 + (y1 - y0) * fractional,
+        z0 + (z1 - z0) * fractional,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Element-wise operators (ColorSpectrum × ColorSpectrum)
+// ---------------------------------------------------------------------------
+
+impl<const N: usize> std::ops::Add<&ColorSpectrum<N>> for &ColorSpectrum<N> {
+    type Output = ColorSpectrum<N>;
+    fn add(self, rhs: &ColorSpectrum<N>) -> ColorSpectrum<N> {
+        ColorSpectrum(&self.0 + &rhs.0)
+    }
+}
+
+impl<const N: usize> std::ops::AddAssign<&ColorSpectrum<N>> for ColorSpectrum<N> {
+    fn add_assign(&mut self, rhs: &ColorSpectrum<N>) {
+        self.0 += &rhs.0;
+    }
+}
+
+impl<const N: usize> std::ops::Sub<&ColorSpectrum<N>> for &ColorSpectrum<N> {
+    type Output = ColorSpectrum<N>;
+    fn sub(self, rhs: &ColorSpectrum<N>) -> ColorSpectrum<N> {
+        ColorSpectrum(&self.0 - &rhs.0)
+    }
+}
+
+impl<const N: usize> std::ops::SubAssign<&ColorSpectrum<N>> for ColorSpectrum<N> {
+    fn sub_assign(&mut self, rhs: &ColorSpectrum<N>) {
+        self.0 -= &rhs.0;
+    }
+}
+
+impl<const N: usize> std::ops::Mul<&ColorSpectrum<N>> for &ColorSpectrum<N> {
+    type Output = ColorSpectrum<N>;
+    fn mul(self, rhs: &ColorSpectrum<N>) -> ColorSpectrum<N> {
+        ColorSpectrum(self.0 * rhs.0)
+    }
+}
+
+impl<const N: usize> std::ops::MulAssign<&ColorSpectrum<N>> for ColorSpectrum<N> {
+    fn mul_assign(&mut self, rhs: &ColorSpectrum<N>) {
+        self.0 *= &rhs.0;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scalar operators (ColorSpectrum × f64)
+// ---------------------------------------------------------------------------
+
+impl<const N: usize> std::ops::Mul<f64> for &ColorSpectrum<N> {
+    type Output = ColorSpectrum<N>;
+    fn mul(self, rhs: f64) -> ColorSpectrum<N> {
+        ColorSpectrum(self.0 * rhs)
+    }
+}
+
+impl<const N: usize> std::ops::Mul<f64> for ColorSpectrum<N> {
+    type Output = ColorSpectrum<N>;
+    fn mul(self, rhs: f64) -> ColorSpectrum<N> {
+        let mut data = self.0;
+        data *= rhs;
+        ColorSpectrum(data)
+    }
+}
+
+impl<const N: usize> std::ops::Mul<&ColorSpectrum<N>> for f64 {
+    type Output = ColorSpectrum<N>;
+    fn mul(self, rhs: &ColorSpectrum<N>) -> ColorSpectrum<N> {
+        ColorSpectrum(self * &rhs.0)
+    }
+}
+
+impl<const N: usize> std::ops::MulAssign<f64> for ColorSpectrum<N> {
+    fn mul_assign(&mut self, rhs: f64) {
+        self.0 *= rhs;
+    }
+}
+
+impl<const N: usize> std::ops::Div<f64> for &ColorSpectrum<N> {
+    type Output = ColorSpectrum<N>;
+    fn div(self, rhs: f64) -> ColorSpectrum<N> {
+        ColorSpectrum(&self.0 / rhs)
+    }
+}
+
+impl<const N: usize> std::ops::Div<f64> for ColorSpectrum<N> {
+    type Output = ColorSpectrum<N>;
+    fn div(self, rhs: f64) -> ColorSpectrum<N> {
+        let mut data = self.0;
+        data /= rhs;
+        ColorSpectrum(data)
+    }
+}
+
+impl<const N: usize> std::ops::DivAssign<f64> for ColorSpectrum<N> {
+    fn div_assign(&mut self, rhs: f64) {
+        self.0 /= rhs;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn smits_round_trip() {
+        let test_colors: [(&str, f64, f64, f64); 6] = [
+            ("white", 1.0, 1.0, 1.0),
+            ("red", 1.0, 0.0, 0.0),
+            ("green", 0.0, 1.0, 0.0),
+            ("blue", 0.0, 0.0, 1.0),
+            ("gray", 0.5, 0.5, 0.5),
+            ("orange", 1.0, 0.5, 0.0),
+        ];
+
+        println!("\n=== Smits RGB → ColorSpectrum → RGB Round-Trip ===");
+        println!(
+            "{:>8} | {:>17} | {:>17} | {:>8}",
+            "Name", "Input RGB", "Output RGB", "G/R"
+        );
+        println!("{:-<8}-+-{:-<17}-+-{:-<17}-+-{:-<8}", "", "", "", "");
+
+        for (name, r, g, b) in test_colors {
+            let spectrum: ColorSpectrum<SPECTRAL_SAMPLE_COUNT> = ColorRgb::new(r, g, b).into();
+            let output: ColorRgb = spectrum.into();
+            let out: [f64; 3] = output.into();
+
+            let gr = if out[0].abs() > 0.001 {
+                format!("{:.3}x", out[1] / out[0])
+            } else {
+                "---".to_string()
+            };
+
+            println!(
+                "{:>8} | ({:.2},{:.2},{:.2}) | ({:.3},{:.3},{:.3}) | {:>8}",
+                name, r, g, b, out[0], out[1], out[2], gr
+            );
+        }
+
+        // Verify rough round-trip (allow 0.05 tolerance per channel)
+        let (r, g, b) = (1.0, 1.0, 1.0);
+        let spectrum: ColorSpectrum<SPECTRAL_SAMPLE_COUNT> = ColorRgb::new(r, g, b).into();
+        let output: ColorRgb = spectrum.into();
+        let out: [f64; 3] = output.into();
+        assert!(
+            (out[0] - 1.0).abs() < 0.1,
+            "White R channel: expected ~1.0, got {}",
+            out[0]
+        );
+        assert!(
+            (out[1] - 1.0).abs() < 0.1,
+            "White G channel: expected ~1.0, got {}",
+            out[1]
+        );
+        assert!(
+            (out[2] - 1.0).abs() < 0.1,
+            "White B channel: expected ~1.0, got {}",
+            out[2]
+        );
+
+        // Verify spectral values are in [0, 1]
+        for sample in spectrum.0.0 {
+            assert!(
+                (-0.001..=1.001).contains(&sample),
+                "Spectral sample {} out of [0,1] range",
+                sample
+            );
+        }
+
+        // Verify spectral values are in a reasonable range for reflectance
+        // Flat white spectrum should be close to 1.0 at all samples
+        let white_spec: ColorSpectrum<SPECTRAL_SAMPLE_COUNT> = ColorRgb::new(1.0, 1.0, 1.0).into();
+        println!("\nWhite spectrum values: {:?}", white_spec.0);
+        for (i, &sample) in white_spec.0.iter().enumerate() {
+            assert!(
+                sample > 0.5,
+                "White spectrum sample {} is too small ({}). Expected ~1.0 for reflectance.",
+                i,
+                sample
+            );
+        }
+
+        // Verify the light spectrum (emittance with values > 1)
+        let light_spec: ColorSpectrum<SPECTRAL_SAMPLE_COUNT> = ColorRgb::new(7.0, 7.0, 7.0).into();
+        println!("Light (7,7,7) spectrum values: {:?}", light_spec.0);
+        for (i, &sample) in light_spec.0.iter().enumerate() {
+            assert!(
+                sample > 3.0,
+                "Light spectrum sample {} is too small ({}). Expected ~7.0 for emittance.",
+                i,
+                sample
+            );
+        }
+
+        println!("===================================\n");
+    }
+
+    #[test]
+    fn from_traits_round_trip() {
+        let rgb = ColorRgb::new(1.0, 0.5, 0.0);
+        let spectrum: ColorSpectrum<SPECTRAL_SAMPLE_COUNT> = ColorSpectrum::from(rgb);
+        let back: ColorRgb = ColorRgb::from(spectrum);
+        let out: [f64; 3] = back.into();
+        assert!((out[0] - 0.989).abs() < 0.05);
+    }
+}

--- a/src/shading/hero_wavelengths.rs
+++ b/src/shading/hero_wavelengths.rs
@@ -1,3 +1,5 @@
+use std::ops::Index;
+
 use crate::{
     geometry::Vector,
     shading::{
@@ -23,6 +25,11 @@ pub const HERO_WAVELENGTH_COUNT: usize = 4;
 pub struct HeroWavelengths<const N: usize>(Vector<N>);
 
 impl<const N: usize> HeroWavelengths<N> {
+    /// Create from an explicit array of wavelengths.
+    pub fn new(wavelengths: [f64; N]) -> Self {
+        Self(Vector::new(wavelengths))
+    }
+
     /// Pick 4 stratified hero wavelengths by dividing 380-780nm into equal bins
     /// and picking a random wavelength within each bin.
     pub fn new_distributed() -> Self {
@@ -66,6 +73,13 @@ impl<const N: usize> HeroWavelengths<N> {
     /// Iterate over the elements by reference.
     pub fn iter(&self) -> std::slice::Iter<'_, f64> {
         self.0.iter()
+    }
+}
+
+impl<const N: usize> Index<usize> for HeroWavelengths<N> {
+    type Output = f64;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
     }
 }
 

--- a/src/shading/hero_wavelengths.rs
+++ b/src/shading/hero_wavelengths.rs
@@ -1,0 +1,78 @@
+use crate::{
+    geometry::Vector,
+    shading::{
+        ColorRgb,
+        color_spectrum::{
+            CIE_WHITE_NORM, LAMBDA_MAX, LAMBDA_MIN, cie_1931_xyz, compute_cie_white_norm,
+        },
+    },
+};
+
+/// Number of hero wavelengths per camera ray.
+///
+/// Hero wavelength sampling (Wilkie et al., 2014) traces multiple wavelengths per
+/// camera ray to share the expensive geometric exploration (BVH traversal,
+/// ray-triangle intersection) across spectral samples. 4 is the sweet spot where
+/// spectral variance becomes negligible relative to geometric variance: fewer
+/// wavelengths waste intersection work, more add material-evaluation cost without
+/// meaningfully reducing total variance. The paper found 2–8 optimal across their
+/// test suite, with 4 as the recommended default.
+pub const HERO_WAVELENGTH_COUNT: usize = 4;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct HeroWavelengths<const N: usize>(Vector<N>);
+
+impl<const N: usize> HeroWavelengths<N> {
+    /// Pick 4 stratified hero wavelengths by dividing 380-780nm into equal bins
+    /// and picking a random wavelength within each bin.
+    pub fn new_distributed() -> Self {
+        use rand::RngExt;
+        let mut rng = rand::rng();
+        let bin_width = (LAMBDA_MAX - LAMBDA_MIN) / N as f64;
+        let mut lambdas = [0.0; N];
+        for (i, lambda) in lambdas.iter_mut().enumerate() {
+            *lambda = LAMBDA_MIN + i as f64 * bin_width + rng.random_range(0.0..bin_width);
+        }
+        Self(Vector::new(lambdas))
+    }
+
+    /// Convert 4 hero wavelength radiance samples directly to RGB using the
+    /// CIE 1931 matching functions evaluated at each hero wavelength.
+    pub fn to_color_rgb(&self, accumulated: Vector<N>) -> ColorRgb {
+        let delta_lambda = (LAMBDA_MAX - LAMBDA_MIN) / N as f64;
+        let mut x = 0.0;
+        let mut y = 0.0;
+        let mut z = 0.0;
+        for (&lambda, &acc) in self.iter().zip(accumulated.iter()) {
+            let (x_bar, y_bar, z_bar) = cie_1931_xyz(lambda);
+            x += acc * x_bar;
+            y += acc * y_bar;
+            z += acc * z_bar;
+        }
+        x *= delta_lambda;
+        y *= delta_lambda;
+        z *= delta_lambda;
+        let cie_norm = CIE_WHITE_NORM.get_or_init(compute_cie_white_norm::<N>);
+        let srgb_white_xyz = [0.95047, 1.0, 1.08883];
+        x = x / cie_norm[0] * srgb_white_xyz[0];
+        y = y / cie_norm[1] * srgb_white_xyz[1];
+        z = z / cie_norm[2] * srgb_white_xyz[2];
+        let r = (3.2406 * x - 1.5372 * y - 0.4986 * z).max(0.0);
+        let g = (-0.9689 * x + 1.8758 * y + 0.0415 * z).max(0.0);
+        let b = (0.0557 * x - 0.2040 * y + 1.0570 * z).max(0.0);
+        ColorRgb::new(r, g, b)
+    }
+
+    /// Iterate over the elements by reference.
+    pub fn iter(&self) -> std::slice::Iter<'_, f64> {
+        self.0.iter()
+    }
+}
+
+impl<'a, const N: usize> IntoIterator for &'a HeroWavelengths<N> {
+    type Item = &'a f64;
+    type IntoIter = std::slice::Iter<'a, f64>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}

--- a/src/shading/materials.rs
+++ b/src/shading/materials.rs
@@ -1,6 +1,7 @@
-use super::Color;
+use super::ColorSpectrum;
 use super::pdf::Pdf;
-use crate::geometry::{Point, Ray, RayHit, Vector};
+use crate::geometry::{Point, Ray, RayHit, Vector3};
+use crate::shading::color_spectrum::SPECTRAL_SAMPLE_COUNT;
 
 mod dielectric;
 pub use dielectric::Dielectric;
@@ -15,7 +16,7 @@ mod specular;
 pub use specular::Specular;
 
 pub trait Material: std::fmt::Debug + Sync + Send {
-    fn emittance(&self, u: f64, v: f64, p: Point) -> Color;
+    fn emittance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT>;
 
     /// Whether this material emits any light at any point on its surface.
     /// Used to build the lights list for importance sampling.
@@ -34,9 +35,9 @@ pub trait Material: std::fmt::Debug + Sync + Send {
     ///
     /// For `Pdf`-variant materials (Lambertian), the actual contribution comes
     /// from `brdf()`, but `reflectance()` is still called for early-termination:
-    /// if the surface absorbs all light (returns `Color::BLACK`), the integrator
-    /// skips scattering entirely.
-    fn reflectance(&self, u: f64, v: f64, p: Point) -> Color;
+    /// if the surface absorbs all light (returns `ColorSpectrum::ZERO`), the
+    /// integrator skips scattering entirely.
+    fn reflectance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT>;
 
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord>;
 
@@ -54,13 +55,13 @@ pub trait Material: std::fmt::Debug + Sync + Send {
     /// never called — they bypass the BRDF path via `ScatterRecord::Delta`.
     fn brdf(
         &self,
-        outgoing_direction: Vector,
-        incident_direction: Vector,
-        normal: Vector,
+        outgoing_direction: Vector3,
+        incident_direction: Vector3,
+        normal: Vector3,
         u: f64,
         v: f64,
         p: Point,
-    ) -> Color;
+    ) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT>;
 }
 
 /// The result of a material scatter operation.

--- a/src/shading/materials.rs
+++ b/src/shading/materials.rs
@@ -1,7 +1,8 @@
 use super::ColorSpectrum;
 use super::pdf::Pdf;
-use crate::geometry::{Point, Ray, RayHit, Vector3};
+use crate::geometry::{Point, Ray, RayHit, Vector, Vector3};
 use crate::shading::color_spectrum::SPECTRAL_SAMPLE_COUNT;
+use crate::shading::hero_wavelengths::{HERO_WAVELENGTH_COUNT, HeroWavelengths};
 
 mod dielectric;
 pub use dielectric::Dielectric;
@@ -39,7 +40,12 @@ pub trait Material: std::fmt::Debug + Sync + Send {
     /// integrator skips scattering entirely.
     fn reflectance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT>;
 
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord>;
+    fn scatter(
+        &self,
+        ray: Ray,
+        ray_hit: &RayHit,
+        hw: &HeroWavelengths<HERO_WAVELENGTH_COUNT>,
+    ) -> Option<ScatterRecord>;
 
     /// Evaluate the BRDF (Bidirectional Reflectance Distribution Function).
     ///
@@ -64,6 +70,17 @@ pub trait Material: std::fmt::Debug + Sync + Send {
     ) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT>;
 }
 
+/// Payload for a dispersive dielectric scatter event.
+/// Boxed to keep `ScatterRecord` small on the stack.
+#[derive(Debug)]
+pub struct SpectralScatter {
+    /// One refracted ray per hero wavelength. `None` when total internal
+    /// reflection occurs at that wavelength.
+    pub rays: [Option<Ray>; HERO_WAVELENGTH_COUNT],
+    /// Per-wavelength reflectance/transmission weight.
+    pub reflectance: Vector<HERO_WAVELENGTH_COUNT>,
+}
+
 /// The result of a material scatter operation.
 ///
 /// `Pdf` carries a sampling probability density for diffuse materials
@@ -77,4 +94,6 @@ pub enum ScatterRecord {
         /// The scattered ray to continue tracing.
         scattered: Ray,
     },
+    /// Dispersive dielectric scatter — boxed to avoid bloating the enum.
+    Spectral(Box<SpectralScatter>),
 }

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -37,11 +37,41 @@ impl Dielectric {
         r0 + (1.0 - r0) * (1.0 - cosine).powi(5)
     }
 
-    /// Index of refraction at a specific wavelength.
-    /// Currently returns the constant IOR. Will be replaced with a
-    /// Sellmeier equation for physically-accurate dispersion.
-    pub fn index_of_refraction_at(&self, _wavelength_nm: f64) -> f64 {
-        self.index_of_refraction
+    /// Index of refraction at a specific wavelength using a one-term
+    /// Sellmeier equation fitted from the user-provided IOR.
+    ///
+    /// The user's IOR is assumed to be n_D — the refractive index at the
+    /// sodium D-line (589.3nm). A single Sellmeier term with C₁ = 0.01 µm²
+    /// provides physically plausible dispersion for optical glass:
+    /// shorter wavelengths → higher IOR, with ~0.01 variation across the
+    /// visible range at IOR ≈ 1.5.
+    pub fn index_of_refraction_at(&self, wavelength_nm: f64) -> f64 {
+        let lambda_um = wavelength_nm / 1000.0;
+        let lambda_sq = lambda_um * lambda_um;
+
+        // D-line reference wavelength in µm
+        let d_um = 0.5893;
+        let d_sq = d_um * d_um;
+
+        // Fixed dispersion constant (µm²) — typical for optical glass
+        let c1 = 0.01;
+
+        // Solve B₁ so that n(589.3nm) = user_ior
+        let n_sq = self.index_of_refraction * self.index_of_refraction;
+        let b1 = (n_sq - 1.0) * (d_sq - c1) / d_sq;
+
+        // n²(λ) = 1 + B₁·λ²/(λ² − C₁)
+        let n_sq_lambda = 1.0 + b1 * lambda_sq / (lambda_sq - c1);
+        let nominal_ior = n_sq_lambda.sqrt().max(1.0);
+
+        // debug: amplify dispersion for visual testing.
+        // remove this multiplier (return nominal_ior) for production.
+        //
+        // const DISPERSION_MULTIPLIER: f64 = 1000.0;
+        // let dispersion = nominal_ior - self.index_of_refraction;
+        // self.index_of_refraction + dispersion * DISPERSION_MULTIPLIER
+
+        nominal_ior
     }
 
     /// Compute the scattered direction for a specific wavelength using

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -1,11 +1,15 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Point, Ray, RayHit, Vector3},
-    shading::{ColorSpectrum, Texture, color_spectrum::SPECTRAL_SAMPLE_COUNT},
+    geometry::{Point, Ray, RayHit, Vector, Vector3},
+    shading::{
+        ColorSpectrum, Texture,
+        color_spectrum::SPECTRAL_SAMPLE_COUNT,
+        hero_wavelengths::{HERO_WAVELENGTH_COUNT, HeroWavelengths},
+    },
 };
 
-use super::{Material, ScatterRecord};
+use super::{Material, ScatterRecord, SpectralScatter};
 
 #[derive(Debug, Clone)]
 pub struct Dielectric {
@@ -31,6 +35,50 @@ impl Dielectric {
         let r0 = (1.0 - ref_idx) / (1.0 + ref_idx);
         let r0 = r0 * r0;
         r0 + (1.0 - r0) * (1.0 - cosine).powi(5)
+    }
+
+    /// Index of refraction at a specific wavelength.
+    /// Currently returns the constant IOR. Will be replaced with a
+    /// Sellmeier equation for physically-accurate dispersion.
+    pub fn index_of_refraction_at(&self, _wavelength_nm: f64) -> f64 {
+        self.index_of_refraction
+    }
+
+    /// Compute the scattered direction for a specific wavelength using
+    /// Fresnel-weighted Monte Carlo: randomly reflects or refracts
+    /// proportional to Schlick reflectance, returning the appropriate
+    /// attenuation weight (1.0 for reflection, 1.0 - reflectance for
+    /// transmission; converges to correct Fresnel over many samples).
+    pub fn refract_at(
+        &self,
+        incident: Vector3,
+        normal: Vector3,
+        wavelength_nm: f64,
+    ) -> (Vector3, f64) {
+        let ior = self.index_of_refraction_at(wavelength_nm);
+        let (refractive_normal, refraction_ratio) = if incident.dot(normal) < 0.0 {
+            (normal, 1.0 / ior)
+        } else {
+            (-normal, ior)
+        };
+
+        let unit_direction = incident.unit_vector();
+        let cos_theta = (-unit_direction).dot(refractive_normal).min(1.0);
+        let sin_theta = (1.0 - cos_theta * cos_theta).sqrt();
+        let cannot_refract = refraction_ratio * sin_theta > 1.0;
+
+        let reflectance = Self::schlick_reflectance(cos_theta, refraction_ratio);
+
+        if cannot_refract || reflectance > rand::random() {
+            // reflect (TIR or Schlick flip chose reflection)
+            (unit_direction.reflect_around(refractive_normal), 1.0)
+        } else {
+            // refract
+            (
+                unit_direction.refract_around(refractive_normal, refraction_ratio),
+                1.0 - reflectance,
+            )
+        }
     }
 }
 
@@ -73,29 +121,24 @@ impl Material for Dielectric {
         ColorSpectrum::ZERO
     }
 
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
-        let (refractive_normal, refraction_ratio) = if ray.direction.dot(ray_hit.normal) < 0.0 {
-            (ray_hit.normal, 1.0 / self.index_of_refraction)
-        } else {
-            (-ray_hit.normal, self.index_of_refraction)
-        };
+    fn scatter(
+        &self,
+        ray: Ray,
+        ray_hit: &RayHit,
+        hw: &HeroWavelengths<HERO_WAVELENGTH_COUNT>,
+    ) -> Option<ScatterRecord> {
+        let mut rays = [None; HERO_WAVELENGTH_COUNT];
+        let mut reflectance = Vector::<HERO_WAVELENGTH_COUNT>::ZERO;
 
-        let unit_direction = ray.direction.unit_vector();
-        let cos_theta = (-unit_direction).dot(refractive_normal).min(1.0);
-        let sin_theta = (1.0 - cos_theta * cos_theta).sqrt();
-        let cannot_refract = refraction_ratio * sin_theta > 1.0;
+        for (i, &lambda) in hw.iter().enumerate() {
+            let (dir, refl) = self.refract_at(ray.direction, ray_hit.normal, lambda);
+            reflectance[i] = refl;
+            rays[i] = Some(Ray::new(ray_hit.point, dir, ray.time));
+        }
 
-        let refracted = if cannot_refract
-            || Dielectric::schlick_reflectance(cos_theta, refraction_ratio) > rand::random()
-        {
-            // cannot refract so must reflect
-            unit_direction.reflect_around(refractive_normal)
-        } else {
-            // can refract
-            unit_direction.refract_around(refractive_normal, refraction_ratio)
-        };
-
-        let scattered = Ray::new(ray_hit.point, refracted, ray.time);
-        Some(ScatterRecord::Delta { scattered })
+        Some(ScatterRecord::Spectral(Box::new(SpectralScatter {
+            rays,
+            reflectance,
+        })))
     }
 }

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Point, Ray, RayHit, Vector},
-    shading::{Color, Texture},
+    geometry::{Point, Ray, RayHit, Vector3},
+    shading::{ColorSpectrum, Texture, color_spectrum::SPECTRAL_SAMPLE_COUNT},
 };
 
 use super::{Material, ScatterRecord};
@@ -35,12 +35,17 @@ impl Dielectric {
 }
 
 impl Material for Dielectric {
-    fn emittance(&self, u: f64, v: f64, p: crate::geometry::Point) -> Color {
+    fn emittance(
+        &self,
+        u: f64,
+        v: f64,
+        p: crate::geometry::Point,
+    ) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         self.emittance_texture.value(u, v, p)
     }
 
     fn is_emissive(&self) -> bool {
-        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
+        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != ColorSpectrum::ZERO
     }
 
     fn is_transmissive(&self) -> bool {
@@ -51,21 +56,21 @@ impl Material for Dielectric {
         false
     }
 
-    fn reflectance(&self, u: f64, v: f64, p: Point) -> Color {
+    fn reflectance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         self.reflectance_texture.value(u, v, p)
     }
 
     fn brdf(
         &self,
-        _outgoing_direction: Vector,
-        _incident_direction: Vector,
-        _normal: Vector,
+        _outgoing_direction: Vector3,
+        _incident_direction: Vector3,
+        _normal: Vector3,
         _u: f64,
         _v: f64,
         _p: Point,
-    ) -> Color {
+    ) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         // delta-function BRDF — never called, bypassed via ScatterRecord::Delta
-        Color::BLACK
+        ColorSpectrum::ZERO
     }
 
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -41,10 +41,9 @@ impl Dielectric {
     /// Sellmeier equation fitted from the user-provided IOR.
     ///
     /// The user's IOR is assumed to be n_D — the refractive index at the
-    /// sodium D-line (589.3nm). A single Sellmeier term with C₁ = 0.01 µm²
-    /// provides physically plausible dispersion for optical glass:
-    /// shorter wavelengths → higher IOR, with ~0.01 variation across the
-    /// visible range at IOR ≈ 1.5.
+    /// sodium D-line (589.3nm). A single Sellmeier term with an IOR-dependent
+    /// C₁ provides physically plausible dispersion across a wide range of
+    /// materials: shorter wavelengths → higher IOR.
     pub fn index_of_refraction_at(&self, wavelength_nm: f64) -> f64 {
         let lambda_um = wavelength_nm / 1000.0;
         let lambda_sq = lambda_um * lambda_um;
@@ -53,25 +52,23 @@ impl Dielectric {
         let d_um = 0.5893;
         let d_sq = d_um * d_um;
 
-        // Fixed dispersion constant (µm²) — typical for optical glass
-        let c1 = 0.01;
+        let n_sq = self.index_of_refraction * self.index_of_refraction;
+
+        // C₁ models the square of the UV resonance wavelength. Higher-index
+        // materials have their resonance closer to the visible range, producing
+        // stronger dispersion. The Sellmeier term λ²/(λ² − C₁) grows more
+        // rapidly across the visible band when C₁ is larger.
+        //
+        // n=1.5 → C₁≈0.011  (moderate dispersion)
+        // n=2.4 → C₁≈0.029  (strong dispersion, ~2.6× glass)
+        let c1 = 0.005 * n_sq;
 
         // Solve B₁ so that n(589.3nm) = user_ior
-        let n_sq = self.index_of_refraction * self.index_of_refraction;
         let b1 = (n_sq - 1.0) * (d_sq - c1) / d_sq;
 
         // n²(λ) = 1 + B₁·λ²/(λ² − C₁)
         let n_sq_lambda = 1.0 + b1 * lambda_sq / (lambda_sq - c1);
-        let nominal_ior = n_sq_lambda.sqrt().max(1.0);
-
-        // debug: amplify dispersion for visual testing.
-        // remove this multiplier (return nominal_ior) for production.
-        //
-        // const DISPERSION_MULTIPLIER: f64 = 1000.0;
-        // let dispersion = nominal_ior - self.index_of_refraction;
-        // self.index_of_refraction + dispersion * DISPERSION_MULTIPLIER
-
-        nominal_ior
+        n_sq_lambda.sqrt().max(1.0)
     }
 
     /// Compute the scattered direction for a specific wavelength using

--- a/src/shading/materials/isotropic.rs
+++ b/src/shading/materials/isotropic.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::shading::hero_wavelengths::{HERO_WAVELENGTH_COUNT, HeroWavelengths};
 use crate::{
     geometry::{Point, Ray, RayHit, Vector3},
     shading::{ColorSpectrum, Texture, color_spectrum::SPECTRAL_SAMPLE_COUNT},
@@ -43,7 +44,12 @@ impl Material for Isotropic {
         false
     }
 
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
+    fn scatter(
+        &self,
+        ray: Ray,
+        ray_hit: &RayHit,
+        _hw: &HeroWavelengths<HERO_WAVELENGTH_COUNT>,
+    ) -> Option<ScatterRecord> {
         // always scatter, and always scatter in a random direction
         Some(ScatterRecord::Delta {
             scattered: Ray::new(ray_hit.point, Vector3::random_unit(), ray.time),

--- a/src/shading/materials/isotropic.rs
+++ b/src/shading/materials/isotropic.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Point, Ray, RayHit, Vector},
-    shading::{Color, Texture},
+    geometry::{Point, Ray, RayHit, Vector3},
+    shading::{ColorSpectrum, Texture, color_spectrum::SPECTRAL_SAMPLE_COUNT},
 };
 
 use super::{Material, ScatterRecord};
@@ -23,16 +23,16 @@ impl Isotropic {
 }
 
 impl Material for Isotropic {
-    fn reflectance(&self, u: f64, v: f64, p: Point) -> Color {
+    fn reflectance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         self.reflectance_texture.value(u, v, p)
     }
 
-    fn emittance(&self, u: f64, v: f64, p: Point) -> Color {
+    fn emittance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         self.emittance_texture.value(u, v, p)
     }
 
     fn is_emissive(&self) -> bool {
-        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
+        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != ColorSpectrum::ZERO
     }
 
     fn is_transmissive(&self) -> bool {
@@ -46,19 +46,19 @@ impl Material for Isotropic {
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
         // always scatter, and always scatter in a random direction
         Some(ScatterRecord::Delta {
-            scattered: Ray::new(ray_hit.point, Vector::random_unit(), ray.time),
+            scattered: Ray::new(ray_hit.point, Vector3::random_unit(), ray.time),
         })
     }
 
     fn brdf(
         &self,
-        _outgoing_direction: Vector,
-        _incident_direction: Vector,
-        _normal: Vector,
+        _outgoing_direction: Vector3,
+        _incident_direction: Vector3,
+        _normal: Vector3,
         u: f64,
         v: f64,
         p: Point,
-    ) -> Color {
+    ) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         let albedo = self.reflectance_texture.value(u, v, p);
         albedo / (4.0 * std::f64::consts::PI)
     }

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -2,8 +2,10 @@ use std::sync::Arc;
 
 use crate::shading::pdf::Pdf;
 use crate::{
-    geometry::{Onb, Point, Ray, RayHit, Vector},
-    shading::{Color, Texture, textures::SolidColor},
+    geometry::{Onb, Point, Ray, RayHit, Vector3},
+    shading::{
+        ColorSpectrum, Texture, color_spectrum::SPECTRAL_SAMPLE_COUNT, textures::SolidColor,
+    },
 };
 
 use super::{Material, ScatterRecord};
@@ -40,16 +42,16 @@ impl Lambertian {
 }
 
 impl Material for Lambertian {
-    fn reflectance(&self, u: f64, v: f64, p: Point) -> Color {
+    fn reflectance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         self.reflectance_texture.value(u, v, p)
     }
 
-    fn emittance(&self, u: f64, v: f64, p: Point) -> Color {
+    fn emittance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         self.emittance_texture.value(u, v, p)
     }
 
     fn is_emissive(&self) -> bool {
-        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
+        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != ColorSpectrum::ZERO
     }
 
     fn is_transmissive(&self) -> bool {
@@ -68,13 +70,13 @@ impl Material for Lambertian {
 
     fn brdf(
         &self,
-        _outgoing_direction: Vector,
-        _incident_direction: Vector,
-        _normal: Vector,
+        _outgoing_direction: Vector3,
+        _incident_direction: Vector3,
+        _normal: Vector3,
         u: f64,
         v: f64,
         p: Point,
-    ) -> Color {
+    ) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         let albedo = self.reflectance_texture.value(u, v, p);
         albedo / std::f64::consts::PI
     }

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::shading::hero_wavelengths::{HERO_WAVELENGTH_COUNT, HeroWavelengths};
 use crate::shading::pdf::Pdf;
 use crate::{
     geometry::{Onb, Point, Ray, RayHit, Vector3},
@@ -62,7 +63,12 @@ impl Material for Lambertian {
         false
     }
 
-    fn scatter(&self, _ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
+    fn scatter(
+        &self,
+        _ray: Ray,
+        ray_hit: &RayHit,
+        _hw: &HeroWavelengths<HERO_WAVELENGTH_COUNT>,
+    ) -> Option<ScatterRecord> {
         Some(ScatterRecord::Pdf(Pdf::CosineHemisphere(Onb::from_w(
             ray_hit.normal,
         ))))

--- a/src/shading/materials/specular.rs
+++ b/src/shading/materials/specular.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Point, Ray, RayHit, Vector},
-    shading::{Color, Texture},
+    geometry::{Point, Ray, RayHit, Vector3},
+    shading::{ColorSpectrum, Texture, color_spectrum::SPECTRAL_SAMPLE_COUNT},
 };
 
 use super::{Material, ScatterRecord};
@@ -29,16 +29,16 @@ impl Specular {
 }
 
 impl Material for Specular {
-    fn reflectance(&self, u: f64, v: f64, p: Point) -> Color {
+    fn reflectance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         self.reflectance_texture.value(u, v, p)
     }
 
-    fn emittance(&self, u: f64, v: f64, p: Point) -> Color {
+    fn emittance(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         self.emittance_texture.value(u, v, p)
     }
 
     fn is_emissive(&self) -> bool {
-        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != Color::BLACK
+        self.emittance_texture.value(0.5, 0.5, Point::ORIGIN) != ColorSpectrum::ZERO
     }
 
     fn is_transmissive(&self) -> bool {
@@ -51,15 +51,15 @@ impl Material for Specular {
 
     fn brdf(
         &self,
-        _outgoing_direction: Vector,
-        _incident_direction: Vector,
-        _normal: Vector,
+        _outgoing_direction: Vector3,
+        _incident_direction: Vector3,
+        _normal: Vector3,
         _u: f64,
         _v: f64,
         _p: Point,
-    ) -> Color {
+    ) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         // delta-function BRDF — never called, bypassed via ScatterRecord::Delta
-        Color::BLACK
+        ColorSpectrum::ZERO
     }
 
     fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
@@ -67,7 +67,7 @@ impl Material for Specular {
 
         let scattered = Ray::new(
             ray_hit.point,
-            reflected + self.roughness * Vector::random_unit(),
+            reflected + self.roughness * Vector3::random_unit(),
             ray.time,
         );
 

--- a/src/shading/materials/specular.rs
+++ b/src/shading/materials/specular.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::shading::hero_wavelengths::{HERO_WAVELENGTH_COUNT, HeroWavelengths};
 use crate::{
     geometry::{Point, Ray, RayHit, Vector3},
     shading::{ColorSpectrum, Texture, color_spectrum::SPECTRAL_SAMPLE_COUNT},
@@ -62,7 +63,12 @@ impl Material for Specular {
         ColorSpectrum::ZERO
     }
 
-    fn scatter(&self, ray: Ray, ray_hit: &RayHit) -> Option<ScatterRecord> {
+    fn scatter(
+        &self,
+        ray: Ray,
+        ray_hit: &RayHit,
+        _hw: &HeroWavelengths<HERO_WAVELENGTH_COUNT>,
+    ) -> Option<ScatterRecord> {
         let reflected = ray.direction.unit_vector().reflect_around(ray_hit.normal);
 
         let scattered = Ray::new(

--- a/src/shading/pdf.rs
+++ b/src/shading/pdf.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::geometry::{Geometric, Onb, Point, Vector};
+use crate::geometry::{Geometric, Onb, Point, Vector3};
 
 /// A probability density function over solid angle.
 #[derive(Debug, Clone)]
@@ -31,19 +31,19 @@ pub enum Pdf {
 impl Pdf {
     /// Draw a random unit direction and the index of the strategy that produced it.
     /// For non-Mixture variants, the index is always 0.
-    pub fn sample(&self) -> (Vector, usize) {
+    pub fn sample(&self) -> (Vector3, usize) {
         match self {
             Pdf::CosineHemisphere(onb) => {
-                (onb.to_world(Vector::random_cosine_weighted_direction()), 0)
+                (onb.to_world(Vector3::random_cosine_weighted_direction()), 0)
             }
             Pdf::UniformHemisphere(onb) => {
-                let mut direction = Vector::random_unit();
+                let mut direction = Vector3::random_unit();
                 if direction.z < 0.0 {
                     direction = -direction;
                 }
                 (onb.to_world(direction), 0)
             }
-            Pdf::UniformSphere => (Vector::random_unit(), 0),
+            Pdf::UniformSphere => (Vector3::random_unit(), 0),
             Pdf::Geometric { geometric, origin } => (geometric.sample_direction_from(*origin), 0),
             Pdf::Mixture { entries } => {
                 let threshold: f64 = rand::random();
@@ -61,7 +61,7 @@ impl Pdf {
     }
 
     /// The solid-angle probability density at `direction`.
-    pub fn density(&self, direction: Vector) -> f64 {
+    pub fn density(&self, direction: Vector3) -> f64 {
         match self {
             Pdf::CosineHemisphere(onb) => {
                 let cos_theta = onb.w.dot(direction);
@@ -91,7 +91,7 @@ impl Pdf {
     ///
     /// For Mixture: `p_idx² / Σ p_i²`, where `p_i = weight_i × density_i(direction)`.
     /// For all other variants: 1.0 (single strategy, no MIS needed).
-    pub fn power_heuristic(&self, direction: Vector, strategy_idx: usize) -> f64 {
+    pub fn power_heuristic(&self, direction: Vector3, strategy_idx: usize) -> f64 {
         match self {
             Pdf::Mixture { entries } => {
                 // un-normalized densities: p_i = weight_i × density_i(dir)
@@ -115,7 +115,7 @@ impl Pdf {
     ///
     /// For Mixture, this is the joint density `w_s × p_s(dir)`.
     /// For all other variants, this is just `density(dir)`.
-    pub fn strategy_density(&self, direction: Vector, strategy_idx: usize) -> f64 {
+    pub fn strategy_density(&self, direction: Vector3, strategy_idx: usize) -> f64 {
         match self {
             Pdf::Mixture { entries } => {
                 let (pdf, weight) = &entries[strategy_idx];

--- a/src/shading/textures.rs
+++ b/src/shading/textures.rs
@@ -1,6 +1,6 @@
 use crate::geometry::Point;
 
-use super::Color;
+use super::{ColorSpectrum, color_spectrum::SPECTRAL_SAMPLE_COUNT};
 
 mod checker;
 pub use checker::Checker;
@@ -15,5 +15,5 @@ mod solid_color;
 pub use solid_color::SolidColor;
 
 pub trait Texture: std::fmt::Debug + Sync + Send {
-    fn value(&self, u: f64, v: f64, p: Point) -> Color;
+    fn value(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT>;
 }

--- a/src/shading/textures/checker.rs
+++ b/src/shading/textures/checker.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::{geometry::Point, shading::Color};
+use crate::{
+    geometry::Point,
+    shading::{ColorSpectrum, color_spectrum::SPECTRAL_SAMPLE_COUNT},
+};
 
 use super::{SolidColor, Texture};
 
@@ -20,7 +23,11 @@ impl Checker {
         }
     }
 
-    pub fn from_colors(scale: f64, even: Color, odd: Color) -> Self {
+    pub fn from_colors(
+        scale: f64,
+        even: ColorSpectrum<SPECTRAL_SAMPLE_COUNT>,
+        odd: ColorSpectrum<SPECTRAL_SAMPLE_COUNT>,
+    ) -> Self {
         Self {
             inverse_scale: 1.0 / scale,
             even: Arc::new(SolidColor::new(even)),
@@ -30,7 +37,7 @@ impl Checker {
 }
 
 impl Texture for Checker {
-    fn value(&self, u: f64, v: f64, p: Point) -> Color {
+    fn value(&self, u: f64, v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         let x_int = (p.0.x * self.inverse_scale).floor() as i32;
         let y_int = (p.0.y * self.inverse_scale).floor() as i32;
         let z_int = (p.0.z * self.inverse_scale).floor() as i32;

--- a/src/shading/textures/image.rs
+++ b/src/shading/textures/image.rs
@@ -1,6 +1,10 @@
 use image::RgbaImage;
 
-use crate::{geometry::Point, shading::Color, utils::Interval};
+use crate::{
+    geometry::Point,
+    shading::{ColorRgb, ColorSpectrum, color_spectrum::SPECTRAL_SAMPLE_COUNT},
+    utils::Interval,
+};
 
 use super::Texture;
 
@@ -19,7 +23,7 @@ impl Image8Bit {
 
         // gamma correction
         for p in image.pixels_mut() {
-            *p = Color::from_rgba_u8(p).as_gamma_corrected_rgba_u8(gamma);
+            *p = ColorRgb::from_rgba_u8(p).as_gamma_corrected_rgba_u8(gamma);
         }
 
         Ok(Self::new(image))
@@ -27,7 +31,7 @@ impl Image8Bit {
 }
 
 impl Texture for Image8Bit {
-    fn value(&self, u: f64, v: f64, _p: Point) -> Color {
+    fn value(&self, u: f64, v: f64, _p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         let u = Interval::new(0.0, 1.0).clamp(u);
         let v = 1.0 - Interval::new(0.0, 1.0).clamp(v);
 
@@ -35,12 +39,12 @@ impl Texture for Image8Bit {
         let y = (v * self.image.height() as f64) as u32;
 
         let pixel = self.image.get_pixel(x, y);
-        let scale = 1.0 / 255.0;
 
-        Color::new(
-            pixel[0] as f64 * scale,
-            pixel[1] as f64 * scale,
-            pixel[2] as f64 * scale,
+        ColorRgb::new(
+            pixel[0] as f64 / 255.0,
+            pixel[1] as f64 / 255.0,
+            pixel[2] as f64 / 255.0,
         )
+        .into()
     }
 }

--- a/src/shading/textures/noise.rs
+++ b/src/shading/textures/noise.rs
@@ -1,6 +1,9 @@
 use noise::NoiseFn;
 
-use crate::{geometry::Point, shading::Color};
+use crate::{
+    geometry::Point,
+    shading::{ColorSpectrum, color_spectrum::SPECTRAL_SAMPLE_COUNT},
+};
 
 use super::Texture;
 
@@ -63,7 +66,7 @@ where
     Input: Fn(Point) -> Point + Sync + Send,
     Output: Fn(f64, Point) -> f64 + Sync + Send,
 {
-    fn value(&self, _u: f64, _v: f64, p: Point) -> Color {
+    fn value(&self, _u: f64, _v: f64, p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         let input = match self.input_fn {
             Some(ref input_fn) => input_fn(p),
             None => p,
@@ -74,6 +77,6 @@ where
             None => val,
         };
 
-        Color::WHITE * output
+        ColorSpectrum::ONE * output
     }
 }

--- a/src/shading/textures/solid_color.rs
+++ b/src/shading/textures/solid_color.rs
@@ -1,25 +1,34 @@
-use crate::{geometry::Point, shading::Color};
+use crate::{
+    geometry::Point,
+    shading::{ColorRgb, ColorSpectrum, color_spectrum::SPECTRAL_SAMPLE_COUNT},
+};
 
 use super::Texture;
 
 #[derive(Debug, Clone)]
-pub struct SolidColor(Color);
+pub struct SolidColor(ColorSpectrum<SPECTRAL_SAMPLE_COUNT>);
 
 impl SolidColor {
-    pub const BLACK: Self = Self(Color::BLACK);
-    pub const WHITE: Self = Self(Color::WHITE);
+    pub const BLACK: Self = Self(ColorSpectrum::ZERO);
+    pub const WHITE: Self = Self(ColorSpectrum::ONE);
 
-    pub fn new(color: Color) -> Self {
+    pub fn new(color: ColorSpectrum<SPECTRAL_SAMPLE_COUNT>) -> Self {
         Self(color)
     }
 
     pub fn from_rgb(r: f64, g: f64, b: f64) -> Self {
-        Self(Color::new(r, g, b))
+        Self(ColorRgb::new(r, g, b).into())
+    }
+}
+
+impl From<ColorRgb> for SolidColor {
+    fn from(color: ColorRgb) -> Self {
+        Self(color.into())
     }
 }
 
 impl Texture for SolidColor {
-    fn value(&self, _u: f64, _v: f64, _p: Point) -> Color {
+    fn value(&self, _u: f64, _v: f64, _p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         self.0
     }
 }

--- a/src/tracing/scene.rs
+++ b/src/tracing/scene.rs
@@ -6,7 +6,7 @@ use crate::{
         Geometric,
         compounds::{Bvh, List},
     },
-    shading::Color,
+    shading::{ColorSpectrum, color_spectrum::SPECTRAL_SAMPLE_COUNT},
 };
 
 #[derive(Clone)]
@@ -14,7 +14,7 @@ pub struct Scene {
     pub world: SceneWorld,
 
     pub camera: Camera,
-    pub background_color: Color,
+    pub background_color: ColorSpectrum<SPECTRAL_SAMPLE_COUNT>,
 }
 
 #[derive(Clone)]

--- a/src/tracing/storage.rs
+++ b/src/tracing/storage.rs
@@ -16,7 +16,7 @@ use image::RgbaImage;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{deserialization::RenderConfig, shading::Color, utils::ProgressInfo};
+use crate::{deserialization::RenderConfig, shading::ColorRgb, utils::ProgressInfo};
 
 use super::{PixelData, RenderParameters};
 
@@ -127,7 +127,7 @@ impl RenderCheckpoint {
         for (x, y, pixel) in image.enumerate_pixels() {
             pixel_data.insert(
                 (x, y),
-                Color::from_gamma_corrected_rgba_u8(pixel, params.gamma_correction),
+                ColorRgb::from_gamma_corrected_rgba_u8(pixel, params.gamma_correction),
             );
         }
         Self {

--- a/src/tracing/storage/in_memory.rs
+++ b/src/tracing/storage/in_memory.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use futures::StreamExt;
 use tokio::sync::RwLock;
 
-use crate::{shading::Color, utils::ProgressInfo};
+use crate::{shading::ColorRgb, utils::ProgressInfo};
 
 use super::{
     Render, RenderCheckpoint, RenderCheckpointMeta, RenderID, RenderState, RenderStorage,
@@ -311,7 +311,7 @@ impl RenderStorage for InMemoryStorage {
         let checkpoints = self.checkpoints.read().await;
 
         let key_size = std::mem::size_of::<(u32, u32)>();
-        let val_size = std::mem::size_of::<Color>();
+        let val_size = std::mem::size_of::<ColorRgb>();
 
         let entry_size_bytes = (key_size + val_size) as u64;
 

--- a/src/tracing/tracer.rs
+++ b/src/tracing/tracer.rs
@@ -4,9 +4,9 @@ use rand::seq::SliceRandom;
 use rayon::prelude::*;
 use tokio::sync::mpsc;
 
-use crate::{deserialization::RenderData, shading::Color};
+use crate::{deserialization::RenderData, shading::ColorRgb};
 
-pub type PixelData = HashMap<(u32, u32), Color>;
+pub type PixelData = HashMap<(u32, u32), ColorRgb>;
 
 #[derive(Debug, Copy, Clone)]
 pub struct ProgressPacket {
@@ -82,7 +82,7 @@ impl Tracer {
                             let stratified_count = grid_size * grid_size;
 
                             let color = (0..parameters.samples_per_checkpoint).fold(
-                                Color::BLACK,
+                                ColorRgb::BLACK,
                                 |acc, i| {
                                     let ray = if i < stratified_count {
                                         cam.get_ray_stratified(
@@ -111,7 +111,7 @@ impl Tracer {
                             let scaled_color = color / parameters.samples_per_checkpoint as f64;
 
                             // scale relative to the current round
-                            let img_color = pixel_data.get(&(x, y)).unwrap_or(&Color::BLACK);
+                            let img_color = pixel_data.get(&(x, y)).unwrap_or(&ColorRgb::BLACK);
                             let weighted_color = (img_color * (checkpoint - 1) as f64
                                 + scaled_color)
                                 / checkpoint as f64;


### PR DESCRIPTION
Implements issue #29 — wavelength-based spectral color rendering alongside RGB.

## What's new

- **`ColorSpectrum<8>`** — 8-sample spectral color type (380–780nm, 57nm spacing) replacing RGB internally
- **Smits (1999) RGB→spectrum reconstruction** — round-trips white/gray perfectly via constrained Tikhonov regularization with 7 basis spectra
- **Hero wavelength sampling** — 4 stratified random wavelengths per camera ray, sharing geometric exploration
- **CIE 1931** — standard 2° observer color matching functions for spectrum→RGB display conversion
- **Sellmeier dispersion** — IOR-dependent Sellmeier equation with physically-motivated C₁ = 0.005×n², continuous for all IORs (no lookup table, no cliffs)
- **Dielectric splitting** — `ScatterRecord::Spectral` spawns per-wavelength sub-paths at glass boundaries; `trace_spectral` handles both shared-geometry (N=4) and recursive sub-paths (N=1)
- **Generic `Vector<N>`** — const-generic arithmetic array type, used for hero wavelength tracking in the integrator
- **`ColorRgb` / `Vector3`** — geometric Vector renamed to Vector3, RGB output type renamed to ColorRgb

## Architecture

```
Config (RGB) → Smits → ColorSpectrum<8> → hero wavelengths → scalar path → CIE → ColorRgb (output)
```

The `Color`/RGB type lives only at the boundaries (config input, display output, checkpoint storage). All internal rendering operates on spectral scalars.

## Breakdown

| Layer | Lines | What |
|---|---|---|
| `color_spectrum.rs` | ~690 | Spectrum type, Smits, CIE, operators, `from_rgb`/`to_rgb` |
| `hero_wavelengths.rs` | ~92 | Hero wavelength struct, stratified picker, `to_color_rgb` |
| `dielectric.rs` | ~+50 | Per-λ Sellmeier, `refract_at`, `Spectral` scatter |
| `camera.rs` | ~+60 | `trace_spectral::<N>`, `Spectral` match arm, `ray_color` delegation |
| `vector.rs` | ~170 | Const-generic `Vector<N>` with element-wise arithmetic |
| `vector3.rs` | ~340 | Renamed `Vector3` geometric type