### PR TITLE
fix: track geometric dependencies for VolumeConstant and Virtual

### DIFF
--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -203,6 +203,7 @@ fn build_materials(
 fn get_geometric_dependencies(geometric: &GeometricData) -> Vec<String> {
     let mut deps = Vec::new();
     match geometric {
+        // these contain a vector of geometric references that must be built first
         GeometricData::CompoundList { geometrics, .. } => {
             for g in geometrics {
                 match g {
@@ -213,16 +214,24 @@ fn get_geometric_dependencies(geometric: &GeometricData) -> Vec<String> {
                 }
             }
         }
+        // these contain a single geometric reference that must be built first
         GeometricData::InstanceRotateXAxis { geometric, .. }
         | GeometricData::InstanceRotateYAxis { geometric, .. }
         | GeometricData::InstanceRotateZAxis { geometric, .. }
-        | GeometricData::InstanceTranslate { geometric, .. } => match geometric {
+        | GeometricData::InstanceTranslate { geometric, .. }
+        | GeometricData::VolumeConstant { geometric, .. }
+        | GeometricData::Virtual { geometric, .. } => match geometric {
             GeometricRefOrInline::Ref(ref_name) => deps.push(ref_name.clone()),
             GeometricRefOrInline::Inline(data) => {
                 deps.append(&mut get_geometric_dependencies(data))
             }
         },
-        _ => {}
+        // these contain no `geometric` field, only a `material` — no geometric dependencies to track
+        GeometricData::CompoundAxisAlignedPBox { .. }
+        | GeometricData::CompoundModelObj { .. }
+        | GeometricData::PrimitiveParallelogram { .. }
+        | GeometricData::PrimitiveSphere { .. }
+        | GeometricData::PrimitiveTriangle { .. } => {}
     }
     deps
 }


### PR DESCRIPTION
## Problem

When a `constant_volume` or `virtual` geometric references another geometric by name, and that referenced geometric appears later in the JSON map order, the build fails with:

```
{"code":400,"message":"Geometric New Rotate_z not found. Is it specified in the geometrics list?"}
```

...even though the geometric IS in the list.

## Root cause

`get_geometric_dependencies` had a `_ => {}` wildcard that silently ignored `VolumeConstant` and `Virtual` variants. Both carry a `geometric: GeometricRefOrInline` field that can reference another geometric by name, but their dependencies weren't being tracked — so the topological build ordering was wrong when the referenced geometric came later in the map.

## Fix

- Added `VolumeConstant` and `Virtual` to the dependency-extraction match alongside the existing rotation/translation instance variants (identical logic: extract the single `geometric` ref)
- Replaced `_ => {}` with explicit enumerated arms for the five variants that genuinely have no geometric dependencies, so the compiler catches any new `GeometricData` variant added in the future