### PR TITLE
chore: audit and clean up AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,47 +11,34 @@ The `ui/` directory is the React frontend.
 ## 2. Tech Stack
 
 ### Backend (Rust)
-- **Web framework**: Axum 0.8 with tower-http (CORS)
-- **Database**: SQLx 0.8 with PostgreSQL (also supports FileStorage and InMemoryStorage backends)
+- **Web framework**: Axum with tower-http (CORS)
+- **Database**: SQLx with PostgreSQL (also supports FileStorage and InMemoryStorage backends)
 - **Auth**: GitHub OAuth2 → JWT (RS256, 24hr expiry)
 - **Rendering**: Custom path tracing engine in `src/tracing/` (rayon-parallel, tile-based)
-- **CLI**: clap 4.5 for the `luxide-cli` binary
-- **Key deps**: tokio, serde/serde_json, uuid, chrono, reqwest, image, dashmap
+- **CLI**: clap for the `luxide-cli` binary
 
 ### Frontend (React + TypeScript)
-- **Build**: Vite 8 + TypeScript ~6.0
-- **Routing**: react-router-dom v7
-- **State/Data**: @tanstack/react-query ^5.100 (server state, 1s polling), @tanstack/react-form ^1.32 + @tanstack/zod-form-adapter (form state)
-- **3D Preview**: @react-three/fiber ^9.6 + @react-three/drei ^10.7 + three ^0.184
-- **UI Kit**: flowbite-react ^0.12
+- **Build**: Vite + TypeScript
+- **Routing**: react-router-dom
+- **State/Data**: @tanstack/react-query (server state, 1s polling), @tanstack/react-form + @tanstack/zod-form-adapter (form state)
+- **3D Preview**: @react-three/fiber + @react-three/drei + three
+- **UI Kit**: flowbite-react
 - **UI Kit Reference**: https://flowbite-react.com/llms.txt
-- **Animation**: framer-motion ^12.40
-- **Validation**: zod ^3.25
+- **Animation**: framer-motion
+- **Validation**: zod
 - **CSS**: Tailwind CSS v4 (configured entirely in CSS, no config file; dark mode via `.dark` class)
-- **Icons**: react-icons ^5.6
+- **Icons**: react-icons
 
 ---
 
 ## 3. Directory Structure
 
 - `src/` — Rust backend: HTTP API server, CLI renderer, path tracing engine, geometry/shading libraries
-  - `src/bin/api.rs` — luxide-api binary entry point
-  - `src/bin/cli.rs` — luxide-cli binary entry point
-  - `src/server/` — Axum HTTP server: router, handlers (14+ endpoints), auth manager, state
-  - `src/tracing/` — Core render engine: tracer (rayon-parallel), render manager (state machine), storage backends (Postgres, File, InMemory)
-  - `src/deserialization/` — JSON/YAML render config deserialization and compilation (scenes, cameras, geometrics, materials, textures)
-  - `src/geometry/` — Geometric primitives (sphere, triangle, parallelogram), transforms, BVH, OBJ loader, volumes
-  - `src/shading/` — Materials (lambertian, specular, dielectric, isotropic) and textures (solid color, checker, image, noise)
-  - `src/utils/` — Utilities: binary encoding, progress tracking, intervals, time formatting
-- `ui/` — React SPA frontend (active)
-  - `ui/src/views/` — Page-level components organized by route (Layout, home, login, renders, render-detail, render-new)
-  - `ui/src/hooks/` — React Query hooks (useRenders, useRender, useLatestCheckpointImage) + TanStack Form hook (useRenderForm)
-  - `ui/src/utils/` — API client (api.ts), Zod schemas for render config domain model, THREE.js helpers
-  - `ui/src/providers/` — AuthProvider (React Context + localStorage token management)
-- `migrations/` — SQLx PostgreSQL migrations (7 migration pairs)
+- `ui/` — React SPA frontend (active): page views, shared components, hooks, providers, API client utils, layouts
+- `migrations/` — SQLx PostgreSQL migrations (9 up/down pairs)
 - `models/` — 3D model files (teapot.obj, teapot_normals.obj)
 - `configs/` — Example render configurations (JSON + YAML, Cornell box variants)
