### PR TITLE
feat: disk geometric primitive

### DIFF
--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -229,6 +229,7 @@ fn get_geometric_dependencies(geometric: &GeometricData) -> Vec<String> {
         // these contain no `geometric` field, only a `material` — no geometric dependencies to track
         GeometricData::CompoundAxisAlignedPBox { .. }
         | GeometricData::CompoundModelObj { .. }
+        | GeometricData::PrimitiveDisk { .. }
         | GeometricData::PrimitiveParallelogram { .. }
         | GeometricData::PrimitivePlane { .. }
         | GeometricData::PrimitiveSphere { .. }

--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -7,7 +7,7 @@ use crate::{
         Geometric, Vector3,
         compounds::{AxisAlignedPBox, Bvh, List, ModelObj, Virtual},
         instances::{RotateXAxis, RotateYAxis, RotateZAxis, Translate},
-        primitives::{Parallelogram, Plane, Sphere, Triangle},
+        primitives::{Disk, Parallelogram, Plane, Sphere, Triangle},
         volumes,
     },
     utils::{Angle, Around},
@@ -124,6 +124,17 @@ pub enum GeometricData {
         b_normal: Option<[f64; 3]>,
         #[serde(skip_serializing_if = "Option::is_none")]
         c_normal: Option<[f64; 3]>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_culled: Option<bool>,
+        material: MaterialRefOrInline,
+    },
+    #[serde(rename = "disk")]
+    PrimitiveDisk {
+        center: [f64; 3],
+        normal: [f64; 3],
+        radius: f64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        inner_radius: Option<f64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         is_culled: Option<bool>,
         material: MaterialRefOrInline,
@@ -304,6 +315,25 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
                     (*is_culled).unwrap_or(false),
                     material,
                 )))
