### PR TITLE
feat: infinite plane geometric primitive

### DIFF
--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -230,6 +230,7 @@ fn get_geometric_dependencies(geometric: &GeometricData) -> Vec<String> {
         GeometricData::CompoundAxisAlignedPBox { .. }
         | GeometricData::CompoundModelObj { .. }
         | GeometricData::PrimitiveParallelogram { .. }
+        | GeometricData::PrimitivePlane { .. }
         | GeometricData::PrimitiveSphere { .. }
         | GeometricData::PrimitiveTriangle { .. } => {}
     }

--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     geometry::{
-        Geometric,
+        Geometric, Vector3,
         compounds::{AxisAlignedPBox, Bvh, List, ModelObj, Virtual},
         instances::{RotateXAxis, RotateYAxis, RotateZAxis, Translate},
-        primitives::{Parallelogram, Sphere, Triangle},
+        primitives::{Parallelogram, Plane, Sphere, Triangle},
         volumes,
     },
     utils::{Angle, Around},
@@ -95,6 +95,14 @@ pub enum GeometricData {
         lower_left: [f64; 3],
         u: [f64; 3],
         v: [f64; 3],
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_culled: Option<bool>,
+        material: MaterialRefOrInline,
+    },
+    #[serde(rename = "plane")]
+    PrimitivePlane {
+        point: [f64; 3],
+        normal: [f64; 3],
         #[serde(skip_serializing_if = "Option::is_none")]
         is_culled: Option<bool>,
         material: MaterialRefOrInline,
@@ -240,6 +248,28 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
                     (*u).into(),
                     (*v).into(),
                     (*is_culled).unwrap_or(false),
+                    material,
+                )))
+            }
+            Self::PrimitivePlane {
+                point,
+                normal,
+                is_culled,
+                material,
+            } => {
+                let material = material.build(builts)?;
+                let [nx, ny, nz] = normal;
+                let normal = Vector3::new(*nx, *ny, *nz);
+                // guard against zero-length normal
+                let len = normal.length();
+                if len <= 0.0 {
+                    return Err("Plane normal vector must be non-zero".to_string());
+                }
+                let is_culled = is_culled.unwrap_or(false);
+                Ok(Arc::new(Plane::new(
+                    (*point).into(),
+                    normal,
+                    is_culled,
                     material,
                 )))
             }

--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -21,6 +21,12 @@ impl Aabb {
         z_interval: Interval::EMPTY,
     };
 
+    pub const UNIVERSE: Self = Self {
+        x_interval: Interval::UNIVERSE,
+        y_interval: Interval::UNIVERSE,
+        z_interval: Interval::UNIVERSE,
+    };
+
     pub fn new(x_interval: Interval, y_interval: Interval, z_interval: Interval) -> Self {
         Self {
             x_interval,
@@ -104,6 +110,14 @@ impl Aabb {
             }
         }
         true
+    }
+
+    /// Returns true if any axis spans the full representable range,
+    /// meaning the AABB cannot be used in a BVH.
+    pub fn is_infinite(&self) -> bool {
+        self.x_interval == Interval::UNIVERSE
+            || self.y_interval == Interval::UNIVERSE
+            || self.z_interval == Interval::UNIVERSE
     }
 
     pub fn center(&self) -> Point {

--- a/src/geometry/compounds/list.rs
+++ b/src/geometry/compounds/list.rs
@@ -107,29 +107,55 @@ impl Geometric for List {
     }
 
     fn sample_direction_from(&self, origin: Point) -> Vector3 {
-        let total_area = self.surface_area();
+        let total_area: f64 = self
+            .items
+            .iter()
+            .map(|item| item.surface_area())
+            .filter(|a| a.is_finite() && *a > 0.0)
+            .sum();
         if total_area <= 0.0 {
             return Vector3::random_unit();
         }
         let mut threshold: f64 = rand::random::<f64>() * total_area;
         for item in &self.items {
             let area = item.surface_area();
+            // skip children with infinite or zero area — they can't be importance-sampled
+            if !area.is_finite() || area <= 0.0 {
+                continue;
+            }
             if threshold <= area {
                 return item.sample_direction_from(origin);
             }
             threshold -= area;
         }
-        // fallback (floating-point edge case)
-        self.items.last().unwrap().sample_direction_from(origin)
+        // fallback to last finite-area child, or random unit if none
+        self.items
+            .iter()
+            .rev()
+            .find(|item| {
+                let a = item.surface_area();
+                a.is_finite() && a > 0.0
+            })
+            .map(|item| item.sample_direction_from(origin))
+            .unwrap_or_else(Vector3::random_unit)
     }
 
     fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
-        let total_area = self.surface_area();
+        let total_area: f64 = self
+            .items
+            .iter()
+            .map(|item| item.surface_area())
+            .filter(|a| a.is_finite() && *a > 0.0)
+            .sum();
         if total_area <= 0.0 {
             return 0.0;
         }
         self.items
             .iter()
+            .filter(|item| {
+                let a = item.surface_area();
+                a.is_finite() && a > 0.0
+            })
             .map(|item| (item.surface_area() / total_area) * item.direction_pdf(origin, dir))
             .sum()
     }

