### PR TITLE
chore: update example render configs to match current schema

### DIFF
--- a/configs/cornell_box.json
+++ b/configs/cornell_box.json
@@ -1,32 +1,47 @@
 {
+  "name": "Cornell Box",
   "parameters": {
-    "image_dimensions": [ 500, 500 ],
-    "tile_dimensions": [ 1, 1 ],
-    "gamma_correction": 2,
-    "samples_per_checkpoint": 1,
-    "checkpoints": 10,
-    "max_bounces": 50,
-    "use_scaling_truncation": true
+    "image_dimensions": [500, 500],
+    "tile_dimensions": [1, 1],
+    "gamma_correction": 2.0,
+    "samples_per_checkpoint": 16,
+    "total_checkpoints": 100,
+    "saved_checkpoint_limit": 1,
+    "bounces": {
+      "max": 50,
+      "use_russian_roulette_after": 3
+    },
+    "use_scaling_truncation": true,
+    "importance_sampling": {
+      "brdf_weight": 1.0,
+      "emissive_weight": 1.0,
+      "transmissive_weight": 0.0,
+      "specular_weight": 0.0,
+      "virtual_weight": 0.0,
+      "use_multiple_importance_sampling": true
+    }
   },
-  "active_scene": {
-    "name": "cornell_box",
-    "geometrics": [
-      "left_wall",
-      "right_wall",
-      "floor",
-      "ceiling",
-      "back_wall",
-      "front_wall",
-      "far_left_box",
-      "near_right_box",
-      "near_right_box_internal"
-    ],
-    "use_bvh": true,
-    "camera": "basic",
-    "background_color": [ 0, 0, 0 ]
+  "active_scene": "Cornell Box",
+  "scenes": {
+    "Cornell Box": {
+      "geometrics": [
+        "left_wall",
+        "right_wall",
+        "floor",
+        "ceiling",
+        "back_wall",
+        "front_wall",
+        "far_left_box",
+        "near_right_box",
+        "near_right_box_internal"
+      ],
+      "use_bvh": true,
+      "camera": "Main Camera",
+      "background_color": [0, 0, 0]
+    }
   },
   "cameras": {
-    "basic": {
+    "Main Camera": {
       "vertical_field_of_view_degrees": 40,
       "eye_location": [ 0.5, 0.5, 1.44144 ],
       "target_location": [ 0.5, 0.5, 0 ],

--- a/configs/cornell_box_inline.json
+++ b/configs/cornell_box_inline.json
@@ -1,234 +1,246 @@
 {
-  "parameters": {
-    "output_dir": "./output",
-    "use_subdir": true,
-    "file_basename": "image",
-    "file_ext": "png",
-    "image_dimensions": [ 600, 600 ],
-    "tile_dimensions": [ 1, 1 ],
-    "gamma_correction": 2,
-    "samples_per_checkpoint": 50,
-    "checkpoints": 50,
-    "max_bounces": 50,
-    "use_scaling_truncation": true,
-    "pixels_per_progress_update": 100,
-    "progress_memory": 50
-  },
-  "active_scene": {
-    "name": "cornell_box",
-    "geometrics": [
-      "left_wall",
-      "right_wall",
-      "floor",
-      "ceiling",
-      "back_wall",
-      "front_wall",
-      "far_left_box",
-      "near_right_box",
-      "near_right_box_internal"
-    ],
-    "use_bvh": true,
-    "camera": {
-      "vertical_field_of_view_degrees": 40,
-      "eye_location": [ 0.5, 0.5, 1.44144 ],
-      "target_location": [ 0.5, 0.5, 0 ],
-      "view_up": [ 0, 1, 0 ],
-      "defocus_angle_degrees": 0,
-      "focus_distance": "eye_to_target"
+    "name": "Cornell Box Inline",
+    "parameters": {
+        "image_dimensions": [600, 600],
+        "tile_dimensions": [1, 1],
+        "gamma_correction": 2.0,
+        "samples_per_checkpoint": 16,
+        "total_checkpoints": 100,
+        "saved_checkpoint_limit": 1,
+        "bounces": {
+            "max": 50,
+            "use_russian_roulette_after": 3
+        },
+        "use_scaling_truncation": true,
+        "importance_sampling": {
+            "brdf_weight": 1.0,
+            "emissive_weight": 1.0,
+            "transmissive_weight": 0.0,
+            "specular_weight": 0.0,
+            "virtual_weight": 0.0,
+            "use_multiple_importance_sampling": true
+        }
     },
-    "background_color": [ 0, 0, 0 ]
-  },
-  "geometrics": {
-    "left_wall": {
-      "type": "parallelogram",
-      "lower_left": [ 0, 0, 0 ],
-      "u": [ 0, 0, -1 ],
-      "v": [ 0, 1, 0 ],
-      "material": {
-        "type": "lambertian",
-        "reflectance_texture": "solid_cb_green",
-        "emittance_texture": "solid_black"
-      }
+    "active_scene": "Main Scene",
+    "scenes": {
+        "Main Scene": {
+            "geometrics": [
+                "left_wall",
+                "right_wall",
+                "floor",
+                "ceiling",
+                "back_wall",
+                "front_wall",
+                "far_left_box",
+                "near_right_box",
+                "near_right_box_internal"
+            ],
+            "use_bvh": true,
+            "camera": "Main Camera",
+            "background_color": [0, 0, 0]
+        }
     },
-    "right_wall": {
-      "type": "parallelogram",
-      "lower_left": [ 1, 0, -1 ],
-      "u": [ 0, 0, 1 ],
-      "v": [ 0, 1, 0 ],
-      "material": {
-        "type": "lambertian",
-        "reflectance_texture": "solid_cb_red",
-        "emittance_texture": "solid_black"
-      }
+    "cameras": {
+        "Main Camera": {
+            "vertical_field_of_view_degrees": 40,
+            "eye_location": [0.5, 0.5, 1.44144],
+            "target_location": [0.5, 0.5, 0],
+            "view_up": [0, 1, 0],
+            "defocus_angle_degrees": 0,
+            "focus_distance": "eye_to_target"
+        }
     },
-    "floor": {
-      "type": "parallelogram",
-      "lower_left": [ 0, 0, 0 ],
-      "u": [ 1, 0, 0 ],
-      "v": [ 0, 0, -1 ],
-      "material": "lambertian_mike_face"
+    "geometrics": {
+        "left_wall": {
+            "type": "parallelogram",
+            "lower_left": [0, 0, 0],
+            "u": [0, 0, -1],
+            "v": [0, 1, 0],
+            "material": {
+                "type": "lambertian",
+                "reflectance_texture": "solid_cb_green",
+                "emittance_texture": "solid_black"
+            }
+        },
+        "right_wall": {
+            "type": "parallelogram",
+            "lower_left": [1, 0, -1],
+            "u": [0, 0, 1],
+            "v": [0, 1, 0],
+            "material": {
+                "type": "lambertian",
+                "reflectance_texture": "solid_cb_red",
+                "emittance_texture": "solid_black"
+            }
+        },
+        "floor": {
+            "type": "parallelogram",
+            "lower_left": [0, 0, 0],
+            "u": [1, 0, 0],
+            "v": [0, 0, -1],
+            "material": "lambertian_mike_face"
+        },
+        "ceiling": {
+            "type": "parallelogram",
+            "lower_left": [0, 1, -1],
+            "u": [1, 0, 0],
+            "v": [0, 0, 1],
+            "material": "lambertian_mike_face_glow"
+        },
+        "back_wall": {
+            "type": "parallelogram",
+            "lower_left": [0, 0, -1],
+            "u": [1, 0, 0],
+            "v": [0, 1, 0],
+            "material": "lambertian_mike_face"
+        },
+        "front_wall": {
+            "type": "parallelogram",
+            "lower_left": [1, 0, 0],
+            "u": [-1, 0, 0],
+            "v": [0, 1, 0],
+            "is_culled": true,
+            "material": "lambertian_cb_white"
+        },
+        "ceiling_light": {
+            "type": "parallelogram",
+            "lower_left": [0.35, 0.999, -0.65],
+            "u": [0.3, 0, 0],
+            "v": [0, 0, 0.3],
+            "material": "lambertian_white_light"
+        },
+        "ceiling_light_dim": {
+            "type": "parallelogram",
+            "lower_left": [0.35, 0.999, -0.65],
+            "u": [0.3, 0, 0],
+            "v": [0, 0, 0.3],
+            "material": "lambertian_white_light_dim"
+        },
+        "far_left_box_core": {
+            "type": "box",
+            "a": [0.2, 0, -0.5],
+            "b": [0.5, 0.6, -0.8],
+            "material": "dielectric_glass"
+        },
+        "far_left_box": {
+            "type": "rotate_y",
+            "geometric": {
+                "type": "box",
+                "a": [0.2, 0, -0.5],
+                "b": [0.5, 0.6, -0.8],
+                "material": "dielectric_glass"
+            },
+            "degrees": 15,
+            "around": [0.35, 0, -0.65]
+        },
+        "near_right_box": {
+            "type": "rotate_y",
+            "geometric": {
+                "type": "box",
+                "a": [0.5, 0, -0.2],
+                "b": [0.8, 0.3, -0.5],
+                "material": "dielectric_glass"
+            },
+            "degrees": -18,
+            "around": [0.65, 0, -0.35]
+        },
+        "near_right_box_internal": {
+            "type": "rotate_y",
+            "geometric": {
+                "type": "box",
+                "a": [0.52, 0.02, -0.22],
+                "b": [0.78, 0.28, -0.48],
+                "material": "lambertian_mike_face_glow"
+            },
+            "degrees": -18,
+            "around": [0.65, 0, -0.35]
+        }
     },
-    "ceiling": {
-      "type": "parallelogram",
-      "lower_left": [ 0, 1, -1 ],
-      "u": [ 1, 0, 0 ],
-      "v": [ 0, 0, 1 ],
-      "material": "lambertian_mike_face_glow"
+    "materials": {
+        "lambertian_white_light": {
+            "type": "lambertian",
+            "reflectance_texture": "solid_black",
+            "emittance_texture": {
+                "type": "color",
+                "color": [7, 7, 7]
+            }
+        },
+        "lambertian_white_light_dim": {
+            "type": "lambertian",
+            "reflectance_texture": "solid_black",
+            "emittance_texture": {
+                "type": "color",
+                "color": [3, 3, 3]
+            }
+        },
+        "lambertian_cb_red_light_dim": {
+            "type": "lambertian",
+            "reflectance_texture": "solid_cb_red",
+            "emittance_texture": {
+                "type": "color",
+                "color": [0.325, 0.025, 0.025]
+            }
+        },
+        "lambertian_cb_green_light_dim": {
+            "type": "lambertian",
+            "reflectance_texture": "solid_cb_green",
+            "emittance_texture": {
+                "type": "color",
+                "color": [0.06, 0.225, 0.075]
+            }
+        },
+        "lambertian_cb_white": {
+            "type": "lambertian",
+            "reflectance_texture": {
+                "type": "color",
+                "color": [0.73, 0.73, 0.73]
+            },
+            "emittance_texture": "solid_black"
+        },
+        "lambertian_mike_face": {
+            "type": "lambertian",
+            "reflectance_texture": "image_mike_face",
+            "emittance_texture": "solid_black"
+        },
+        "lambertian_mike_face_glow": {
+            "type": "lambertian",
+            "reflectance_texture": "image_mike_face",
+            "emittance_texture": "image_mike_face"
+        },
+        "dielectric_glass": {
+            "type": "dielectric",
+            "reflectance_texture": "solid_white",
+            "emittance_texture": "solid_black",
+            "index_of_refraction": 1.5
+        },
+        "specular_mirror": {
+            "type": "specular",
+            "reflectance_texture": "solid_white",
+            "emittance_texture": "solid_black",
+            "roughness": 0
+        }
     },
-    "back_wall": {
-      "type": "parallelogram",
-      "lower_left": [ 0, 0, -1 ],
-      "u": [ 1, 0, 0 ],
-      "v": [ 0, 1, 0 ],
-      "material": "lambertian_mike_face"
-    },
-    "front_wall": {
-      "type": "parallelogram",
-      "lower_left": [ 1, 0, 0 ],
-      "u": [ -1, 0, 0 ],
-      "v": [ 0, 1, 0 ],
-      "is_culled": true,
-      "material": "lambertian_cb_white"
-    },
-    "ceiling_light": {
-      "type": "parallelogram",
-      "lower_left": [ 0.35, 0.999, -0.65 ],
-      "u": [ 0.3, 0, 0 ],
-      "v": [ 0, 0, 0.3 ],
-      "material": "lambertian_white_light"
-    },
-    "ceiling_light_dim": {
-      "type": "parallelogram",
-      "lower_left": [ 0.35, 0.999, -0.65 ],
-      "u": [ 0.3, 0, 0 ],
-      "v": [ 0, 0, 0.3 ],
-      "material": "lambertian_white_light_dim"
-    },
-    "far_left_box_core": {
-      "type": "box",
-      "a": [ 0.2, 0, -0.5 ],
-      "b": [ 0.5, 0.6, -0.8 ],
-      "material": "dielectric_glass"
-    },
-    "far_left_box": {
-      "type": "rotate_y",
-      "geometric": {
-        "type": "box",
-        "a": [ 0.2, 0, -0.5 ],
-        "b": [ 0.5, 0.6, -0.8 ],
-        "material": "dielectric_glass"
-      },
-      "degrees": 15,
-      "around": [ 0.35, 0, -0.65 ]
-    },
-    "near_right_box": {
-      "type": "rotate_y",
-      "geometric": {
-        "type": "box",
-        "a": [ 0.5, 0, -0.2 ],
-        "b": [ 0.8, 0.3, -0.5 ],
-        "material": "dielectric_glass"
-      },
-      "degrees": -18,
-      "around": [ 0.65, 0, -0.35 ]
-    },
-    "near_right_box_internal": {
-      "type": "rotate_y",
-      "geometric": {
-        "type": "box",
-        "a": [ 0.52, 0.02, -0.22 ],
-        "b": [ 0.78, 0.28, -0.48 ],
-        "material": "lambertian_mike_face_glow"
-      },
-      "degrees": -18,
-      "around": [ 0.65, 0, -0.35 ]
+    "textures": {
+        "solid_white": {
+            "type": "color",
+            "color": [1, 1, 1]
+        },
+        "solid_black": {
+            "type": "color",
+            "color": [0, 0, 0]
+        },
+        "solid_cb_green": {
+            "type": "color",
+            "color": [0.12, 0.45, 0.15]
+        },
+        "solid_cb_red": {
+            "type": "color",
+            "color": [0.65, 0.05, 0.05]
+        },
+        "image_mike_face": {
+            "type": "image",
+            "filename": "texture_images/mike_face.png",
+            "gamma": 2
+        }
     }
-  },
-  "materials": {
-    "lambertian_white_light": {
-      "type": "lambertian",
-      "reflectance_texture": "solid_black",
-      "emittance_texture": {
-        "type": "color",
-        "color": [ 7, 7, 7 ]
-      }
-    },
-    "lambertian_white_light_dim": {
-      "type": "lambertian",
-      "reflectance_texture": "solid_black",
-      "emittance_texture": {
-        "type": "color",
-        "color": [ 3, 3, 3 ]
-      }
-    },
-    "lambertian_cb_red_light_dim": {
-      "type": "lambertian",
-      "reflectance_texture": "solid_cb_red",
-      "emittance_texture": {
-        "type": "color",
-        "color": [ 0.325, 0.025, 0.025 ]
-      }
-    },
-    "lambertian_cb_green_light_dim": {
-      "type": "lambertian",
-      "reflectance_texture": "solid_cb_green",
-      "emittance_texture": {
-        "type": "color",
-        "color": [ 0.06, 0.225, 0.075 ]
-      }
-    },
-    "lambertian_cb_white": {
-      "type": "lambertian",
-      "reflectance_texture": {
-        "type": "color",
-        "color": [ 0.73, 0.73, 0.73 ]
-      },
-      "emittance_texture": "solid_black"
-    },
-    "lambertian_mike_face": {
-      "type": "lambertian",
-      "reflectance_texture": "image_mike_face",
-      "emittance_texture": "solid_black"
-    },
-    "lambertian_mike_face_glow": {
-      "type": "lambertian",
-      "reflectance_texture": "image_mike_face",
-      "emittance_texture": "image_mike_face"
-    },
-    "dielectric_glass": {
-      "type": "dielectric",
-      "reflectance_texture": "solid_white",
-      "emittance_texture": "solid_black",
-      "index_of_refraction": 1.5
-    },
-    "specular_mirror": {
-      "type": "specular",
-      "reflectance_texture": "solid_white",
-      "emittance_texture": "solid_black",
-      "roughness": 0
-    }
-  },
-  "textures": {
-    "solid_white": {
-      "type": "color",
-      "color": [ 1, 1, 1 ]
-    },
-    "solid_black": {
-      "type": "color",
-      "color": [ 0, 0, 0 ]
-    },
-    "solid_cb_green": {
-      "type": "color",
-      "color": [ 0.12, 0.45, 0.15 ]
-    },
-    "solid_cb_red": {
-      "type": "color",
-      "color": [ 0.65, 0.05, 0.05 ]
-    },
-    "image_mike_face": {
-      "type": "image",
-      "filename": "texture_images/mike_face.png",
-      "gamma": 2
-    }
-  }
 }

--- a/configs/cornell_box_teapot.json
+++ b/configs/cornell_box_teapot.json
@@ -1,143 +1,92 @@
 {
+    "name": "Cornell Box with Teapots",
     "parameters": {
-        "output_dir": "./output",
-        "use_subdir": true,
-        "file_basename": "image",
-        "file_ext": "png",
-        "image_dimensions": [ 500, 500 ],
-        "tile_dimensions": [ 1, 1 ],
-        "gamma_correction": 2,
-        "samples_per_round": 100,
-        "round_limit": null,
-        "max_bounces": 50,
+        "image_dimensions": [500, 500],
+        "tile_dimensions": [1, 1],
+        "gamma_correction": 2.0,
+        "samples_per_checkpoint": 16,
+        "total_checkpoints": 100,
+        "saved_checkpoint_limit": 1,
+        "bounces": {
+            "max": 50,
+            "use_russian_roulette_after": 3
+        },
         "use_scaling_truncation": true,
-        "pixels_per_progress_update": 2000,
-        "progress_memory": 50
-    },
-    "active_scene": {
-        "name": "teapot",
-        "geometrics": [
-            "cornell_box",
-            {
-                "type": "rotate_y",
-                "degrees": -60,
-                "around": [ 0.3, 0.000001, -0.7 ],
-                "geometric": {
-                    "type": "obj_model",
-                    "filename": "./models/teapot.obj",
-                    "origin": [ 0.3, 0.000001, -0.7 ],
-                    "scale": 0.08,
-                    "recalculate_normals": true,
-                    "use_bvh": true,
-                    "material": {
-                        "type": "dielectric",
-                        "reflectance_texture": {
-                            "type": "color",
-                            "color": [ 0.95, 0.95, 1.0 ]
-                        },
-                        "emittance_texture": {
-                            "type": "color",
-                            "color": [ 0.0, 0.0, 0.0 ]
-                        },
-                        "index_of_refraction": 1.5
-                    }
-                }
-            },
-            {
-                "type": "rotate_y",
-                "degrees": -120,
-                "around": [ 0.7, 0.000001, -0.3 ],
-                "geometric": {
-                    "type": "obj_model",
-                    "filename": "./models/teapot.obj",
-                    "origin": [ 0.7, 0.000001, -0.3 ],
-                    "scale": 0.08,
-                    "recalculate_normals": true,
-                    "use_bvh": true,
-                    "material": {
-                        "type": "specular",
-                        "reflectance_texture": "solid_white",
-                        "emittance_texture": "solid_black",
-                        "roughness": 0.2
-                    }
-                }
-            }
-        ],
-        "use_bvh": false,
-        "camera": {
-            "vertical_field_of_view_degrees": 40,
-            "eye_location": [ 0.5, 0.5, 1.44144 ],
-            "target_location": [ 0.5, 0.5, 0 ],
-            "view_up": [ 0, 1, 0 ],
-            "defocus_angle_degrees": 0,
-            "focus_distance": "eye_to_target"
-        },
-        "background_color": [ 0, 0, 0 ]
-    },
-    "geometrics": {
-        "cb_left_wall": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 0, 0 ],
-            "u": [ 0, 0, -1 ],
-            "v": [ 0, 1, 0 ],
-            "material": {
-                "type": "lambertian",
-                "reflectance_texture": "solid_cb_green",
-                "emittance_texture": "solid_black"
-            }
-        },
-        "cb_right_wall": {
-            "type": "parallelogram",
-            "lower_left": [ 1, 0, -1 ],
-            "u": [ 0, 0, 1 ],
-            "v": [ 0, 1, 0 ],
-            "material": {
-                "type": "lambertian",
-                "reflectance_texture": "solid_cb_red",
-                "emittance_texture": "solid_black"
-            }
-        },
-        "cb_floor": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 0, 0 ],
-            "u": [ 1, 0, 0 ],
-            "v": [ 0, 0, -1 ],
-            "material": "lambertian_cb_white"
-        },
-        "cb_ceiling": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 1, -1 ],
-            "u": [ 1, 0, 0 ],
-            "v": [ 0, 0, 1 ],
-            "material": "lambertian_cb_white"
-        },
-        "cb_back_wall": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 0, -1 ],
-            "u": [ 1, 0, 0 ],
-            "v": [ 0, 1, 0 ],
-            "material": "lambertian_cb_white"
-        },
-        "cb_ceiling_light": {
-            "type": "parallelogram",
-            "lower_left": [ 0.35, 0.999, -0.65 ],
-            "u": [ 0.3, 0, 0 ],
-            "v": [ 0, 0, 0.3 ],
-            "material": "lambertian_white_light"
-        },
-        "cornell_box": {
-            "type": "list",
-            "use_bvh": true,
-            "geometrics": [
-                "cb_left_wall",
-                "cb_right_wall",
-                "cb_floor",
-                "cb_ceiling",
-                "cb_back_wall",
-                "cb_ceiling_light"
-            ]
+        "importance_sampling": {
+            "brdf_weight": 1.0,
+            "emissive_weight": 1.0,
+            "transmissive_weight": 0.0,
+            "specular_weight": 0.0,
+            "virtual_weight": 0.0,
+            "use_multiple_importance_sampling": true
         }
     },
+    "active_scene": "Teapot Scene",
+    "scenes": {
+        "Teapot Scene": {
+            "geometrics": [
+                "__cornell_box_room",
+                {
+                    "type": "rotate_y",
+                    "degrees": -60,
+                    "around": [0.3, 0.000001, -0.7],
+                    "geometric": {
+                        "type": "obj_model",
+                        "filename": "./models/teapot.obj",
+                        "origin": [0.3, 0.000001, -0.7],
+                        "scale": 0.08,
+                        "recalculate_normals": true,
+                        "use_bvh": true,
+                        "material": {
+                            "type": "dielectric",
+                            "reflectance_texture": {
+                                "type": "color",
+                                "color": [0.95, 0.95, 1.0]
+                            },
+                            "emittance_texture": {
+                                "type": "color",
+                                "color": [0.0, 0.0, 0.0]
+                            },
+                            "index_of_refraction": 1.5
+                        }
+                    }
+                },
+                {
+                    "type": "rotate_y",
+                    "degrees": -120,
+                    "around": [0.7, 0.000001, -0.3],
+                    "geometric": {
+                        "type": "obj_model",
+                        "filename": "./models/teapot.obj",
+                        "origin": [0.7, 0.000001, -0.3],
+                        "scale": 0.08,
+                        "recalculate_normals": true,
+                        "use_bvh": true,
+                        "material": {
+                            "type": "specular",
+                            "reflectance_texture": "solid_white",
+                            "emittance_texture": "solid_black",
+                            "roughness": 0.2
+                        }
+                    }
+                }
+            ],
+            "use_bvh": true,
+            "camera": "Main Camera",
+            "background_color": [0, 0, 0]
+        }
+    },
+    "cameras": {
+        "Main Camera": {
+            "vertical_field_of_view_degrees": 40,
+            "eye_location": [0.5, 0.5, 1.44144],
+            "target_location": [0.5, 0.5, 0],
+            "view_up": [0, 1, 0],
+            "defocus_angle_degrees": 0,
+            "focus_distance": "eye_to_target"
+        }
+    },
+    "geometrics": {},
     "materials": {
         "lambertian_white_light": {
             "type": "lambertian",

--- a/configs/cornell_triangle_test.json
+++ b/configs/cornell_triangle_test.json
@@ -1,128 +1,77 @@
 {
+    "name": "Cornell Triangle Test",
     "parameters": {
-        "output_dir": "./output",
-        "use_subdir": true,
-        "file_basename": "image",
-        "file_ext": "png",
-        "image_dimensions": [ 500, 500 ],
-        "tile_dimensions": [ 1, 1 ],
-        "gamma_correction": 2,
-        "samples_per_round": 100,
-        "round_limit": null,
-        "max_bounces": 50,
+        "image_dimensions": [500, 500],
+        "tile_dimensions": [1, 1],
+        "gamma_correction": 2.0,
+        "samples_per_checkpoint": 16,
+        "total_checkpoints": 100,
+        "saved_checkpoint_limit": 1,
+        "bounces": {
+            "max": 50,
+            "use_russian_roulette_after": 3
+        },
         "use_scaling_truncation": true,
-        "pixels_per_progress_update": 100,
-        "progress_memory": 50
-    },
-    "active_scene": {
-        "name": "cornell_triangle_test",
-        "geometrics": [
-            "cornell_box",
-            {
-                "type": "triangle",
-                "a": [ 0.2, 0.2, -0.2 ],
-                "b": [ 0.8, 0.2, -0.2 ],
-                "c": [ 0.2, 0.2, -0.8 ],
-                "material": {
-                    "type": "dielectric",
-                    "reflectance_texture": {
-                        "type": "color",
-                        "color": [ 0.05, 0.05, 0.75 ]
-                    },
-                    "emittance_texture": "solid_black",
-                    "index_of_refraction": 1.5
-                }
-            }
-        ],
-        "use_bvh": true,
-        "camera": {
-            "vertical_field_of_view_degrees": 40,
-            "eye_location": [ 0.5, 0.5, 1.44144 ],
-            "target_location": [ 0.5, 0.5, 0 ],
-            "view_up": [ 0, 1, 0 ],
-            "defocus_angle_degrees": 0,
-            "focus_distance": "eye_to_target"
-        },
-        "background_color": [ 0, 0, 0 ]
-    },
-    "geometrics": {
-        "cb_left_wall": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 0, 0 ],
-            "u": [ 0, 0, -1 ],
-            "v": [ 0, 1, 0 ],
-            "material": {
-                "type": "lambertian",
-                "reflectance_texture": "solid_cb_green",
-                "emittance_texture": "solid_black"
-            }
-        },
-        "cb_right_wall": {
-            "type": "parallelogram",
-            "lower_left": [ 1, 0, -1 ],
-            "u": [ 0, 0, 1 ],
-            "v": [ 0, 1, 0 ],
-            "material": {
-                "type": "lambertian",
-                "reflectance_texture": "solid_cb_red",
-                "emittance_texture": "solid_black"
-            }
-        },
-        "cb_floor": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 0, 0 ],
-            "u": [ 1, 0, 0 ],
-            "v": [ 0, 0, -1 ],
-            "material": "lambertian_cb_white"
-        },
-        "cb_ceiling": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 1, -1 ],
-            "u": [ 1, 0, 0 ],
-            "v": [ 0, 0, 1 ],
-            "material": "lambertian_cb_white"
-        },
-        "cb_back_wall": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 0, -1 ],
-            "u": [ 1, 0, 0 ],
-            "v": [ 0, 1, 0 ],
-            "material": "lambertian_cb_white"
-        },
-        "cb_ceiling_light": {
-            "type": "parallelogram",
-            "lower_left": [ 0.35, 0.999, -0.65 ],
-            "u": [ 0.3, 0, 0 ],
-            "v": [ 0, 0, 0.3 ],
-            "material": "lambertian_white_light"
-        },
-        "cornell_box": {
-            "type": "list",
-            "use_bvh": true,
-            "geometrics": [
-                "cb_left_wall",
-                "cb_right_wall",
-                "cb_floor",
-                "cb_ceiling",
-                "cb_back_wall",
-                "cb_ceiling_light"
-            ]
+        "importance_sampling": {
+            "brdf_weight": 1.0,
+            "emissive_weight": 1.0,
+            "transmissive_weight": 0.0,
+            "specular_weight": 0.0,
+            "virtual_weight": 0.0,
+            "use_multiple_importance_sampling": true
         }
     },
+    "active_scene": "Triangle Test Scene",
+    "scenes": {
+        "Triangle Test Scene": {
+            "geometrics": [
+                "__cornell_box_room",
+                {
+                    "type": "triangle",
+                    "a": [0.2, 0.2, -0.2],
+                    "b": [0.8, 0.2, -0.2],
+                    "c": [0.2, 0.2, -0.8],
+                    "material": {
+                        "type": "dielectric",
+                        "reflectance_texture": {
+                            "type": "color",
+                            "color": [0.05, 0.05, 0.75]
+                        },
+                        "emittance_texture": "solid_black",
+                        "index_of_refraction": 1.5
+                    }
+                }
+            ],
+            "use_bvh": true,
+            "camera": "Main Camera",
+            "background_color": [0, 0, 0]
+        }
+    },
+    "cameras": {
+        "Main Camera": {
+            "vertical_field_of_view_degrees": 40,
+            "eye_location": [0.5, 0.5, 1.44144],
+            "target_location": [0.5, 0.5, 0],
+            "view_up": [0, 1, 0],
+            "defocus_angle_degrees": 0,
+            "focus_distance": "eye_to_target"
+        }
+    },
+    "geometrics": {},
     "materials": {
         "lambertian_white_light": {
             "type": "lambertian",
             "reflectance_texture": "solid_black",
             "emittance_texture": {
                 "type": "color",
-                "color": [ 10, 10, 10 ]
+                "color": [10, 10, 10]
             }
         },
         "lambertian_cb_white": {
             "type": "lambertian",
             "reflectance_texture": {
                 "type": "color",
-                "color": [ 0.73, 0.73, 0.73 ]
+                "color": [0.73, 0.73, 0.73]
             },
             "emittance_texture": "solid_black"
         },
@@ -142,19 +91,19 @@
     "textures": {
         "solid_white": {
             "type": "color",
-            "color": [ 1, 1, 1 ]
+            "color": [1, 1, 1]
         },
         "solid_black": {
             "type": "color",
-            "color": [ 0, 0, 0 ]
+            "color": [0, 0, 0]
         },
         "solid_cb_green": {
             "type": "color",
-            "color": [ 0.12, 0.45, 0.15 ]
+            "color": [0.12, 0.45, 0.15]
         },
         "solid_cb_red": {
             "type": "color",
-            "color": [ 0.65, 0.05, 0.05 ]
+            "color": [0.65, 0.05, 0.05]
         }
     }
 }

--- a/configs/template.json
+++ b/configs/template.json
@@ -1,119 +1,68 @@
 {
+    "name": "Template",
     "parameters": {
-        "output_dir": "./output",
-        "use_subdir": true,
-        "file_basename": "image",
-        "file_ext": "png",
-        "image_dimensions": [ 500, 500 ],
-        "tile_dimensions": [ 1, 1 ],
-        "gamma_correction": 2,
-        "samples_per_round": 10,
-        "round_limit": null,
-        "max_bounces": 50,
+        "image_dimensions": [500, 500],
+        "tile_dimensions": [1, 1],
+        "gamma_correction": 2.0,
+        "samples_per_checkpoint": 16,
+        "total_checkpoints": 100,
+        "saved_checkpoint_limit": 1,
+        "bounces": {
+            "max": 50,
+            "use_russian_roulette_after": 3
+        },
         "use_scaling_truncation": true,
-        "pixels_per_progress_update": 100,
-        "progress_memory": 50
-    },
-    "active_scene": {
-        "name": "template",
-        "geometrics": [
-            "cornell_box",
-            {
-                "type": "sphere",
-                "center": [ 0.5, 0.2, -0.5 ],
-                "radius": 0.2,
-                "material": "dielectric_glass"
-            }
-        ],
-        "use_bvh": true,
-        "camera": {
-            "vertical_field_of_view_degrees": 40,
-            "eye_location": [ 0.5, 0.5, 1.44144 ],
-            "target_location": [ 0.5, 0.5, 0 ],
-            "view_up": [ 0, 1, 0 ],
-            "defocus_angle_degrees": 0,
-            "focus_distance": "eye_to_target"
-        },
-        "background_color": [ 0, 0, 0 ]
-    },
-    "geometrics": {
-        "cb_left_wall": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 0, 0 ],
-            "u": [ 0, 0, -1 ],
-            "v": [ 0, 1, 0 ],
-            "material": {
-                "type": "lambertian",
-                "reflectance_texture": "solid_cb_green",
-                "emittance_texture": "solid_black"
-            }
-        },
-        "cb_right_wall": {
-            "type": "parallelogram",
-            "lower_left": [ 1, 0, -1 ],
-            "u": [ 0, 0, 1 ],
-            "v": [ 0, 1, 0 ],
-            "material": {
-                "type": "lambertian",
-                "reflectance_texture": "solid_cb_red",
-                "emittance_texture": "solid_black"
-            }
-        },
-        "cb_floor": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 0, 0 ],
-            "u": [ 1, 0, 0 ],
-            "v": [ 0, 0, -1 ],
-            "material": "lambertian_cb_white"
-        },
-        "cb_ceiling": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 1, -1 ],
-            "u": [ 1, 0, 0 ],
-            "v": [ 0, 0, 1 ],
-            "material": "lambertian_cb_white"
-        },
-        "cb_back_wall": {
-            "type": "parallelogram",
-            "lower_left": [ 0, 0, -1 ],
-            "u": [ 1, 0, 0 ],
-            "v": [ 0, 1, 0 ],
-            "material": "lambertian_cb_white"
-        },
-        "cb_ceiling_light": {
-            "type": "parallelogram",
-            "lower_left": [ 0.35, 0.999, -0.65 ],
-            "u": [ 0.3, 0, 0 ],
-            "v": [ 0, 0, 0.3 ],
-            "material": "lambertian_white_light"
-        },
-        "cornell_box": {
-            "type": "list",
-            "use_bvh": true,
-            "geometrics": [
-                "cb_left_wall",
-                "cb_right_wall",
-                "cb_floor",
-                "cb_ceiling",
-                "cb_back_wall",
-                "cb_ceiling_light"
-            ]
+        "importance_sampling": {
+            "brdf_weight": 1.0,
+            "emissive_weight": 1.0,
+            "transmissive_weight": 0.0,
+            "specular_weight": 0.0,
+            "virtual_weight": 0.0,
+            "use_multiple_importance_sampling": true
         }
     },
