### PR TITLE
fix: preserve list position when renaming entities

### DIFF
--- a/ui/src/utils/render/utils.ts
+++ b/ui/src/utils/render/utils.ts
@@ -217,10 +217,20 @@ function moveKey<T>(
   oldName: string,
   newName: string,
 ): Record<string, T> {
-  const newCollection = { ...collection };
-  newCollection[newName] = newCollection[oldName];
-  delete newCollection[oldName];
-  return newCollection;
+  if (!collection) {
+    return {};
+  }
+
+  const result: Record<string, T> = {};
+  for (const key of Object.keys(collection)) {
+    if (key === oldName) {
+      result[newName] = collection[oldName];
+    } else {
+      result[key] = collection[key];
+    }
+  }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
Renaming a material, texture, geometric, or camera was pushing it to the bottom of the list due to JavaScript object insertion order.

**Root cause:** `moveKey()` was appending the new key to the end of the object instead of placing it where the old key was.

**Fix:** Rebuild the object by iterating keys in insertion order, substituting the new name in place of the old one.