### PR TITLE
chore: update package-lock.json for npm 11

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@floating-ui/react": "^0.27.17",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.1",
         "@tanstack/react-form": "^1.32.0",


### PR DESCRIPTION
Node 26.4.0 (per `.nvmrc`) ships with npm 11, which uses a new lockfile resolver. The old lockfile was generated by an older npm version and drifts on every `npm` invocation. This commit aligns it with npm 11.