### PR TITLE
fix(benches): correct Vector→Vector3 references and add clippy-compliant type aliases

### DIFF
--- a/benches/aabb.rs
+++ b/benches/aabb.rs
@@ -1,15 +1,19 @@
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use luxide::{
-    geometry::{Aabb, Point, Ray, Vector},
+    geometry::{Aabb, Point, Ray, Vector3},
     utils::Interval,
 };
 
-fn random() -> (String, Box<dyn Fn() -> Ray>, Box<dyn Fn(Ray) -> bool>) {
+type Id = String;
+type Setup = Box<dyn Fn() -> Ray>;
+type Routine = Box<dyn Fn(Ray) -> bool>;
+
+fn random() -> (Id, Setup, Routine) {
     let aabb = Aabb::unit();
 
     let setup = || -> Ray {
         let origin = Point::new(0.0, 0.0, 3.0);
-        let direction = Vector::random_in_unit_sphere();
+        let direction = Vector3::random_in_unit_sphere();
 
         Ray::new(origin, direction, 0.0)
     };
@@ -20,13 +24,13 @@ fn random() -> (String, Box<dyn Fn() -> Ray>, Box<dyn Fn(Ray) -> bool>) {
     ("random".to_string(), Box::new(setup), Box::new(routine))
 }
 
-fn hit() -> (String, Box<dyn Fn() -> Ray>, Box<dyn Fn(Ray) -> bool>) {
+fn hit() -> (Id, Setup, Routine) {
     let aabb = Aabb::unit();
 
     let setup = || -> Ray {
-        let origin = Point::from_vector(Vector::random_in_unit_cube().unit_vector() * 3.0);
+        let origin = Point::from_vector3(Vector3::random_in_unit_cube().unit_vector() * 3.0);
 
-        let new_target_fn = || origin + Vector::random_in_unit_sphere();
+        let new_target_fn = || origin + Vector3::random_in_unit_sphere();
         let mut target = new_target_fn();
         while origin.to(target).angle(origin.to(Point::ZERO)).as_degrees() > 10.0 {
             target = new_target_fn();
@@ -42,13 +46,13 @@ fn hit() -> (String, Box<dyn Fn() -> Ray>, Box<dyn Fn(Ray) -> bool>) {
     ("hit".to_string(), Box::new(setup), Box::new(routine))
 }
 
-fn miss() -> (String, Box<dyn Fn() -> Ray>, Box<dyn Fn(Ray) -> bool>) {
+fn miss() -> (Id, Setup, Routine) {
     let aabb: Aabb = Aabb::unit();
 
     let setup = || -> Ray {
-        let origin = Point::from_vector(Vector::random_in_unit_cube().unit_vector() * 3.0);
+        let origin = Point::from_vector3(Vector3::random_in_unit_cube().unit_vector() * 3.0);
 
-        let new_target_fn = || origin + Vector::random_in_unit_sphere();
+        let new_target_fn = || origin + Vector3::random_in_unit_sphere();
         let mut target = new_target_fn();
         while origin.to(target).angle(origin.to(Point::ZERO)).as_degrees() < 45.0 {
             target = new_target_fn();

--- a/benches/parallelogram.rs
+++ b/benches/parallelogram.rs
@@ -1,20 +1,20 @@
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use luxide::{
-    geometry::{Geometric, Point, Ray, RayHit, Vector, primitives::Parallelogram},
+    geometry::{Geometric, Point, Ray, RayHit, Vector3, primitives::Parallelogram},
     utils::Interval,
 };
 use rand::{RngExt, rngs::ThreadRng};
 
-fn random() -> (
-    String,
-    Box<dyn Fn() -> Ray>,
-    Box<dyn Fn(Ray) -> Option<RayHit>>,
-) {
+type Id = String;
+type Setup = Box<dyn Fn() -> Ray>;
+type Routine = Box<dyn Fn(Ray) -> Option<RayHit>>;
+
+fn random() -> (Id, Setup, Routine) {
     let p = Parallelogram::unit();
 
     let setup = || -> Ray {
         let origin = Point::new(0.0, 0.0, 1.0);
-        let direction = Vector::random_in_unit_sphere();
+        let direction = Vector3::random_in_unit_sphere();
 
         Ray::new(origin, direction, 0.0)
     };
@@ -25,11 +25,7 @@ fn random() -> (
     ("random".to_string(), Box::new(setup), Box::new(routine))
 }
 
-fn hit() -> (
-    String,
-    Box<dyn Fn() -> Ray>,
-    Box<dyn Fn(Ray) -> Option<RayHit>>,
-) {
+fn hit() -> (Id, Setup, Routine) {
     let p = Parallelogram::unit();
 
     let setup = || -> Ray {
@@ -52,11 +48,7 @@ fn hit() -> (
     ("hit".to_string(), Box::new(setup), Box::new(routine))
 }
 
-fn miss_offset() -> (
-    String,
-    Box<dyn Fn() -> Ray>,
-    Box<dyn Fn(Ray) -> Option<RayHit>>,
-) {
+fn miss_offset() -> (Id, Setup, Routine) {
     let p = Parallelogram::unit();
 
     let setup = || -> Ray {
@@ -91,11 +83,7 @@ fn miss_offset() -> (
     )
 }
 
-fn miss_plane() -> (
-    String,
-    Box<dyn Fn() -> Ray>,
-    Box<dyn Fn(Ray) -> Option<RayHit>>,
-) {
+fn miss_plane() -> (Id, Setup, Routine) {
     let p = Parallelogram::unit();
 
     let setup = || -> Ray {
@@ -118,11 +106,7 @@ fn miss_plane() -> (
     ("miss_plane".to_string(), Box::new(setup), Box::new(routine))
 }
 
-fn miss_culled() -> (
-    String,
-    Box<dyn Fn() -> Ray>,
-    Box<dyn Fn(Ray) -> Option<RayHit>>,
-) {
+fn miss_culled() -> (Id, Setup, Routine) {
     let p = Parallelogram::unit();
 
     let setup = || -> Ray {

--- a/benches/sphere.rs
+++ b/benches/sphere.rs
@@ -1,20 +1,20 @@
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use luxide::{
-    geometry::{Geometric, Point, Ray, RayHit, Vector, primitives::Sphere},
+    geometry::{Geometric, Point, Ray, RayHit, Vector3, primitives::Sphere},
     utils::Interval,
 };
 use rand::RngExt;
 
-fn random() -> (
-    String,
-    Box<dyn Fn() -> Ray>,
-    Box<dyn Fn(Ray) -> Option<RayHit>>,
-) {
+type Id = String;
+type Setup = Box<dyn Fn() -> Ray>;
+type Routine = Box<dyn Fn(Ray) -> Option<RayHit>>;
+
+fn random() -> (Id, Setup, Routine) {
     let s = Sphere::unit();
 
     let setup = || -> Ray {
         let origin = Point::new(0.0, 0.0, 2.0);
-        let direction = Vector::random_in_unit_sphere();
+        let direction = Vector3::random_in_unit_sphere();
 
         Ray::new(origin, direction, 0.0)
     };
@@ -25,11 +25,7 @@ fn random() -> (
     ("random".to_string(), Box::new(setup), Box::new(routine))
 }
 
-fn hit() -> (
-    String,
-    Box<dyn Fn() -> Ray>,
-    Box<dyn Fn(Ray) -> Option<RayHit>>,
-) {
+fn hit() -> (Id, Setup, Routine) {
     let s = Sphere::unit();
 
     let setup = || -> Ray {
@@ -52,11 +48,7 @@ fn hit() -> (
     ("hit".to_string(), Box::new(setup), Box::new(routine))
 }
 
-fn hit_tangent() -> (
-    String,
-    Box<dyn Fn() -> Ray>,
-    Box<dyn Fn(Ray) -> Option<RayHit>>,
-) {
+fn hit_tangent() -> (Id, Setup, Routine) {
     let s = Sphere::unit();
 
     let setup = || -> Ray {
@@ -77,17 +69,13 @@ fn hit_tangent() -> (
     )
 }
 
-fn miss() -> (
-    String,
-    Box<dyn Fn() -> Ray>,
-    Box<dyn Fn(Ray) -> Option<RayHit>>,
-) {
+fn miss() -> (Id, Setup, Routine) {
     let s = Sphere::unit();
 
     let setup = || -> Ray {
         let origin = Point::new(0.0, 0.0, 2.0);
 
-        let new_target_fn = || origin + Vector::random_in_unit_sphere();
+        let new_target_fn = || origin + Vector3::random_in_unit_sphere();
         let mut target = new_target_fn();
         while origin.to(target).angle(origin.to(Point::ZERO)).as_degrees() < 45.0 {
             target = new_target_fn();


### PR DESCRIPTION
## Summary

Fixes compilation errors and clippy warnings in all three benchmark files.

### Compilation errors (Vector vs Vector3)
The benchmarks were importing `Vector` (a generic, non-geometric numeric array type) but calling `random_in_unit_sphere()` and `random_in_unit_cube()` — methods that only exist on `Vector3` (the geometric 3D vector). Also corrected `Point::from_vector` to `Point::from_vector3`.

### Clippy: `type_complexity`
Replaced inline tuple return types with three separate type aliases (`Id`, `Setup`, `Routine`) matching the pattern established in `aabb.rs`.

### Files changed
- `benches/aabb.rs` — import fix, method call fixes, type aliases
- `benches/sphere.rs` — import fix, method call fixes, type aliases
- `benches/parallelogram.rs` — import fix, method call fix, type aliases