### PR TITLE
feat: geometric naming, truncation, texture fix, and Double Sided toggle

### DIFF
--- a/ui/src/components/form-controls/ToggleControl.tsx
+++ b/ui/src/components/form-controls/ToggleControl.tsx
@@ -7,10 +7,11 @@ export type ToggleControlProps = {
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
   disabled?: boolean;
+  invert?: boolean;
 };
 
 export function ToggleControl(props: ToggleControlProps) {
-  const { label, labelPrefix, labelSuffix, disabled } = props;
+  const { label, labelPrefix, labelSuffix, disabled, invert } = props;
 
   const field = useFieldContext<boolean>();
 
@@ -25,8 +26,8 @@ export function ToggleControl(props: ToggleControlProps) {
           </span>
         </h6>
         <ToggleSwitch
-          checked={!!field.state.value}
-          onChange={(checked) => field.handleChange(checked)}
+          checked={invert ? !field.state.value : !!field.state.value}
+          onChange={(checked) => field.handleChange(invert ? !checked : checked)}
           disabled={disabled}
         />
       </div>

--- a/ui/src/views/renders/new/Controls/shared/AddEntityDropdown.tsx
+++ b/ui/src/views/renders/new/Controls/shared/AddEntityDropdown.tsx
@@ -62,10 +62,18 @@ export function AddEntityDropdown<T extends EntityType>(props: AddEntityDropdown
     ) {
       // the inner geometric always gets an auto-generated name;
       // the user's custom name is applied to the outermost wrapper below
+      const instanceTypeLabels: Record<string, string> = {
+        translate: 'Translate',
+        rotate_x: 'Rotate X',
+        rotate_y: 'Rotate Y',
+        rotate_z: 'Rotate Z',
+      };
+      const nameChain: { oldName: string; typeLabel: string }[] = [];
       let currentRecord = { ...record };
       const innerName = getNextUniqueName(currentRecord, autoName);
 
       currentRecord = { ...currentRecord, [innerName]: newEntity };
+      nameChain.push({ oldName: innerName, typeLabel: label });
       let currentRef = innerName;
 
       // stack instances from inner to outer
@@ -79,6 +87,7 @@ export function AddEntityDropdown<T extends EntityType>(props: AddEntityDropdown
           geometric: currentRef,
         };
         currentRecord = { ...currentRecord, [instanceName]: wrapper } as EntityRecord<T>;
+        nameChain.push({ oldName: instanceName, typeLabel: instanceTypeLabels[instanceType] });
         currentRef = instanceName;
       }
 
@@ -93,6 +102,7 @@ export function AddEntityDropdown<T extends EntityType>(props: AddEntityDropdown
           geometric: currentRef,
         };
         currentRecord = { ...currentRecord, [cvName]: cv } as EntityRecord<T>;
+        nameChain.push({ oldName: cvName, typeLabel: 'Constant Volume' });
         currentRef = cvName;
       }
 
@@ -107,6 +117,7 @@ export function AddEntityDropdown<T extends EntityType>(props: AddEntityDropdown
           geometric: currentRef,
         };
         currentRecord = { ...currentRecord, [virtName]: virt } as EntityRecord<T>;
+        nameChain.push({ oldName: virtName, typeLabel: 'Virtual' });
         currentRef = virtName;
       }
 
@@ -117,6 +128,30 @@ export function AddEntityDropdown<T extends EntityType>(props: AddEntityDropdown
         const { [currentRef]: entry, ...rest } = currentRecord as Record<string, unknown>;
         currentRecord = { ...rest, [outerName]: entry } as EntityRecord<T>;
         currentRef = outerName;
+        nameChain[nameChain.length - 1].oldName = currentRef;
+      }
+
+      // rename sub-geometrics to inherit their immediate parent's name
+      let parentNewName = nameChain[nameChain.length - 1].oldName;
+
+      for (let i = nameChain.length - 2; i >= 0; i--) {
+        const { oldName, typeLabel } = nameChain[i];
+        const newName = getNextUniqueName(currentRecord, `${parentNewName}_${typeLabel}`);
+
+        // move the entry to the new name
+        currentRecord = { ...currentRecord };
+        currentRecord[newName] = currentRecord[oldName];
+        delete currentRecord[oldName];
+
+        // type narrowing on generic T doesn't propagate inside the if-block
+        const parentEntry = currentRecord[parentNewName] as Record<string, unknown>;
+        currentRecord = {
+          ...currentRecord,
+          [parentNewName]: { ...parentEntry, geometric: newName },
+        } as EntityRecord<T>;
+
+        // this child's new name becomes the prefix for the next inner sibling
+        parentNewName = newName;
       }
 
       form.setFieldValue(type, currentRecord as never);

--- a/ui/src/views/renders/new/Controls/shared/LabelText.tsx
+++ b/ui/src/views/renders/new/Controls/shared/LabelText.tsx
@@ -1,17 +1,19 @@
 export type LabelTextProps = {
   text: string;
   type: 'bold' | 'light';
+  className?: string;
+  title?: string;
 };
 
 export function LabelText(props: LabelTextProps) {
-  const { text, type } = props;
+  const { text, type, className, title } = props;
 
   switch (type) {
     case 'bold': {
-      return <h2 className="text-xl font-bold">{text}</h2>;
+      return <h2 className={`text-xl font-bold ${className ?? ''}`} title={title}>{text}</h2>;
     }
     case 'light': {
-      return <h2 className="text-lg font-light italic">{text}</h2>;
+      return <h2 className={`text-lg font-light italic ${className ?? ''}`} title={title}>{text}</h2>;
     }
   }
 }