-- `benches/` — Criterion benchmarks (AABB, parallelogram, sphere)
+- `benches/` — Criterion benchmarks
 - `bruno/` — Bruno API client collections for testing endpoints
 - `texture_images/` — Texture images for rendering
 
@@ -60,7 +47,7 @@ The `ui/` directory is the React frontend.
 ## 4. Key Architectural Decisions
 
 - **TanStack Form over alternatives**: Chosen for headless, type-safe form management with Zod schema integration. All render configuration forms use TanStack Form with the Zod adapter.
-- **R3F (React Three Fiber) over Threlte**: Since the project migrated to React, R3F is the natural React renderer for Three.js. The 3D scene preview is built with R3F + drei helpers.
+- **R3F (React Three Fiber) is the React renderer for Three.js**: The 3D scene preview is built with R3F + drei helpers.
 - **3D scene preview embedded in `views/render-new/`**: The 3D preview canvas is tightly coupled to the "new render" creation page rather than being a standalone reusable component. This is because the preview is only needed during scene creation — once a render is submitted, the backend handles the actual path tracing and the UI displays checkpoint images.
 - **Trait-based storage backends**: The `RenderStorage` and `UserStorage` traits allow swapping between PostgreSQL, filesystem, and in-memory storage via config. Both the API server and CLI use the same storage abstraction.
 - **GitHub OAuth → JWT auth flow**: Users authenticate via GitHub OAuth2. On callback, the server creates/finds the user, issues a RS256-signed JWT (24hr). Subsequent requests use `Authorization: Bearer <token>`. Admin users (defined in secrets) get unlimited resource quotas.
@@ -124,10 +111,8 @@ Dark mode requires THREE things simultaneously:
 - The Rust crate uses `#![forbid(unsafe_code)]` — no unsafe Rust anywhere.
 - Rust edition: 2024
 - Database: PostgreSQL with JSONB columns for render state and config, BYTEA for bincode-encoded pixel data.
-- The backend embeds the built UI at compile time via `include_dir!`, so `just build-api` builds the UI first.
 - The API server's Vite dev proxy forwards `/api` to `localhost:8080` for development; in production the API serves the UI directly.
 
 ## 7. React Component Conventions
 
-Load the `react-code-conventions` skill (`.opencode/skills/react-code-conventions/`) when editing any TypeScript file in `ui/src/`. All UI components must use
-`export type` props, function declaration, and first-line destructure.
+Load the `react-code-conventions` skill (`.opencode/skills/react-code-conventions/`) when editing any TypeScript file in `ui/src/`. All UI components must use `export type` props, function declaration, and first-line destructure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,6 @@ Luxide is a **ray tracing render manager** — a multi-tenant platform where use
 - A **Rust backend** (HTTP API server + CLI renderer) with a custom path tracing engine
 - A **React SPA frontend** for creating render configurations and monitoring progress
 
-The `ui/` directory is the React frontend.
-
 ---
 
 ## 2. Tech Stack
@@ -15,19 +13,12 @@ The `ui/` directory is the React frontend.
 - **Database**: SQLx with PostgreSQL (also supports FileStorage and InMemoryStorage backends)
 - **Auth**: GitHub OAuth2 → JWT (RS256, 24hr expiry)
 - **Rendering**: Custom path tracing engine in `src/tracing/` (rayon-parallel, tile-based)
-- **CLI**: clap for the `luxide-cli` binary
 
 ### Frontend (React + TypeScript)
-- **Build**: Vite + TypeScript
-- **Routing**: react-router-dom
 - **State/Data**: @tanstack/react-query (server state, 1s polling), @tanstack/react-form + @tanstack/zod-form-adapter (form state)
 - **3D Preview**: @react-three/fiber + @react-three/drei + three
