### PR TITLE
fix: portal dropdown menus to document.body to escape sidebar scrollbar occlusion

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "@uiw/react-codemirror": "^4.25.10",
     "eventsource": "^4.1.0",
     "flowbite-react": "^0.12.17",
+    "@floating-ui/react": "^0.27.17",
     "framer-motion": "^12.40.0",
     "json-source-map": "^0.6.1",
     "luxon": "^3.7.2",

--- a/ui/src/views/renders/new/Controls/shared/AddEntityDropdown.tsx
+++ b/ui/src/views/renders/new/Controls/shared/AddEntityDropdown.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Dropdown, DropdownItem } from 'flowbite-react';
+import { PortalDropdown, PortalDropdownItem } from './PortalDropdown';
 import { getNextUniqueName, capitalize } from '@/utils/render/utils';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
@@ -176,16 +176,20 @@ export function AddEntityDropdown<T extends EntityType>(props: AddEntityDropdown
 
   return (
     <>
-      <Dropdown label={<HiPlus className="h-6 w-6" />} arrowIcon={false} color="light" size="sm">
+      <PortalDropdown
+        label={<HiPlus className="h-6 w-6" />}
+        placement="bottom"
+        triggerClassName="p-1 rounded-md border border-gray-300 bg-white text-gray-900 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-600 dark:text-white dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-700 flex items-center justify-center"
+      >
         {options.map(({ subtype, label }) => (
-          <DropdownItem key={subtype} onClick={() => handleDropdownClick(subtype)}>
+          <PortalDropdownItem key={subtype} onClick={() => handleDropdownClick(subtype)}>
             <div className="flex items-center gap-2">
               <HiPlus className="h-4 w-4" />
               {label}
             </div>
-          </DropdownItem>
+          </PortalDropdownItem>
         ))}
-      </Dropdown>
+      </PortalDropdown>
       {selectedSubtype && (
         <AddEntityModal
           entityType={type}

--- a/ui/src/views/renders/new/Controls/shared/DuplicateDropdown.tsx
+++ b/ui/src/views/renders/new/Controls/shared/DuplicateDropdown.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, DropdownItem } from 'flowbite-react';
+import { PortalDropdown, PortalDropdownItem } from './PortalDropdown';
 import { HiEllipsisHorizontal } from 'react-icons/hi2';
 
 export type DuplicateDropdownProps = {
@@ -9,14 +9,11 @@ export function DuplicateDropdown(props: DuplicateDropdownProps) {
   const { onDuplicate } = props;
 
   return (
-    <Dropdown
+    <PortalDropdown
       label={<HiEllipsisHorizontal className="h-5 w-5" />}
-      arrowIcon={false}
-      color="light"
-      size="sm"
-      inline
+      triggerClassName="flex items-center"
     >
-      <DropdownItem onClick={onDuplicate}>Duplicate</DropdownItem>
-    </Dropdown>
+      <PortalDropdownItem onClick={onDuplicate}>Duplicate</PortalDropdownItem>
+    </PortalDropdown>
   );
 }

--- a/ui/src/views/renders/new/Controls/shared/PortalDropdown/PortalDropdownContext.tsx
+++ b/ui/src/views/renders/new/Controls/shared/PortalDropdown/PortalDropdownContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+export type PortalDropdownContextValue = {
+  close: () => void;
+};
+
+export const PortalDropdownContext = createContext<PortalDropdownContextValue>({
+  close: () => {
+    // no-op default; replaced by provider before any consumer reads it
+  },
+});

--- a/ui/src/views/renders/new/Controls/shared/PortalDropdown/PortalDropdownDivider.tsx
+++ b/ui/src/views/renders/new/Controls/shared/PortalDropdown/PortalDropdownDivider.tsx
@@ -1,0 +1,3 @@
+export function PortalDropdownDivider() {
+  return <div className="my-1 h-px bg-gray-100 dark:bg-gray-600" />;
+}

--- a/ui/src/views/renders/new/Controls/shared/PortalDropdown/PortalDropdownItem.tsx
+++ b/ui/src/views/renders/new/Controls/shared/PortalDropdown/PortalDropdownItem.tsx
@@ -1,0 +1,27 @@
+import { useContext } from 'react';
+import { PortalDropdownContext } from './PortalDropdownContext';
+
+export type PortalDropdownItemProps = {
+  onClick?: () => void;
+  children: React.ReactNode;
+};
+
+export function PortalDropdownItem(props: PortalDropdownItemProps) {
+  const { onClick, children } = props;
+  const { close } = useContext(PortalDropdownContext);
+
+  function handleClick() {
+    onClick?.();
+    close();
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="flex w-full cursor-pointer items-center justify-start px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 focus:bg-gray-100 focus:outline-none dark:text-gray-200 dark:hover:bg-gray-600 dark:hover:text-white dark:focus:bg-gray-600 dark:focus:text-white"
+    >
+      {children}
+    </button>
+  );
+}

--- a/ui/src/views/renders/new/Controls/shared/PortalDropdown/index.tsx
+++ b/ui/src/views/renders/new/Controls/shared/PortalDropdown/index.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import {
+  useFloating,
+  FloatingPortal,
+  useClick,
+  useDismiss,
+  useRole,
+  useInteractions,
+  flip,
+  shift,
+  offset,
+  autoUpdate,
+} from '@floating-ui/react';
+import { PortalDropdownContext } from './PortalDropdownContext';
+
+export { PortalDropdownItem } from './PortalDropdownItem';
+export { PortalDropdownDivider } from './PortalDropdownDivider';
+export type { PortalDropdownItemProps } from './PortalDropdownItem';
+
+export type PortalDropdownProps = {
+  label: React.ReactNode;
+  children: React.ReactNode;
+  triggerClassName?: string;
+  placement?: 'bottom' | 'bottom-start';
+};
+
+export function PortalDropdown(props: PortalDropdownProps) {
+  const { label, children, triggerClassName, placement } = props;
+
+  const [open, setOpen] = useState(false);
+
+  const { refs, floatingStyles, context } = useFloating({
+    open,
+    onOpenChange: setOpen,
+    placement: placement ?? 'bottom-start',
+    strategy: 'fixed',
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(4), flip(), shift({ padding: 8 })],
+  });
+
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context, { role: 'menu' });
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, role]);
+
+  return (
+    <PortalDropdownContext.Provider value={{ close: () => setOpen(false) }}>
+      <button
+        type="button"
+        ref={refs.setReference}
+        className={triggerClassName}
+        {...getReferenceProps()}
+      >
+        {label}
+      </button>
+      {open && (
+        <FloatingPortal>
+          <div
+            // eslint-disable-next-line react-hooks/refs
+            ref={refs.setFloating}
+            style={floatingStyles}
+            className="z-50 min-w-fit divide-y divide-gray-100 rounded border border-gray-200 bg-white text-gray-900 shadow focus:outline-none dark:border-none dark:bg-gray-700 dark:text-white"
+            {...getFloatingProps()}
+          >
+            <div className="py-1">{children}</div>
+          </div>
+        </FloatingPortal>
+      )}
+    </PortalDropdownContext.Provider>
+  );
+}

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricMoreOptionsDropdown/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricMoreOptionsDropdown/index.tsx
@@ -1,5 +1,9 @@
 import { useState, useMemo } from 'react';