--- a/ui/src/views/renders/new/Controls/shared/LabelText.tsx
+++ b/ui/src/views/renders/new/Controls/shared/LabelText.tsx
@@ -10,10 +10,18 @@ export function LabelText(props: LabelTextProps) {
 
   switch (type) {
     case 'bold': {
-      return <h2 className={`text-xl font-bold ${className ?? ''}`} title={title}>{text}</h2>;
+      return (
+        <h2 className={`text-xl font-bold ${className ?? ''}`} title={title}>
+          {text}
+        </h2>
+      );
     }
     case 'light': {
-      return <h2 className={`text-lg font-light italic ${className ?? ''}`} title={title}>{text}</h2>;
+      return (
+        <h2 className={`text-lg font-light italic ${className ?? ''}`} title={title}>
+          {text}
+        </h2>
+      );
     }
   }
 }

--- a/ui/src/views/renders/new/Controls/shared/RenamableLabel.tsx
+++ b/ui/src/views/renders/new/Controls/shared/RenamableLabel.tsx
@@ -57,10 +57,10 @@ export function RenamableLabel(props: RenamableLabelProps) {
   }
 
   return (
-    <span className="inline-flex items-center gap-2">
-      <LabelText text={label} type={labelStyle} />
+    <span className="inline-flex items-center gap-2 min-w-0">
+      <LabelText text={label} type={labelStyle} className="truncate" title={label} />
       {afterLabel}
-      <Button {...buttonProps} onClick={handleStartEditing}>
+      <Button {...buttonProps} onClick={handleStartEditing} className="shrink-0">
         <HiPencil className="h-4 w-4" />
       </Button>
     </span>

--- a/ui/src/views/renders/new/Controls/shared/RenamableLabel.tsx
+++ b/ui/src/views/renders/new/Controls/shared/RenamableLabel.tsx
@@ -57,7 +57,7 @@ export function RenamableLabel(props: RenamableLabelProps) {
   }
 
   return (
-    <span className="inline-flex items-center gap-2 min-w-0">
+    <span className="inline-flex min-w-0 items-center gap-2">
       <LabelText text={label} type={labelStyle} className="truncate" title={label} />
       {afterLabel}
       <Button {...buttonProps} onClick={handleStartEditing} className="shrink-0">

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricTextureSelect.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricTextureSelect.tsx
@@ -1,0 +1,17 @@
+import type { RenderForm } from '@/hooks/useRenderForm';
+
+export type GeometricTextureSelectProps = {
+  form: RenderForm;
+  name: string;
+  items: { label: string; value: string }[];
+};
+
+export function GeometricTextureSelect(props: GeometricTextureSelectProps) {
+  const { form, name, items } = props;
+
+  return (
+    <form.AppField name={`geometrics.${name}.reflectance_texture`}>
+      {(field) => <field.SelectControl label="Reflectance Texture" items={items} />}
+    </form.AppField>
+  );
+}

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -3,6 +3,7 @@ import { TextInputControl } from '@/components/form-controls/TextInputControl';
 import { getGeometricData } from '@/utils/render/geometric';
 import { AroundVariantControls } from './AroundVariantControls';
 import { GeometricMaterialSelect } from './GeometricMaterialSelect';
+import { GeometricTextureSelect } from './GeometricTextureSelect';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
 
@@ -20,6 +21,11 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
 
   // build material select items
   const materialItems = Object.keys(renderConfig.materials ?? {}).map((key) => ({
+    label: key,
+    value: key,
+  }));
+
+  const textureItems = Object.keys(renderConfig.textures ?? {}).map((key) => ({
     label: key,
     value: key,
   }));
@@ -165,7 +171,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <form.AppField name={`geometrics.${name}.density`}>
             {(field) => <field.RangeControl label="Density" min={0} max={1} step={0.01} />}
           </form.AppField>
-          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+          <GeometricTextureSelect form={form} name={name} items={textureItems} />
         </>
       );
     case 'virtual':

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -48,6 +48,9 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
+          <form.AppField name={`geometrics.${name}.is_culled`}>
+            {(field) => <field.ToggleControl label="Double Sided" invert />}
+          </form.AppField>
           <GeometricMaterialSelect form={form} name={name} items={materialItems} />
         </>
       );
@@ -95,6 +98,9 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
+          <form.AppField name={`geometrics.${name}.is_culled`}>
+            {(field) => <field.ToggleControl label="Double Sided" invert />}
+          </form.AppField>
           <GeometricMaterialSelect form={form} name={name} items={materialItems} />
         </>
       );
@@ -130,6 +136,9 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
               </>
             }
           />
+          <form.AppField name={`geometrics.${name}.is_culled`}>
+            {(field) => <field.ToggleControl label="Double Sided" invert />}
+          </form.AppField>
           <GeometricMaterialSelect form={form} name={name} items={materialItems} />
         </>
       );


### PR DESCRIPTION
## Changes

### Sub-geometric naming
Auto-named sub-geometrics now inherit their immediate parent's name with `_` separator:
- Box + CV → `"New Constant Volume"`, `"New Constant Volume_Box"`
- Box + Translate + CV → `"New Constant Volume"`, `"New Constant Volume_Translate"`, `"New Constant Volume_Translate_Box"`

### Long name truncation + tooltip
Long geometric names no longer wrap — they truncate with ellipsis. Hovering shows the full name via native `title` attribute.

### Constant Volume texture select fix
Constant Volume controls incorrectly showed a Material select binding to a nonexistent `material` field. Fixed to show a Texture select binding to `reflectance_texture`.

### Double Sided toggle
Added a "Double Sided" toggle to box, parallelogram, and triangle form controls. Toggle ON = double-sided (`is_culled = false`), toggle OFF = culled (`is_culled = true`). Uses a new `invert` prop on `ToggleControl` for the inverted boolean binding.