### PR TITLE
fix: prevent long entity names from pushing sidebar content off-screen

### DIFF
--- a/ui/src/views/renders/new/Controls/shared/AccordionRow.tsx
+++ b/ui/src/views/renders/new/Controls/shared/AccordionRow.tsx
@@ -68,7 +68,7 @@ export function AccordionRow(props: AccordionRowProps) {
           </span>
         )}
 
-        <div className="flex flex-row items-center gap-2">
+        <div className="flex shrink-0 flex-row items-center gap-2">
           {rightLabel && <LabelText text={rightLabel} type={rightLabelStyle} />}
           <div onClick={(e) => e.stopPropagation()}>{rightActions}</div>
           {isExpanded ? (

--- a/ui/src/views/renders/new/Controls/shared/DraggableGroup.tsx
+++ b/ui/src/views/renders/new/Controls/shared/DraggableGroup.tsx
@@ -29,7 +29,7 @@ export function DraggableGroup(props: DraggableGroupProps) {
   const hasRest = rest.length > 0;
 
   return (
-    <div ref={setNodeRef} style={style} className="ml-[calc(var(--row-depth)*0.75rem)]">
+    <div ref={setNodeRef} style={style} className="ml-[calc(var(--row-depth)*0.75rem)] min-w-0">
       <div className="flex items-center">
         <button
           type="button"
@@ -40,12 +40,12 @@ export function DraggableGroup(props: DraggableGroupProps) {
         >
           <HiBars3 className="h-4 w-4" />
         </button>
-        <div className="flex-1">{first}</div>
+        <div className="flex-1 min-w-0">{first}</div>
       </div>
       {hasRest && (
         <div className="flex items-start">
           <div className="w-6 shrink-0" />
-          <div className="flex-1">{rest}</div>
+          <div className="flex-1 min-w-0">{rest}</div>
         </div>
       )}
     </div>

--- a/ui/src/views/renders/new/Controls/shared/DraggableGroup.tsx
+++ b/ui/src/views/renders/new/Controls/shared/DraggableGroup.tsx
@@ -40,12 +40,12 @@ export function DraggableGroup(props: DraggableGroupProps) {
         >
           <HiBars3 className="h-4 w-4" />
         </button>
-        <div className="flex-1 min-w-0">{first}</div>
+        <div className="min-w-0 flex-1">{first}</div>
       </div>
       {hasRest && (
         <div className="flex items-start">
           <div className="w-6 shrink-0" />
-          <div className="flex-1 min-w-0">{rest}</div>
+          <div className="min-w-0 flex-1">{rest}</div>
         </div>
       )}
     </div>

--- a/ui/src/views/renders/new/Controls/shared/RenamableLabel.tsx
+++ b/ui/src/views/renders/new/Controls/shared/RenamableLabel.tsx
@@ -57,8 +57,8 @@ export function RenamableLabel(props: RenamableLabelProps) {
   }
 
   return (
-    <span className="inline-flex min-w-0 items-center gap-2">
-      <LabelText text={label} type={labelStyle} className="truncate" title={label} />
+    <span className="flex items-center gap-2 min-w-0">
+      <LabelText text={label} type={labelStyle} className="min-w-0 truncate" title={label} />
       {afterLabel}
       <Button {...buttonProps} onClick={handleStartEditing} className="shrink-0">
         <HiPencil className="h-4 w-4" />

--- a/ui/src/views/renders/new/Controls/shared/RenamableLabel.tsx
+++ b/ui/src/views/renders/new/Controls/shared/RenamableLabel.tsx
@@ -57,7 +57,7 @@ export function RenamableLabel(props: RenamableLabelProps) {
   }
 
   return (
-    <span className="flex items-center gap-2 min-w-0">
+    <span className="flex min-w-0 items-center gap-2">
       <LabelText text={label} type={labelStyle} className="min-w-0 truncate" title={label} />
       {afterLabel}
       <Button {...buttonProps} onClick={handleStartEditing} className="shrink-0">

--- a/ui/src/views/renders/new/NewRenderSidebar/index.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/index.tsx
@@ -96,7 +96,7 @@ export function NewRenderSidebar(props: NewRenderSidebarProps) {
       <Sidebar theme={sidebarTheme} className="z-10 h-full w-lg">
         <SidebarItems className="h-full">
           <SidebarItemGroup className="flex h-full flex-col">
-            <div className="mb-0 flex flex-1 flex-col gap-2 overflow-y-auto">
+            <div className="mb-0 flex flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto">
               <Controls form={form} />
             </div>
             <div className="mt-0 flex flex-col gap-2">


### PR DESCRIPTION
## Problem

Long entity names (materials, textures, geometrics) would expand past the sidebar boundary, pushing the right-side elements (type label, dropdown, chevron) off-screen. The `<h2>` element already had `truncate min-w-0` from #177, but it never actually truncated because every parent container up the chain had CSS flexbox's default `min-width: auto`, which resolved to content size and prevented shrinking.

## Root cause

Three links in the DOM chain each had `min-width: auto` (the CSS flexbox default), which means each refused to shrink below its content width:

1. **DraggableGroup outer div** — `min-width: auto` = total content (~524px) → overflowed the 384px sidebar
2. **flex-1 wrapper** — `flex: 1 1 0%` but `min-width: auto` = AccordionRow content (~500px) → never actually started at 0
3. **RenamableLabel span** — `min-width: auto` = `<h2>` text width (~400px) → never allowed the `<h2>` to be constrained for truncation

## Fix

Added `min-w-0` at each level to break the `min-width: auto` chain, plus defensive measures:

| File | Change | Purpose |
|------|--------|---------|
| `DraggableGroup.tsx` L32 (outer div) | `min-w-0` | Stops expansion at sidebar boundary |
| `DraggableGroup.tsx` L43 (flex-1, main) | `min-w-0` | Lets `flex: 1 1 0%` actually work |
| `DraggableGroup.tsx` L48 (flex-1, nested) | `min-w-0` | Same fix for list child rows |
| `RenamableLabel.tsx` L60 (span) | `min-w-0` | Allows span to shrink in the row |
| `RenamableLabel.tsx` L61 (h2) | `min-w-0` | Allows `<h2>` to shrink for truncation |
| `AccordionRow.tsx` L71 | `shrink-0` | Defensive — prevents right side from ever shrinking |
| `NewRenderSidebar/index.tsx` L99 | `overflow-x-hidden` | Defensive — clips any remaining overflow |