+    "active_scene": "Template Scene",
+    "scenes": {
+        "Template Scene": {
+            "geometrics": [
+                "__cornell_box_room",
+                {
+                    "type": "sphere",
+                    "center": [0.5, 0.2, -0.5],
+                    "radius": 0.2,
+                    "material": "dielectric_glass"
+                }
+            ],
+            "use_bvh": true,
+            "camera": "Main Camera",
+            "background_color": [0, 0, 0]
+        }
+    },
+    "cameras": {
+        "Main Camera": {
+            "vertical_field_of_view_degrees": 40,
+            "eye_location": [0.5, 0.5, 1.44144],
+            "target_location": [0.5, 0.5, 0],
+            "view_up": [0, 1, 0],
+            "defocus_angle_degrees": 0,
+            "focus_distance": "eye_to_target"
+        }
+    },
+    "geometrics": {},
     "materials": {
         "lambertian_white_light": {
             "type": "lambertian",
             "reflectance_texture": "solid_black",
             "emittance_texture": {
                 "type": "color",
-                "color": [ 10, 10, 10 ]
+                "color": [10, 10, 10]
             }
         },
         "lambertian_cb_white": {
             "type": "lambertian",
             "reflectance_texture": {
                 "type": "color",
-                "color": [ 0.73, 0.73, 0.73 ]
+                "color": [0.73, 0.73, 0.73]
             },
             "emittance_texture": "solid_black"
         },
@@ -133,19 +82,19 @@
     "textures": {
         "solid_white": {
             "type": "color",
-            "color": [ 1, 1, 1 ]
+            "color": [1, 1, 1]
         },
         "solid_black": {
             "type": "color",
-            "color": [ 0, 0, 0 ]
+            "color": [0, 0, 0]
         },
         "solid_cb_green": {
             "type": "color",
-            "color": [ 0.12, 0.45, 0.15 ]
+            "color": [0.12, 0.45, 0.15]
         },
         "solid_cb_red": {
             "type": "color",
-            "color": [ 0.65, 0.05, 0.05 ]
+            "color": [0.65, 0.05, 0.05]
         }
     }
 }


### PR DESCRIPTION
Updates all 5 example render config files in `configs/` to match the current `RenderConfig` deserialization schema.

### Changes per file

**All files:**
- Added top-level `name` field (required by new schema)
- Restructured `max_bounces` → `bounces: { max, use_russian_roulette_after }`
- Added `saved_checkpoint_limit`, `importance_sampling` block
- Renamed `checkpoints` → `total_checkpoints`
- Moved scene definitions to `scenes` map, `active_scene` as string ref
- Moved cameras to `cameras` map as `Main Camera`

**`cornell_box.json`** — kept all custom resources (image textures, dielectric glass)
**`cornell_box_inline.json`** — kept all inline resource definitions, removed dropped CLI fields
**`cornell_box_teapot.json`** — replaced user-defined room walls with `__cornell_box_room` builtin
**`cornell_triangle_test.json`** — same builtin substitution
**`template.json`** — same builtin substitution