-- **UI Kit**: flowbite-react
-- **UI Kit Reference**: https://flowbite-react.com/llms.txt
-- **Animation**: framer-motion
-- **Validation**: zod
+- **UI Kit**: flowbite-react — reference: https://flowbite-react.com/llms.txt
 - **CSS**: Tailwind CSS v4 (configured entirely in CSS, no config file; dark mode via `.dark` class)
-- **Icons**: react-icons
 
 ---
 
@@ -36,11 +27,6 @@ The `ui/` directory is the React frontend.
 - `src/` — Rust backend: HTTP API server, CLI renderer, path tracing engine, geometry/shading libraries
 - `ui/` — React SPA frontend (active): page views, shared components, hooks, providers, API client utils, layouts
 - `migrations/` — SQLx PostgreSQL migrations (9 up/down pairs)
-- `models/` — 3D model files (teapot.obj, teapot_normals.obj)
-- `configs/` — Example render configurations (JSON + YAML, Cornell box variants)
-- `benches/` — Criterion benchmarks
-- `bruno/` — Bruno API client collections for testing endpoints
-- `texture_images/` — Texture images for rendering
 
 ---
 
@@ -70,10 +56,6 @@ The `ui/` directory is the React frontend.
 | `just build-ui`                 | Setup Node env + build React UI                                  |
 | `just clean`                    | Cargo clean + remove ui/dist + stop Docker                       |
 | `just generate-jwt-keypair-pem` | Generate RSA keypair for JWT signing                             |
-| `cd ui && npm run dev`          | Start Vite dev server (port 5173, proxies /api → localhost:8080) |
-| `cd ui && npm run build`        | TypeScript check + Vite production build (outputs to ../ui/dist) |
-| `cd ui && npm run lint`         | Run ESLint                                                       |
-| `cargo build --release`         | Build both Rust binaries                                         |
 
 Note: The `just build-api` and `just run` commands embed the UI's `dist/` folder into the Rust binary at compile time via `include_dir!`. The API server serves the React SPA alongside the API routes.
 
@@ -103,15 +85,7 @@ Dark mode requires THREE things simultaneously:
 ### Backend
 - `luxide.json` and `luxide.secret.json` in the repo root are the API config and secrets files (not checked into git; templates should exist).
 - The Rust project is a single crate with two binaries (NOT a workspace with multiple crates).
-
----
-
-## Additional Notes
-
 - The Rust crate uses `#![forbid(unsafe_code)]` — no unsafe Rust anywhere.
-- Rust edition: 2024
-- Database: PostgreSQL with JSONB columns for render state and config, BYTEA for bincode-encoded pixel data.
-- The API server's Vite dev proxy forwards `/api` to `localhost:8080` for development; in production the API serves the UI directly.
 
 ## 7. React Component Conventions
 


### PR DESCRIPTION
A thorough audit of AGENTS.md followed by targeted cleanup. Changes:

### Errors fixed
- **Migration count**: 7 → 9 pairs (two were added since last update)
- **Stale directory listing**: Removed per-directory inventories that had drifted (wrong view names, missing `components/` and `layouts/`, stale hook/provider counts)
- **Truncated sentence** in Section 7 (React Component Conventions) — joined across line break

### Cruft removed
- **Version numbers** from all Tech Stack entries — they rot within weeks and add no value for a document consumed by LLM agents
- **"Key deps" line** — an arbitrary 7-of-25 selection from Cargo.toml
- **Threlte comparison + migration history** in Section 4 — past-tense decision history is dead weight
- **Duplicate `include_dir!` note** — same info was stated in two places

### Structural improvement
- **Directory Structure section** (Section 3) trimmed from 20-line detailed tree to 8-line conceptual overview. Agents can `read` directories faster than stale prose.