--- a/src/geometry/geometric.rs
+++ b/src/geometry/geometric.rs
@@ -18,7 +18,6 @@ pub trait Geometric: std::fmt::Debug + Sync + Send {
     fn is_specular(&self) -> bool;
 
     /// Whether this geometric object contains no primitives.
-    /// Defaults to `false` — overridden by compound types like `List`.
     fn is_empty(&self) -> bool;
 
     fn surface_area(&self) -> f64;

--- a/src/geometry/primitives.rs
+++ b/src/geometry/primitives.rs
@@ -1,6 +1,9 @@
 mod parallelogram;
 pub use parallelogram::Parallelogram;
 
+mod plane;
+pub use plane::Plane;
+
 mod sphere;
 pub use sphere::Sphere;
 

--- a/src/geometry/primitives/plane.rs
+++ b/src/geometry/primitives/plane.rs
@@ -1,0 +1,149 @@
+use std::sync::Arc;
+
+use crate::{
+    geometry::{Aabb, Geometric, Onb, Point, Ray, RayHit, Vector3},
+    shading::materials::Material,
+    utils::Interval,
+};
+
+#[derive(Clone, Debug)]
+pub struct Plane {
+    point: Point,
+    normal: Vector3,
+    is_culled: bool,
+    plane_d: f64,
+    onb: Onb,
+    bounding_box: Aabb,
+    material: Arc<dyn Material>,
+}
+
+impl Plane {
+    pub fn new(
+        point: Point,
+        normal: Vector3,
+        is_culled: bool,
+        material: Arc<dyn Material>,
+    ) -> Self {
+        let normal = normal.unit_vector();
+        let onb = Onb::from_w(normal);
+        let bounding_box = Aabb::new(
+            if onb.u.x.abs() > 0.0 || onb.v.x.abs() > 0.0 {
+                Interval::UNIVERSE
+            } else {
+                Interval::new(point.0.x, point.0.x)
+            },
+            if onb.u.y.abs() > 0.0 || onb.v.y.abs() > 0.0 {
+                Interval::UNIVERSE
+            } else {
+                Interval::new(point.0.y, point.0.y)
+            },
+            if onb.u.z.abs() > 0.0 || onb.v.z.abs() > 0.0 {
+                Interval::UNIVERSE
+            } else {
+                Interval::new(point.0.z, point.0.z)
+            },
+        );
+        Self {
+            point,
+            normal,
+            is_culled,
+            plane_d: point.0.dot(normal),
+            onb,
+            bounding_box,
+            material,
+        }
+    }
+}
+
+impl Geometric for Plane {
+    fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
+        let denominator = self.normal.dot(ray.direction);
+
+        if self.is_culled && denominator >= -1e-8 {
+            // if we are culled, then back-hitting rays do not intersect
+            return None;
+        } else if denominator.abs() <= 1e-8 {
+            // if the ray is parallel to the plane, then there is no intersection
+            return None;
+        }
+
+        let t = (self.plane_d - self.normal.dot(ray.origin.0)) / denominator;
+        if !ray_t.contains_including(t) {
+            return None;
+        }
+
+        let hit_point = ray.at(t);
+
+        // invert the normal if we are not culled and the ray hits the back side
+        let local_normal = if !self.is_culled && denominator > 0.0 {
+            -self.normal
+        } else {
+            self.normal
+        };
+
+        // unbounded UV coordinates — plane extends infinitely
+        let u = (hit_point - self.point).dot(self.onb.u);
+        let v = (hit_point - self.point).dot(self.onb.v);
+
+        Some(RayHit {
+            t,
+            point: hit_point,
+            normal: local_normal,
+            material: Arc::clone(&self.material),
+            u,
+            v,
+        })
+    }
+
+    fn surface_area(&self) -> f64 {
+        f64::INFINITY
+    }
+
+    fn is_emissive(&self) -> bool {
+        self.material.is_emissive()
+    }
+
+    fn is_transmissive(&self) -> bool {
+        self.material.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.material.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+
+    fn bounding_box(&self) -> Aabb {
+        self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
+        // determine which side of the plane the origin is on
+        let dir_to_point = self.point.0 - origin.0;
+        let side = dir_to_point.dot(self.normal);
+        let sign = if side > 0.0 { 1.0 } else { -1.0 };
+
+        // hemisphere axis pointing toward the plane
+        let w = self.normal * -sign;
+
+        // cosine-weighted hemisphere sampling
+        let r1: f64 = rand::random();
+        let r2: f64 = rand::random();
+        let phi = 2.0 * std::f64::consts::PI * r1;
+        let cos_theta = r2.sqrt();
+        let sin_theta = (1.0 - r2).sqrt();
+
+        // build direction in local space using ONB
+        let u = self.onb.u * (sin_theta * phi.cos());
+        let v = self.onb.v * (sin_theta * phi.sin());
+
+        (u + v + w * cos_theta).unit_vector()
+    }
+
+    fn direction_pdf(&self, _origin: Point, _dir: Vector3) -> f64 {
+        // infinite surface area - zero probability density for any finite solid angle
+        0.0
+    }
+}

--- a/src/tracing/scene.rs
+++ b/src/tracing/scene.rs
@@ -45,11 +45,37 @@ impl SceneWorld {
         world_virtual: &[Arc<dyn Geometric>],
         use_bvh: bool,
     ) -> Self {
-        let list = List::from_vec(world.clone());
-        let compiled_world: Arc<dyn Geometric> = if use_bvh {
-            Arc::new(Bvh::from_list(list))
-        } else {
-            Arc::new(list)
+        // separate bounded and unbounded geometrics — unbounded primitives
+        // (e.g. Plane) have Aabb::UNIVERSE and would break BVH construction
+        let mut bounded = Vec::new();
+        let mut unbounded = Vec::new();
+        for geometric in world {
+            let bounding_box = geometric.bounding_box();
+            if bounding_box.is_infinite() {
+                unbounded.push(geometric.clone());
+            } else {
+                bounded.push(geometric.clone());
+            }
+        }
+
+        let compiled_world: Arc<dyn Geometric> = {
+            let bounded_list = List::from_vec(bounded);
+            let bounded_compiled: Arc<dyn Geometric> =
+                if use_bvh && !bounded_list.items().is_empty() {
+                    Arc::new(Bvh::from_list(bounded_list))
+                } else {
+                    Arc::new(bounded_list)
+                };
+
+            if unbounded.is_empty() {
+                bounded_compiled
+            } else {
+                // binary-tree style: List(BVH, List(unbounded...))
+                let mut combined = List::new();
+                combined.push(bounded_compiled);
+                combined.push(Arc::new(List::from_vec(unbounded)));
+                Arc::new(combined)
+            }
         };
 
         let mut emissives = Vec::new();

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -39,6 +39,8 @@ export function normalizeGeometricData(
       return normalizeGeometricInstanceTranslate(config, name, geometricData);
     case 'parallelogram':
       return normalizeGeometricParallelogram(config, name, geometricData);
+    case 'plane':
+      return normalizeGeometricPlane(config, name, geometricData);
     case 'sphere':
       return normalizeGeometricSphere(config, name, geometricData);
     case 'triangle':
@@ -57,6 +59,7 @@ export type NormalizedGeometricData =
   | NormalizedGeometricInstanceRotate
   | NormalizedGeometricInstanceTranslate
   | NormalizedGeometricParallelogram
+  | NormalizedGeometricPlane
   | NormalizedGeometricSphere
   | NormalizedGeometricTriangle
   | NormalizedGeometricConstantVolume
@@ -69,6 +72,7 @@ export type RawGeometricData =
   | RawGeometricInstanceRotate
   | RawGeometricInstanceTranslate
   | RawGeometricParallelogram
+  | RawGeometricPlane
   | RawGeometricSphere
   | RawGeometricTriangle
   | RawGeometricConstantVolume
@@ -86,6 +90,7 @@ export function isGeometricData(data: unknown): data is GeometricData {
       'rotate_z',
       'translate',
       'parallelogram',
+      'plane',
       'sphere',
       'triangle',
       'constant_volume',
@@ -117,6 +122,7 @@ export function getReferencedMaterialNames(
     case 'box':
     case 'obj_model':
     case 'parallelogram':
+    case 'plane':
     case 'sphere':
     case 'triangle':
       materials.push(data.material);
@@ -254,6 +260,8 @@ export function getCenterPoint(
         data.lower_left[1] + (data.u[1] + data.v[1]) / 2,
         data.lower_left[2] + (data.u[2] + data.v[2]) / 2,
       ];
+    case 'plane':
+      return data.point;
     case 'sphere':
       return data.center;
     case 'triangle':
@@ -382,6 +390,13 @@ export function defaultGeometricForType(
         lower_left: [0, 0, 0],
         u: [0, 0, 0],
         v: [0, 0, 0],
+        material: '__lambertian_white',
+      };
+    case 'plane':
+      return {
+        type: 'plane',
+        point: [0, 0, 0],
+        normal: [0, 1, 0],
         material: '__lambertian_white',
       };
     case 'sphere':
@@ -717,6 +732,52 @@ export type RawGeometricParallelogram = {
   material: string | RawMaterialData;
 };
 
+export const GeometricPlaneSchema = z.object({
+  type: z.literal('plane'),
+  point: z.tuple([z.number(), z.number(), z.number()]),
+  normal: z.tuple([z.number(), z.number(), z.number()]),
+  is_culled: z.boolean().optional(),
+  material: z.string(),
+});
+
+export type GeometricPlane = NormalizedGeometricPlane;
+
+export function normalizeGeometricPlane(
+  config: RenderConfig,
+  name: string,
+  geometricData: RawGeometricPlane,
+): NormalizedGeometricPlane {
+  const geometric = geometricData;
+
+  if (typeof geometric.material !== 'string') {
+    if (!config.materials) {
+      config.materials = {};
+    }
+
+    const materialName = getNextUniqueName(config.materials, `${name}_${geometric.material.type}`);
+    config.materials[materialName] = normalizeMaterialData(
+      config,
+      materialName,
+      geometric.material,
+    );
+    geometric.material = materialName;
+  }
+
+  return geometric as NormalizedGeometricPlane;
+}
+
+export type NormalizedGeometricPlane = Omit<RawGeometricPlane, 'material'> & {
+  material: string;
+};
+
+export type RawGeometricPlane = {
+  type: 'plane';
+  point: [number, number, number];
+  normal: [number, number, number];
+  is_culled?: boolean;
+  material: string | RawMaterialData;
+};
+
 export const GeometricSphereSchema = z.object({
   type: z.literal('sphere'),
   center: z.tuple([z.number(), z.number(), z.number()]),
@@ -897,6 +958,8 @@ export const GeometricVirtualSchema = z.object({
   geometric: z.string().nonempty(),
 });
 
+export type GeometricVirtual = NormalizedGeometricVirtual;
+
 export function normalizeGeometricVirtual(
   config: RenderConfig,
   name: string,
@@ -933,6 +996,7 @@ const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   rotate_z: GeometricInstanceRotateZSchema,
   translate: GeometricInstanceTranslateSchema,
   parallelogram: GeometricParallelogramSchema,
+  plane: GeometricPlaneSchema,
   sphere: GeometricSphereSchema,
   triangle: GeometricTriangleSchema,
   constant_volume: GeometricConstantVolumeSchema,

--- a/ui/src/views/renders/new/Controls/index.tsx
+++ b/ui/src/views/renders/new/Controls/index.tsx
@@ -83,6 +83,11 @@ export function Controls(props: ControlsProps) {
                   description: 'Parallelogram defined by origin and two edge vectors.',
                 },
                 {
+                  subtype: 'plane',
+                  label: 'Plane',
+                  description: 'Infinite plane defined by a point and a normal vector.',
+                },
+                {
                   subtype: 'list',
                   label: 'List',
                   description: 'A group of geometrics rendered together.',

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -143,6 +143,29 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <GeometricMaterialSelect form={form} name={name} items={materialItems} />
         </>
       );
+    case 'plane':
+      return (
+        <>
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.point`}
+            label="Point"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.normal`}
+            label="Normal"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <form.AppField name={`geometrics.${name}.is_culled`}>
+            {(field) => <field.ToggleControl label="Double Sided" invert />}
+          </form.AppField>
+          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+        </>
+      );
     case 'rotate_x':
     case 'rotate_y':
     case 'rotate_z': {

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import { getAroundPoint, getGeometricDataSafe } from '@/utils/render/geometric';
 import { toRadians } from '@/utils/render/utils';
 import { createParallelogramGeometry, createTriangleGeometry } from '@/utils/three';
@@ -194,6 +195,42 @@ export function GeometricRenderer(props: GeometricRendererProps) {
               <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
               <bufferAttribute attach="index" args={[geom.indices, 1]} />
             </bufferGeometry>
+            <MaterialResolver config={config} materialName={data.material} />
+          </mesh>
+          {emissiveInfo && (
+            <pointLight
+              color={emissiveInfo.color}
+              intensity={emissiveInfo.intensity}
+              position={getCenterPoint(config, data)}
+              castShadow
+            />
+          )}
+        </>
+      );
+    }
+
+    case 'plane': {
+      const normalVec = new THREE.Vector3(
+        data.normal[0],
+        data.normal[1],
+        data.normal[2],
+      ).normalize();
+      const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), normalVec);
+      const rot = new THREE.Euler().setFromQuaternion(quat);
+
+      const emissiveInfo = getEmissiveInfo(config, data.material);
+
+      const extent = 1_000; // arbitrary large value to simulate an infinite plane
+
+      return (
+        <>
+          <mesh
+            position={[data.point[0], data.point[1], data.point[2]]}
+            rotation={[rot.x, rot.y, rot.z]}
+            castShadow={!emissiveInfo}
+            receiveShadow
+          >
+            <planeGeometry args={[extent, extent]} />
             <MaterialResolver config={config} materialName={data.material} />
           </mesh>
           {emissiveInfo && (

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -168,7 +168,12 @@ export function GeometricRenderer(props: GeometricRendererProps) {
               <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
               <bufferAttribute attach="index" args={[geom.indices, 1]} />
             </bufferGeometry>
-            <MaterialResolver config={config} materialName={data.material} />
+            <MaterialResolver
+              config={config}
+              materialName={data.material}
+              side={data.is_culled ? THREE.FrontSide : THREE.DoubleSide}
+              shadowSide={data.is_culled ? undefined : THREE.BackSide}
+            />
           </mesh>
           {emissiveInfo && (
             <pointLight
@@ -195,7 +200,12 @@ export function GeometricRenderer(props: GeometricRendererProps) {
               <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
               <bufferAttribute attach="index" args={[geom.indices, 1]} />
             </bufferGeometry>
-            <MaterialResolver config={config} materialName={data.material} />
+            <MaterialResolver
+              config={config}
+              materialName={data.material}
+              side={data.is_culled ? THREE.FrontSide : THREE.DoubleSide}
+              shadowSide={data.is_culled ? undefined : THREE.BackSide}
+            />
           </mesh>
           {emissiveInfo && (
             <pointLight
@@ -220,18 +230,22 @@ export function GeometricRenderer(props: GeometricRendererProps) {
 
       const emissiveInfo = getEmissiveInfo(config, data.material);
 
-      const extent = 1_000; // arbitrary large value to simulate an infinite plane
-
       return (
-        <>
+        <group rotation={rotation}>
           <mesh
             position={[data.point[0], data.point[1], data.point[2]]}
             rotation={[rot.x, rot.y, rot.z]}
+            frustumCulled={false}
             castShadow={!emissiveInfo}
             receiveShadow
           >
-            <planeGeometry args={[extent, extent]} />
-            <MaterialResolver config={config} materialName={data.material} />
+            <planeGeometry args={[1_000, 1_000]} />
+            <MaterialResolver
+              config={config}
+              materialName={data.material}
+              side={data.is_culled ? THREE.FrontSide : THREE.DoubleSide}
+              shadowSide={data.is_culled ? undefined : THREE.BackSide}
+            />
           </mesh>
           {emissiveInfo && (
             <pointLight
@@ -241,7 +255,7 @@ export function GeometricRenderer(props: GeometricRendererProps) {
               castShadow
             />
           )}
-        </>
+        </group>
       );
     }
 

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -1,4 +1,5 @@
 import { MeshTransmissionMaterial } from '@react-three/drei';
+import type * as THREE from 'three';
 import { getMaterialDataSafe } from '@/utils/render/material';
 import { getTextureDataSafe } from '@/utils/render/texture';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
@@ -6,10 +7,12 @@ import type { NormalizedRenderConfig } from '@/utils/render/config';
 export type MaterialResolverProps = {
   config: NormalizedRenderConfig;
   materialName: string;
+  side?: THREE.Side;
+  shadowSide?: THREE.Side;
 };
 
 export function MaterialResolver(props: MaterialResolverProps) {
-  const { config, materialName } = props;
+  const { config, materialName, side, shadowSide } = props;
 
   const { data: materialData } = getMaterialDataSafe(config, materialName);
   const { data: reflectanceTexture } = getTextureDataSafe(config, materialData.reflectance_texture);
@@ -33,6 +36,8 @@ export function MaterialResolver(props: MaterialResolverProps) {
               transmission={1.0}
               ior={ior}
               roughness={0}
+              side={side}
+              shadowSide={shadowSide}
               {...(emissiveColor ? { emissive: emissiveColor } : {})}
             />
           );
@@ -49,6 +54,8 @@ export function MaterialResolver(props: MaterialResolverProps) {
               transmission={1.0}
               ior={ior}
               roughness={0}
+              side={side}
+              shadowSide={shadowSide}
             />
           );
         }
@@ -62,6 +69,8 @@ export function MaterialResolver(props: MaterialResolverProps) {
             <meshLambertMaterial
               attach="material"
               color={reflectanceTexture.color}
+              side={side}
+              shadowSide={shadowSide}
               {...(emissiveColor ? { emissive: emissiveColor } : {})}
             />
           );
@@ -71,7 +80,14 @@ export function MaterialResolver(props: MaterialResolverProps) {
           console.warn(
             `${reflectanceTexture.type} texture not yet supported for lambertian material`,
           );
-          return <meshLambertMaterial attach="material" color={[1, 1, 1]} />;
+          return (
+            <meshLambertMaterial
+              attach="material"
+              color={[1, 1, 1]}
+              side={side}
+              shadowSide={shadowSide}
+            />
+          );
         }
       }
     }
@@ -83,6 +99,8 @@ export function MaterialResolver(props: MaterialResolverProps) {
             <meshStandardMaterial
               attach="material"
               color={reflectanceTexture.color}
+              side={side}
+              shadowSide={shadowSide}
               {...(emissiveColor ? { emissive: emissiveColor } : {})}
               metalness={1.0}
               roughness={materialData.roughness}
@@ -98,6 +116,8 @@ export function MaterialResolver(props: MaterialResolverProps) {
             <meshStandardMaterial
               attach="material"
               color={[1, 1, 1]}
+              side={side}
+              shadowSide={shadowSide}
               metalness={1.0}
               roughness={materialData.roughness}
             />


### PR DESCRIPTION
Adds an unbounded (infinite) plane geometric primitive to the ray tracing engine and UI, per #5.

## Backend
- **`Plane` primitive** (`src/geometry/primitives/plane.rs`) — ray-plane intersection with back-face culling, `ONB`-based tangent space for UV mapping, hemisphere fallback sampling
- **`Aabb::UNIVERSE`** + **`is_infinite()`** — sentinel for unbounded objects; true AABB computed for axis-aligned planes (2 infinite axes, 1 zero-extent)
- **Scene compilation** (`src/tracing/scene.rs`) — split bounded/unbounded by `is_infinite()` check; bounded go into BVH, unbounded wrapped in `List(BVH, List(unbounded...))` binary-tree shape
- **List sampling fix** — `sample_direction_from()` and `direction_pdf()` skip infinite/zero-area children
- **Deserialization** — `{ "type": "plane", "point": [...], "normal": [...], ... }` support in scene JSON

## Frontend
- **Form controls** — Point, Normal, Double Sided toggle, Material select
- **3D preview** — 1000×1000 quad oriented by plane normal, `DoubleSide` support via `MaterialResolver` with `shadowSide={BackSide}` to prevent self-shadowing artifacts
- **Picker** — Plane added to geometric type dropdown

## Verification
- `cargo check`, `cargo test`, `cargo clippy` — all pass
- `eslint`, `prettier`, `tsc --noEmit` — all pass