+            }
+            Self::PrimitiveDisk {
+                center,
+                normal,
+                radius,
+                inner_radius,
+                is_culled,
+                material,
+            } => {
+                let material = material.build(builts)?;
+
+                Ok(Arc::new(Disk::new(
+                    (*center).into(),
+                    (*normal).into(),
+                    *radius,
+                    (*inner_radius).unwrap_or(0.0),
+                    (*is_culled).unwrap_or(false),
+                    material,
+                )?))
             }
             Self::VolumeConstant {
                 geometric: geometric_ref,

--- a/src/geometry/primitives.rs
+++ b/src/geometry/primitives.rs
@@ -9,3 +9,6 @@ pub use sphere::Sphere;
 
 mod triangle;
 pub use triangle::Triangle;
+
+mod disk;
+pub use disk::Disk;

--- a/src/geometry/primitives/disk.rs
+++ b/src/geometry/primitives/disk.rs
@@ -1,0 +1,355 @@
+use std::f64::consts::{PI, TAU};
+use std::sync::Arc;
+
+use crate::{
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
+    shading::materials::{Lambertian, Material},
+    utils::Interval,
+};
+
+#[derive(Clone, Debug)]
+pub struct Disk {
+    center: Point,
+    normal: Vector3,
+    radius: f64,
+    inner_radius: f64,
+    is_culled: bool,
+    plane_d: f64,
+    u_axis: Vector3,
+    v_axis: Vector3,
+    material: Arc<dyn Material>,
+    bounding_box: Aabb,
+    area: f64,
+}
+
+impl Disk {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        center: Point,
+        normal: Vector3,
+        radius: f64,
+        inner_radius: f64,
+        is_culled: bool,
+        material: Arc<dyn Material>,
+    ) -> Result<Self, String> {
+        if radius <= 0.0 {
+            return Err("disk radius must be positive".to_string());
+        }
+        if inner_radius < 0.0 || inner_radius >= radius {
+            return Err("disk inner_radius must be in [0, radius)".to_string());
+        }
+        if normal.squared_length() <= 0.0 {
+            return Err("disk normal must not be zero-length".to_string());
+        }
+        let normal = normal.unit_vector();
+
+        // tangent basis
+        let reference = if normal.y.abs() < 0.999 {
+            Vector3::new(0.0, 1.0, 0.0)
+        } else {
+            Vector3::new(1.0, 0.0, 0.0)
+        };
+        let u_axis = reference.cross(normal).unit_vector();
+        let v_axis = normal.cross(u_axis);
+
+        let plane_d = center.0.dot(normal);
+
+        // area of the annular disk
+        let area = PI * (radius.powi(2) - inner_radius.powi(2));
+
+        // bounding box: for each axis, compute the half-extent as the
+        // maximum projection of the disk's tangent vectors
+        let ex = ((u_axis.x * radius).powi(2) + (v_axis.x * radius).powi(2)).sqrt();
+        let ey = ((u_axis.y * radius).powi(2) + (v_axis.y * radius).powi(2)).sqrt();
+        let ez = ((u_axis.z * radius).powi(2) + (v_axis.z * radius).powi(2)).sqrt();
+        let points = [
+            center + Vector3::new(-ex, -ey, -ez),
+            center + Vector3::new(-ex, -ey, ez),
+            center + Vector3::new(-ex, ey, -ez),
+            center + Vector3::new(-ex, ey, ez),
+            center + Vector3::new(ex, -ey, -ez),
+            center + Vector3::new(ex, -ey, ez),
+            center + Vector3::new(ex, ey, -ez),
+            center + Vector3::new(ex, ey, ez),
+        ];
+
+        Ok(Self {
+            center,
+            normal,
+            radius,
+            inner_radius,
+            is_culled,
+            plane_d,
+            u_axis,
+            v_axis,
+            material,
+            bounding_box: Aabb::from_points(&points).pad(0.0001),
+            area,
+        })
+    }
+
+    pub fn unit() -> Self {
+        Self::new(
+            Point::new(0.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            1.0,
+            0.0,
+            true,
+            Arc::new(Lambertian::white()),
+        )
+        .expect("unit disk parameters are valid")
+    }
+}
+
+impl Geometric for Disk {
+    fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
+        let denominator = self.normal.dot(ray.direction);
+
+        // parallel ray — no intersection
+        if denominator.abs() < 1e-8 {
+            return None;
+        }
+
+        // back-face culling
+        if self.is_culled && denominator >= -1e-8 {
+            return None;
+        }
+
+        let t = (self.plane_d - self.normal.dot(ray.origin.0)) / denominator;
+        if !ray_t.contains_including(t) {
+            return None;
+        }
+
+        let hit_point = ray.at(t);
+        let diff = hit_point - self.center;
+        let d_sq = diff.squared_length();
+
+        // radial containment (squared, no sqrt)
+        if d_sq < self.inner_radius.powi(2) || d_sq > self.radius.powi(2) {
+            return None;
+        }
+
+        // UV mapping
+        let hit_local = hit_point.0 - self.center.0;
+        let phi = hit_local.dot(self.v_axis).atan2(hit_local.dot(self.u_axis));
+        let phi_wrapped = if phi < 0.0 { phi + TAU } else { phi };
+        let u = phi_wrapped / TAU;
+        let d = d_sq.sqrt();
+        let v = (self.radius - d) / (self.radius - self.inner_radius);
+
+        // invert the normal if we are not culled and the ray hits the back side
+        let local_normal = if !self.is_culled && denominator > 0.0 {
+            -self.normal
+        } else {
+            self.normal
+        };
+
+        Some(RayHit {
+            t,
+            point: hit_point,
+            normal: local_normal,
+            material: Arc::clone(&self.material),
+            u,
+            v,
+        })
+    }
+
+    fn surface_area(&self) -> f64 {
+        self.area
+    }
+
+    fn is_emissive(&self) -> bool {
+        self.material.is_emissive()
+    }
+
+    fn is_transmissive(&self) -> bool {
+        self.material.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.material.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.surface_area() <= 0.0
+    }
+
+    fn bounding_box(&self) -> Aabb {
+        self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
+        // uniform area sampling on a disk: sample r² uniformly in
+        // [inner_radius², radius²] and φ uniformly in [0, 2π].
+        // the sqrt correction (r = sqrt(r²)) ensures uniform area
+        // distribution — without it, the center would get over-sampled.
+        // when inner_radius == 0 this is equivalent to Malley's method
+        // used by Vector3::random_cosine_weighted_direction.
+        let r_sq: f64 = rand::random::<f64>() * (self.radius.powi(2) - self.inner_radius.powi(2))
+            + self.inner_radius.powi(2);
+        let r = r_sq.sqrt();
+        let phi: f64 = rand::random::<f64>() * TAU;
+        let p = self.center + r * phi.cos() * self.u_axis + r * phi.sin() * self.v_axis;
+        origin.to(p).unit_vector()
+    }
+
+    fn direction_pdf(&self, origin: Point, direction: Vector3) -> f64 {
+        let ray = Ray::new(origin, direction, 0.0);
+
+        let Some(hit) = self.intersect(ray, Interval::new(0.001, f64::INFINITY)) else {
+            return 0.0;
+        };
+
+        let cos_theta = direction.dot(hit.normal).abs();
+        if cos_theta < 1e-8 {
+            return 0.0;
+        }
+
+        (hit.t * hit.t) / (cos_theta * self.area)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hits_front_center() {
+        let d = Disk::unit();
+
+        let ray = Ray::new(Point::new(0.0, 0.0, 1.0), Vector3::new(0.0, 0.0, -1.0), 0.0);
+        let ray_t = Interval::new(0.0, f64::INFINITY);
+
+        let opt_hit = d.intersect(ray, ray_t);
+        assert!(opt_hit.is_some());
+        let hit = opt_hit.unwrap();
+
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, 1.0));
+        assert_eq!(hit.point, Point::new(0.0, 0.0, 0.0));
+        assert_eq!(hit.t, 1.0);
+        assert_eq!(hit.v, 1.0);
+    }
+
+    #[test]
+    fn hits_front_edge() {
+        let d = Disk::unit();
+
+        let ray = Ray::new(Point::new(1.0, 0.0, 1.0), Vector3::new(0.0, 0.0, -1.0), 0.0);
+        let ray_t = Interval::new(0.0, f64::INFINITY);
+
+        let opt_hit = d.intersect(ray, ray_t);
+        assert!(opt_hit.is_some());
+        let hit = opt_hit.unwrap();
+
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, 1.0));
+        assert_eq!(hit.point, Point::new(1.0, 0.0, 0.0));
+        assert_eq!(hit.t, 1.0);
+    }
+
+    #[test]
+    fn misses_outside_radius() {
+        let d = Disk::unit();
+
+        let ray = Ray::new(Point::new(2.0, 0.0, 1.0), Vector3::new(0.0, 0.0, -1.0), 0.0);
+        let ray_t = Interval::new(0.0, f64::INFINITY);
+
+        let opt_hit = d.intersect(ray, ray_t);
+        assert!(opt_hit.is_none());
+    }
+
+    #[test]
+    fn misses_culled_back() {
+        let d = Disk::unit();
+
+        let ray = Ray::new(Point::new(0.0, 0.0, -1.0), Vector3::new(0.0, 0.0, 1.0), 0.0);
+        let ray_t = Interval::new(0.0, f64::INFINITY);
+
+        let opt_hit = d.intersect(ray, ray_t);
+        assert!(opt_hit.is_none());
+    }
+
+    #[test]
+    fn hits_unculled_back() {
+        let d = Disk::new(
+            Point::new(0.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            1.0,
+            0.0,
+            false,
+            Arc::new(Lambertian::white()),
+        )
+        .unwrap();
+
+        let ray = Ray::new(Point::new(0.0, 0.0, -1.0), Vector3::new(0.0, 0.0, 1.0), 0.0);
+        let ray_t = Interval::new(0.0, f64::INFINITY);
+
+        let opt_hit = d.intersect(ray, ray_t);
+        assert!(opt_hit.is_some());
+        let hit = opt_hit.unwrap();
+
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, -1.0));
+        assert_eq!(hit.point, Point::new(0.0, 0.0, 0.0));
+        assert_eq!(hit.t, 1.0);
+    }
+
+    #[test]
+    fn parallel_ray_misses() {
+        let d = Disk::unit();
+
+        let ray = Ray::new(Point::new(0.0, 0.0, 1.0), Vector3::new(1.0, 0.0, 0.0), 0.0);
+        let ray_t = Interval::new(0.0, f64::INFINITY);
+
+        let opt_hit = d.intersect(ray, ray_t);
+        assert!(opt_hit.is_none());
+    }
+
+    #[test]
+    fn hits_annulus_inner() {
+        let d = Disk::new(
+            Point::new(0.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            1.0,
+            0.5,
+            true,
+            Arc::new(Lambertian::white()),
+        )
+        .unwrap();
+
+        let ray = Ray::new(
+            Point::new(0.75, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, -1.0),
+            0.0,
+        );
+        let ray_t = Interval::new(0.0, f64::INFINITY);
+
+        let opt_hit = d.intersect(ray, ray_t);
+        assert!(opt_hit.is_some());
+        let hit = opt_hit.unwrap();
+
+        assert_eq!(hit.point, Point::new(0.75, 0.0, 0.0));
+        assert_eq!(hit.t, 1.0);
+    }
+
+    #[test]
+    fn misses_annulus_hole() {
+        let d = Disk::new(
+            Point::new(0.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            1.0,
+            0.5,
+            true,
+            Arc::new(Lambertian::white()),
+        )
+        .unwrap();
+
+        let ray = Ray::new(
+            Point::new(0.25, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, -1.0),
+            0.0,
+        );
+        let ray_t = Interval::new(0.0, f64::INFINITY);
+
+        let opt_hit = d.intersect(ray, ray_t);
+        assert!(opt_hit.is_none());
+    }
+}

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -49,6 +49,8 @@ export function normalizeGeometricData(
       return normalizeGeometricConstantVolume(config, name, geometricData);
     case 'virtual':
       return normalizeGeometricVirtual(config, name, geometricData);
+    case 'disk':
+      return normalizeGeometricDisk(config, name, geometricData);
   }
 }
 