-import { Dropdown, DropdownItem, DropdownDivider } from 'flowbite-react';
+import {
+  PortalDropdown,
+  PortalDropdownItem,
+  PortalDropdownDivider,
+} from '@/views/renders/new/Controls/shared/PortalDropdown';
 import { useSelector } from '@tanstack/react-store';
 import { HiEllipsisHorizontal } from 'react-icons/hi2';
 import {
@@ -88,44 +92,43 @@ export function GeometricMoreOptionsDropdown(props: GeometricMoreOptionsDropdown
 
   return (
     <>
-      <Dropdown
+      <PortalDropdown
         label={<HiEllipsisHorizontal className="h-5 w-5" />}
-        arrowIcon={false}
-        color="light"
-        size="sm"
-        inline
+        triggerClassName="flex items-center"
       >
-        <DropdownItem
+        <PortalDropdownItem
           onClick={() => {
             setModalOpen(true);
           }}
         >
           Wrap
-        </DropdownItem>
+        </PortalDropdownItem>
         {availableLists.length > 0 && (
-          <DropdownItem
+          <PortalDropdownItem
             onClick={() => {
               setListModalOpen(true);
             }}
           >
             Add to List
-          </DropdownItem>
+          </PortalDropdownItem>
         )}
-        <DropdownDivider />
-        <DropdownItem onClick={handleDuplicate}>Duplicate</DropdownItem>
+        <PortalDropdownDivider />
+        <PortalDropdownItem onClick={handleDuplicate}>Duplicate</PortalDropdownItem>
         {isDirectlyInActiveScene && (
           <>
-            <DropdownDivider />
-            <DropdownItem onClick={handleRemoveFromScene}>Remove from Scene</DropdownItem>
+            <PortalDropdownDivider />
+            <PortalDropdownItem onClick={handleRemoveFromScene}>
+              Remove from Scene
+            </PortalDropdownItem>
           </>
         )}
         {!isUsedByActiveScene && (
           <>
-            <DropdownDivider />
-            <DropdownItem onClick={handleAddToScene}>Add to Scene</DropdownItem>
+            <PortalDropdownDivider />
+            <PortalDropdownItem onClick={handleAddToScene}>Add to Scene</PortalDropdownItem>
           </>
         )}
-      </Dropdown>
+      </PortalDropdown>
       <WrapGeometricModal
         geometricName={geometricName}
         open={modalOpen}


### PR DESCRIPTION
## Problem

Dropdown menus (three-dots menus on accordion rows and the `+` Add Entity button) render **underneath the sidebar's browser scrollbar** when the sidebar is tall enough to scroll. This happens because:

- flowbite-react's `Dropdown` uses `@floating-ui/react` inline (no portal) — the floating menu is a DOM descendant of the scrollable container
- Native OS scrollbars (especially on Linux/GTK) paint above all web content in their scroll container's subtree, regardless of CSS `z-index`

## Solution

Replaced flowbite-react's `Dropdown` with a custom `PortalDropdown` component built on `@floating-ui/react` using:

- **`FloatingPortal`** — renders the dropdown menu to `document.body`, escaping the sidebar's DOM subtree entirely
- **`strategy: 'fixed'`** — viewport-relative positioning
- **`autoUpdate`** — tracks the trigger button position during scroll

## Changes

- **New:** `PortalDropdown/` folder (4 files) — shared portal dropdown compound component (`PortalDropdown`, `PortalDropdownItem`, `PortalDropdownDivider`)
- **Updated:** `AddEntityDropdown`, `DuplicateDropdown`, `GeometricMoreOptionsDropdown` — swapped flowbite `Dropdown` imports for `PortalDropdown`
- **Updated:** `ui/package.json` — added `@floating-ui/react` as a direct dependency (was previously only a transitive dep via flowbite-react)

### Affected dropdowns

| Component | Where | Fix |
|---|---|---|
| `AddEntityDropdown` | `+` button in Geometrics/Materials/Textures tabs | Portal + `placement="bottom"` (centered) |
| `DuplicateDropdown` | Three-dots on material/texture accordion rows | Portal + `placement="bottom-start"` (inline) |
| `GeometricMoreOptionsDropdown` | Three-dots on geometric accordion rows | Portal + `placement="bottom-start"` (inline) |