### PR TITLE
feat: persist render form draft to sessionStorage

### DIFF
--- a/ui/src/hooks/useRenderForm.ts
+++ b/ui/src/hooks/useRenderForm.ts
@@ -1,19 +1,55 @@
+import { useEffect, useRef, useState } from 'react';
 import { type DeepKeys } from '@tanstack/react-form';
 import { useAppForm } from '@/hooks/useAppForm';
 import { RenderConfigSchema, type NormalizedRenderConfig } from '../utils/render/config';
 import { getDefaultRenderConfig } from '../utils/render/templates';
 import type { User } from '../utils/api';
 
+const DRAFT_KEY = 'luxide-render-config-draft';
+
+function loadRenderDraft(): NormalizedRenderConfig | undefined {
+  try {
+    const raw = sessionStorage.getItem(DRAFT_KEY);
+    if (raw === null) {
+      return undefined;
+    }
+
+    const parsed = JSON.parse(raw);
+    const { data, success } = RenderConfigSchema.safeParse(parsed);
+    if (!success) {
+      return undefined;
+    }
+    return data;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveRenderDraft(config: NormalizedRenderConfig): void {
+  try {
+    sessionStorage.setItem(DRAFT_KEY, JSON.stringify(config));
+  } catch {
+    // silently ignore
+  }
+}
+
+export function clearRenderDraft(): void {
+  try {
+    sessionStorage.removeItem(DRAFT_KEY);
+  } catch {
+    // silently ignore
+  }
+}
+
 export type UseRenderFormOptions = {
   user: User | undefined;
-  initialValues?: NormalizedRenderConfig;
 };
 
 export type RenderForm = ReturnType<typeof useRenderForm>;
 export type RenderFormPath = DeepKeys<NormalizedRenderConfig>;
 
 export function useRenderForm(options: UseRenderFormOptions) {
-  const { user, initialValues } = options;
+  const { user } = options;
 
   const formSchema = RenderConfigSchema.refine(
     ({ parameters }) => {
@@ -63,10 +99,43 @@ export function useRenderForm(options: UseRenderFormOptions) {
       },
     );
 
-  return useAppForm({
-    defaultValues: initialValues ?? getDefaultRenderConfig(),
+  const [resolvedDefaults] = useState(() => {
+    return loadRenderDraft() ?? getDefaultRenderConfig();
+  });
+
+  const form = useAppForm({
+    defaultValues: resolvedDefaults,
     validators: {
       onChange: formSchema,
     },
   });
+
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  // debounced auto-save: persist form values to sessionStorage after
+  // the user stops typing for 500ms, avoiding writes on every keystroke
+  useEffect(() => {
+    // subscribe to the form store — fires on every value change
+    const { unsubscribe } = form.store.subscribe(() => {
+      // a pending save is already scheduled — cancel it to reset the debounce clock
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+      }
+      // start a new 500ms timer; if no further changes arrive, persist current values
+      saveTimerRef.current = setTimeout(() => {
+        saveRenderDraft(form.state.values);
+      }, 500);
+    });
+
+    return () => {
+      // stop listening for changes on unmount
+      unsubscribe();
+      // cancel any still-pending save
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+      }
+    };
+  }, [form]);
+
+  return form;
 }

--- a/ui/src/views/renders/CreateRenderModal/index.tsx
+++ b/ui/src/views/renders/CreateRenderModal/index.tsx
@@ -7,6 +7,7 @@ import { ImportConfigBody } from './ImportConfigModal/ImportConfigBody';
 import { ExistingRenderPicker } from './ExistingRenderPicker';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import type { Template } from '@/utils/render/templates';
+import { saveRenderDraft } from '@/hooks/useRenderForm';
 
 type Stage = 'source-choice' | 'template-picker' | 'import-json' | 'render-picker';
 
@@ -28,18 +29,21 @@ export function CreateRenderModal(props: CreateRenderModalProps) {
 
   const handleTemplateSelect = (template: Template) => {
     const config = template.config;
-    navigate('/renders/new', { state: { importedConfig: config } });
+    saveRenderDraft(config);
+    navigate('/renders/new');
     onClose();
   };
 
   const handleImportSuccess = (config: NormalizedRenderConfig) => {
-    navigate('/renders/new', { state: { importedConfig: config } });
+    saveRenderDraft(config);
+    navigate('/renders/new');
     onClose();
   };
 
   const handleExistingRenderSelect = (config: NormalizedRenderConfig) => {
     const modifiedConfig = { ...config, name: `${config.name} (copy)` };
-    navigate('/renders/new', { state: { importedConfig: modifiedConfig } });
+    saveRenderDraft(modifiedConfig);
+    navigate('/renders/new');
     onClose();
   };
 

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderInfo/index.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderInfo/index.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { HiDocumentDuplicate } from 'react-icons/hi2';
 import { normalizeRenderConfig } from '@/utils/render/config';
 import { withDefaultResources } from '@/utils/render/templates';
+import { saveRenderDraft } from '@/hooks/useRenderForm';
 
 /**
  * formats a pixel sample count for display.
@@ -68,7 +69,8 @@ export function RenderInfo(props: RenderInfoProps) {
     const normalizedConfig = normalizeRenderConfig(render.config);
     const configWithDefaults = withDefaultResources(normalizedConfig);
     const modifiedConfig = { ...configWithDefaults, name: `${configWithDefaults.name} (copy)` };
-    navigate('/renders/new', { replace: true, state: { importedConfig: modifiedConfig } });
+    saveRenderDraft(modifiedConfig);
+    navigate('/renders/new', { replace: true });
   }
 
   const totalSamples = renderStats

--- a/ui/src/views/renders/new/NewRenderSidebar/index.tsx
+++ b/ui/src/views/renders/new/NewRenderSidebar/index.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '@/providers/Auth';
 import { useCreateRenderMutation } from '@/hooks/useRenderMutations';
 import { useRendersQuery } from '@/hooks/useRenders';
 import type { RenderForm } from '@/hooks/useRenderForm';
+import { clearRenderDraft } from '@/hooks/useRenderForm';
 import { ViewConfigJSONButton } from './ViewConfigJSONButton';
 import { ConfigJSONModal } from '@/components/ViewRenderJSONButton/ConfigJSONModal';
 import toast from 'react-hot-toast';
@@ -72,6 +73,7 @@ export function NewRenderSidebar(props: NewRenderSidebarProps) {
     createRender(form.state.values, {
       onSuccess: (response) => {
         navigate(`/renders/${response.id}`);
+        clearRenderDraft();
       },
       onError: (error) => {
         toast.error(extractErrorMessage(error));

--- a/ui/src/views/renders/new/index.tsx
+++ b/ui/src/views/renders/new/index.tsx
@@ -1,16 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 import { useAuth } from '@/providers/Auth';
 import { useRenderForm } from '@/hooks/useRenderForm';
 import { NewRenderSidebar } from './NewRenderSidebar';
 import { Scene } from './Scene';
-import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { useSelector } from '@tanstack/react-store';
 
 export function NewRenderPage() {
   const { user } = useAuth();
-  const location = useLocation();
-  const importedConfig = location.state?.importedConfig as NormalizedRenderConfig | undefined;
 
   // canvas container sizing
   const containerRef = useRef<HTMLDivElement>(null);
@@ -30,7 +26,7 @@ export function NewRenderPage() {
     return () => observer.disconnect();
   }, []);
 
-  const form = useRenderForm({ user, initialValues: importedConfig });
+  const form = useRenderForm({ user });
 
   // canvas sizing - maintain aspect ratio in container
   const imageDimensions = useSelector(


### PR DESCRIPTION
### What

Saves the render configuration form state to `sessionStorage` as the user edits, so work survives page refreshes and unexpected navigation away.

### How

Switches from React Router `location.state` to `sessionStorage` as the single source of truth for passing render configs to the `/renders/new` page:

| Before | After |
|---|---|
| Import/clone → `navigate({ state: { importedConfig } })` | Import/clone → `saveRenderDraft(config)` → `navigate('/renders/new')` |
| Page reads `location.state` | Page reads `sessionStorage` |

### Changes (5 files)

- **`useRenderForm.ts`** — `loadRenderDraft`/`saveRenderDraft`/`clearRenderDraft` functions. Form resolves defaults from sessionStorage on mount. 500ms debounced auto-save on every edit.
- **`renders/new/index.tsx`** — Removed `useLocation` and `location.state` reading. Simplified form creation.
- **`CreateRenderModal/index.tsx`** — All 3 handlers (template, import, clone) write to sessionStorage before navigating.
- **`RenderInfo/index.tsx`** — Clone button writes to sessionStorage before navigating.
- **`NewRenderSidebar/index.tsx`** — Clears draft on successful render creation.

### Edge cases handled

- Schema validation on load (corrupted data → fall back to defaults)
- JSON parse errors, quota exceeded → silently ignored
- Draft cleared on submit → next visit starts fresh
- Per-tab isolation via `sessionStorage` — no cross-tab interference