@@ -63,7 +65,8 @@ export type NormalizedGeometricData =
   | NormalizedGeometricSphere
   | NormalizedGeometricTriangle
   | NormalizedGeometricConstantVolume
-  | NormalizedGeometricVirtual;
+  | NormalizedGeometricVirtual
+  | NormalizedGeometricDisk;
 
 export type RawGeometricData =
   | RawGeometricBox
@@ -76,7 +79,8 @@ export type RawGeometricData =
   | RawGeometricSphere
   | RawGeometricTriangle
   | RawGeometricConstantVolume
-  | RawGeometricVirtual;
+  | RawGeometricVirtual
+  | RawGeometricDisk;
 
 export function isGeometricData(data: unknown): data is GeometricData {
   return (
@@ -93,6 +97,7 @@ export function isGeometricData(data: unknown): data is GeometricData {
       'plane',
       'sphere',
       'triangle',
+      'disk',
       'constant_volume',
       'virtual',
     ].includes(data.type)
@@ -120,6 +125,7 @@ export function getReferencedMaterialNames(
   const materials: string[] = [];
   switch (data.type) {
     case 'box':
+    case 'disk':
     case 'obj_model':
     case 'parallelogram':
     case 'plane':
@@ -270,6 +276,8 @@ export function getCenterPoint(
         (data.a[1] + data.b[1] + data.c[1]) / 3,
         (data.a[2] + data.b[2] + data.c[2]) / 3,
       ];
+    case 'disk':
+      return data.center;
   }
 }
 
@@ -425,6 +433,16 @@ export function defaultGeometricForType(
       return {
         type: 'virtual',
         geometric: '__unit_box',
+      };
+    case 'disk':
+      return {
+        type: 'disk',
+        center: [0, 0, 0],
+        normal: [0, 1, 0],
+        radius: 1,
+        inner_radius: 0,
+        is_culled: false,
+        material: '__lambertian_white',
       };
   }
 }
@@ -987,6 +1005,61 @@ export function normalizeGeometricVirtual(
   return geometric as NormalizedGeometricVirtual;
 }
 
+export const GeometricDiskSchema = z
+  .object({
+    type: z.literal('disk'),
+    center: z.tuple([z.number(), z.number(), z.number()]),
+    normal: z.tuple([z.number(), z.number(), z.number()]),
+    radius: z.number().positive(),
+    inner_radius: z.number().min(0).optional().default(0),
+    is_culled: z.boolean().nullish(),
+    material: z.string().nonempty(),
+  })
+  .refine(({ inner_radius, radius }) => (inner_radius ?? 0.0) < radius, {
+    message: 'Inner radius must be less than the outer radius',
+    path: ['inner_radius'],
+  });
+
+export type GeometricDisk = NormalizedGeometricDisk;
+
+export function normalizeGeometricDisk(
+  config: RenderConfig,
+  name: string,
+  geometricData: RawGeometricDisk,
+): NormalizedGeometricDisk {
+  const geometric = geometricData;
+
+  if (typeof geometric.material !== 'string') {
+    if (!config.materials) {
+      config.materials = {};
+    }
+
+    const materialName = getNextUniqueName(config.materials, `${name}_${geometric.material.type}`);
+    config.materials[materialName] = normalizeMaterialData(
+      config,
+      materialName,
+      geometric.material,
+    );
+    geometric.material = materialName;
+  }
+
+  return geometric as NormalizedGeometricDisk;
+}
+
+export type NormalizedGeometricDisk = Omit<RawGeometricDisk, 'material'> & {
+  material: string;
+};
+
+export type RawGeometricDisk = {
+  type: 'disk';
+  center: [number, number, number];
+  normal: [number, number, number];
+  radius: number;
+  inner_radius?: number;
+  is_culled?: boolean;
+  material: string | RawMaterialData;
+};
+
 const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   box: GeometricBoxSchema,
   list: GeometricListSchema,
@@ -996,6 +1069,7 @@ const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   rotate_z: GeometricInstanceRotateZSchema,
   translate: GeometricInstanceTranslateSchema,
   parallelogram: GeometricParallelogramSchema,
+  disk: GeometricDiskSchema,
   plane: GeometricPlaneSchema,
   sphere: GeometricSphereSchema,
   triangle: GeometricTriangleSchema,
@@ -1044,6 +1118,7 @@ export function wrapGeometric(
     sphere: 'Sphere',
     triangle: 'Triangle',
     parallelogram: 'Parallelogram',
+    disk: 'Disk',
     obj_model: 'OBJ Model',
     list: 'List',
     rotate_x: 'Rotate X',

--- a/ui/src/utils/render/utils.ts
+++ b/ui/src/utils/render/utils.ts
@@ -164,6 +164,7 @@ export function fixReferences(config: NormalizedRenderConfig): NormalizedRenderC
   for (const geometric of Object.values(geometrics)) {
     switch (geometric.type) {
       case 'box':
+      case 'disk':
       case 'obj_model':
       case 'parallelogram':
       case 'sphere':
@@ -329,6 +330,7 @@ export function renameMaterial(
   Object.values(newConfig.geometrics ?? {}).forEach((geometric) => {
     switch (geometric.type) {
       case 'box':
+      case 'disk':
       case 'obj_model':
       case 'parallelogram':
       case 'sphere':

--- a/ui/src/views/renders/new/Controls/index.tsx
+++ b/ui/src/views/renders/new/Controls/index.tsx
@@ -88,6 +88,11 @@ export function Controls(props: ControlsProps) {
                   description: 'Infinite plane defined by a point and a normal vector.',
                 },
                 {
+                  subtype: 'disk',
+                  label: 'Disk',
+                  description: 'Flat disc defined by center, normal, and radius.',
+                },
+                {
                   subtype: 'list',
                   label: 'List',
                   description: 'A group of geometrics rendered together.',

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -166,6 +166,43 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <GeometricMaterialSelect form={form} name={name} items={materialItems} />
         </>
       );
+    case 'disk':
+      return (
+        <>
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.center`}
+            label="Center"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.normal`}
+            label="Normal"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <TextInputControl
+            form={form}
+            fieldName={`geometrics.${name}.radius`}
+            label="Radius"
+            valueLabel="radius"
+            type="number"
+          />
+          <TextInputControl
+            form={form}
+            fieldName={`geometrics.${name}.inner_radius`}
+            label="Inner Radius"
+            valueLabel="inner_radius"
+            type="number"
+          />
+          <form.AppField name={`geometrics.${name}.is_culled`}>
+            {(field) => <field.ToggleControl label="Double Sided" invert />}
+          </form.AppField>
+          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+        </>
+      );
     case 'rotate_x':
     case 'rotate_y':
     case 'rotate_z': {

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -187,6 +187,48 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       );
     }
 
+    case 'disk': {
+      const innerRadius = data.inner_radius ?? 0;
+
+      // orient the disk using the normal
+      const normalVec = new THREE.Vector3(
+        data.normal[0],
+        data.normal[1],
+        data.normal[2],
+      ).normalize();
+      const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), normalVec);
+      const rot = new THREE.Euler().setFromQuaternion(quat);
+
+      const emissiveInfo = getEmissiveInfo(config, data.material);
+
+      return (
+        <>
+          <mesh
+            position={[data.center[0], data.center[1], data.center[2]]}
+            rotation={[rot.x, rot.y, rot.z]}
+            castShadow={!emissiveInfo}
+            receiveShadow
+          >
+            <ringGeometry args={[innerRadius, data.radius, 64]} />
+            <MaterialResolver
+              config={config}
+              materialName={data.material}
+              side={data.is_culled ? THREE.FrontSide : THREE.DoubleSide}
+              shadowSide={data.is_culled ? undefined : THREE.BackSide}
+            />
+          </mesh>
+          {emissiveInfo && (
+            <pointLight
+              color={emissiveInfo.color}
+              intensity={emissiveInfo.intensity}
+              position={getCenterPoint(config, data)}
+              castShadow
+            />
+          )}
+        </>
+      );
+    }
+
     case 'triangle': {
       const geom = createTriangleGeometry(data);
 


### PR DESCRIPTION
Adds a Disk geometric primitive supporting full disks and annuli (rings) via an optional `inner_radius` parameter.

## Backend
- `Disk` struct with full `Geometric` trait (plane-ray intersection with squared radial containment, uniform area sampling with sqrt correction, Jacobian-based `direction_pdf`)
- `Result`-based constructor with validation (radius > 0, inner_radius in [0, radius), normal non-zero)
- Deserialization support (`"type": "disk"` in scene JSON)
- 8 unit tests

## Frontend
- Zod schema with cross-field validation (`inner_radius < radius`)
- Form controls: center, normal, radius, inner radius, double-sided toggle, material select
- 3D preview using native `THREE.RingGeometry` (64 segments)
- Reference fixers for material deletion/renaming

## Example JSON
```json
{
  "type": "disk",
  "center": [0, 5, 0],
  "normal": [0, 1, 0],
  "radius": 2,
  "inner_radius": 0.5,
  "is_culled": false,
  "material": "white_light"
}
```

**Angular sector support** (`phi_min`/`phi_max`) deferred to #202.

Closes #6