### PR TITLE
feat: bilinear patch geometric primitive with GARP intersection (#182)

### DIFF
--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -233,6 +233,7 @@ fn get_geometric_dependencies(geometric: &GeometricData) -> Vec<String> {
         | GeometricData::PrimitiveParallelogram { .. }
         | GeometricData::PrimitivePlane { .. }
         | GeometricData::PrimitiveSphere { .. }
+        | GeometricData::PrimitiveBilinearPatch { .. }
         | GeometricData::PrimitiveTriangle { .. } => {}
     }
     deps

--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -7,7 +7,7 @@ use crate::{
         Geometric, Vector3,
         compounds::{AxisAlignedPBox, Bvh, List, ModelObj, Virtual},
         instances::{RotateXAxis, RotateYAxis, RotateZAxis, Translate},
-        primitives::{Disk, Parallelogram, Plane, Sphere, Triangle},
+        primitives::{BilinearPatch, Disk, Parallelogram, Plane, Sphere, Triangle},
         volumes,
     },
     utils::{Angle, Around},
@@ -97,6 +97,14 @@ pub enum GeometricData {
         v: [f64; 3],
         #[serde(skip_serializing_if = "Option::is_none")]
         is_culled: Option<bool>,
+        material: MaterialRefOrInline,
+    },
+    #[serde(rename = "bilinear_patch")]
+    PrimitiveBilinearPatch {
+        p00: [f64; 3],
+        p10: [f64; 3],
+        p01: [f64; 3],
+        p11: [f64; 3],
         material: MaterialRefOrInline,
     },
     #[serde(rename = "plane")]
@@ -259,6 +267,23 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
                     (*u).into(),
                     (*v).into(),
                     (*is_culled).unwrap_or(false),
+                    material,
+                )))
+            }
+            Self::PrimitiveBilinearPatch {
+                p00,
+                p10,
+                p01,
+                p11,
+                material,
+            } => {
+                let material = material.build(builts)?;
+
+                Ok(Arc::new(BilinearPatch::new(
+                    (*p00).into(),
+                    (*p10).into(),
+                    (*p01).into(),
+                    (*p11).into(),
                     material,
                 )))
             }

--- a/src/geometry/primitives.rs
+++ b/src/geometry/primitives.rs
@@ -12,3 +12,6 @@ pub use triangle::Triangle;
 
 mod disk;
 pub use disk::Disk;
+
+mod bilinear_patch;
+pub use bilinear_patch::BilinearPatch;

--- a/src/geometry/primitives/bilinear_patch.rs
+++ b/src/geometry/primitives/bilinear_patch.rs
@@ -1,0 +1,187 @@
+use std::sync::Arc;
+
+use crate::{
+    geometry::{
+        Aabb, Geometric, Point, Ray, RayHit, Vector3, compounds::List, primitives::Triangle,
+    },
+    shading::materials::Material,
+    utils::Interval,
+};
+
+#[derive(Clone, Debug)]
+pub struct BilinearPatch {
+    p00: Point,
+    p10: Point,
+    p01: Point,
+    p11: Point,
+    material: Arc<dyn Material>,
+    e00_10: Vector3,
+    e00_01: Vector3,
+    e01_11: Vector3,
+    e10_11: Vector3,
+    cross_edges: Vector3,
+    bounding_box: Aabb,
+    proxy_triangles_list: List,
+}
+
+impl BilinearPatch {
+    pub fn new(
+        p00: Point,
+        p10: Point,
+        p01: Point,
+        p11: Point,
+        material: Arc<dyn Material>,
+    ) -> Self {
+        let e00_10 = p10 - p00;
+        let e00_01 = p01 - p00;
+        let e01_11 = p11 - p01;
+        let e10_11 = p11 - p10;
+        let cross_edges = e01_11 - e00_10;
+        let bounding_box = Aabb::from_points(&[p00, p10, p01, p11]).pad(0.0001);
+
+        // two-triangle proxy for surface area, sampling, and PDF
+        let tri1 = Arc::new(Triangle::new(p00, p10, p11, false, Arc::clone(&material)));
+        let tri2 = Arc::new(Triangle::new(p00, p11, p01, false, Arc::clone(&material)));
+        let proxy_triangles_list = List::from_vec(vec![tri1, tri2]);
+
+        Self {
+            p00,
+            p10,
+            p01,
+            p11,
+            material,
+            e00_10,
+            e00_01,
+            e01_11,
+            e10_11,
+            cross_edges,
+            bounding_box,
+            proxy_triangles_list,
+        }
+    }
+
+    fn point_at(&self, u: f64, v: f64) -> Point {
+        let w00 = (1.0 - u) * (1.0 - v);
+        let w10 = u * (1.0 - v);
+        let w01 = (1.0 - u) * v;
+        let w11 = u * v;
+        Point::new(
+            w00 * self.p00[0] + w10 * self.p10[0] + w01 * self.p01[0] + w11 * self.p11[0],
+            w00 * self.p00[1] + w10 * self.p10[1] + w01 * self.p01[1] + w11 * self.p11[1],
+            w00 * self.p00[2] + w10 * self.p10[2] + w01 * self.p01[2] + w11 * self.p11[2],
+        )
+    }
+}
+
+impl Geometric for BilinearPatch {
+    fn is_emissive(&self) -> bool {
+        self.material.is_emissive()
+    }
+
+    fn is_transmissive(&self) -> bool {
+        self.material.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.material.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.proxy_triangles_list.surface_area() <= 0.0
+    }
+
+    fn surface_area(&self) -> f64 {
+        self.proxy_triangles_list.surface_area()
+    }
+
+    fn bounding_box(&self) -> Aabb {
+        self.bounding_box
+    }
+
+    // GARP (Griffin-Alexa-Rusu-Preda) intersection algorithm for bilinear patches.
+    // solves a quadratic to find ruling-line parameter u where the ray is
+    // coplanar with a bilinear ruling, then intersects the ray with that
+    // ruling line to compute the v parameter.
+    fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
+        let origin_offset = ray.origin - self.p00;
+
+        // helper: scalar triple product (D × a) · b = D · (a × b)
+        let stp = |a: Vector3, b: Vector3| -> f64 { ray.direction.dot(a.cross(b)) };
+
+        // GARP quadratic coefficients for u
+        let a = -stp(self.cross_edges, self.e00_10);
+        let b = stp(self.cross_edges, origin_offset) - stp(self.e00_01, self.e00_10);
+        let c = stp(self.e00_01, origin_offset);
+
+        let mut closest_hit: Option<RayHit> = None;
+        let mut closest_t = ray_t.maximum;
+
+        let u_candidates = crate::utils::solve_quadratic(a, b, c);
+        for u in u_candidates {
+            if !(0.0..=1.0).contains(&u) {
+                continue;
+            }
+
+            // build the ruling line endpoints A(u) and B(u)
+            let a_point = self.p00 + u * self.e00_10;
+            let b_point = self.p01 + u * self.e01_11;
+            let ruling = b_point - a_point;
+
+            // intersect ray with the ruling line
+            let d_cross_r = ray.direction.cross(ruling);
+            let denom = d_cross_r.dot(d_cross_r);
+            if denom < 1e-20 {
+                continue; // ray parallel to ruling
+            }
+
+            let offset = a_point - ray.origin;
+
+            let t = offset.cross(ruling).dot(d_cross_r) / denom;
+            let v = offset.cross(ray.direction).dot(d_cross_r) / denom;
+
+            if !(0.0..=1.0).contains(&v) {
+                continue;
+            }
+            if !ray_t.contains_excluding(t) {
+                continue;
+            }
+            if t >= closest_t {
+                continue;
+            }
+
+            // compute normal from partial derivatives at (u, v)
+            let dp_du = (1.0 - v) * self.e00_10 + v * self.e01_11;
+            let dp_dv = (1.0 - u) * self.e00_01 + u * self.e10_11;
+            let mut normal = dp_du.cross(dp_dv).unit_vector();
+
+            // always face the incoming ray (always double-sided)
+            let dot_ray_normal = ray.direction.dot(normal);
+            if dot_ray_normal > 0.0 {
+                normal = -normal;
+            }
+
+            // evaluate hit point via the bilinear function for numerical consistency
+            let point = self.point_at(u, v);
+
+            closest_hit = Some(RayHit {
+                t,
+                point,
+                normal,
+                material: Arc::clone(&self.material),
+                u,
+                v,
+            });
+            closest_t = t;
+        }
+
+        closest_hit
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
+        self.proxy_triangles_list.sample_direction_from(origin)
+    }
+
+    fn direction_pdf(&self, origin: Point, direction: Vector3) -> f64 {
+        self.proxy_triangles_list.direction_pdf(origin, direction)
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,3 +21,6 @@ pub use time::*;
 
 mod units;
 pub use units::*;
+
+mod quadratic;
+pub use quadratic::{solve_quadratic, QuadraticRoots, QuadraticRootsIter};

--- a/src/utils/quadratic.rs
+++ b/src/utils/quadratic.rs
@@ -1,0 +1,173 @@
+#[derive(Clone, Copy, Debug)]
+pub enum QuadraticRoots {
+    None,
+    One(f64),
+    Two(f64, f64),
+}
+
+/// Returns 0, 1, or 2 real roots of ax² + bx + c = 0,
+/// using a cancellation-safe formulation.
+/// Roots are returned in ascending order in the first `usize` entries.
+pub fn solve_quadratic(a: f64, b: f64, c: f64) -> QuadraticRoots {
+    // linear case
+    if a.abs() < 1e-12 {
+        if b.abs() < 1e-12 {
+            return QuadraticRoots::None;
+        }
+        return QuadraticRoots::One(-c / b);
+    }
+
+    let discriminant = b * b - 4.0 * a * c;
+
+    if discriminant < 0.0 {
+        return QuadraticRoots::None;
+    }
+
+    if discriminant == 0.0 {
+        let root = -0.5 * b / a;
+        return QuadraticRoots::One(root);
+    }
+
+    let sqrt_disc = discriminant.sqrt();
+
+    // cancellation-safe computation of q
+    let q = if b >= 0.0 {
+        -0.5 * (b + sqrt_disc)
+    } else {
+        -0.5 * (b - sqrt_disc)
+    };
+
+    let t0 = q / a;
+    let t1 = c / q;
+
+    if t0 < t1 {
+        QuadraticRoots::Two(t0, t1)
+    } else {
+        QuadraticRoots::Two(t1, t0)
+    }
+}
+
+// iterator for for-loop ergonomics: `for u in solve_quadratic(a, b, c) { ... }`
+pub struct QuadraticRootsIter {
+    roots: QuadraticRoots,
+    index: u8,
+}
+
+impl Iterator for QuadraticRootsIter {
+    type Item = f64;
+
+    fn next(&mut self) -> Option<f64> {
+        match (&self.roots, self.index) {
+            (QuadraticRoots::One(t), 0) => {
+                self.index = 1;
+                Some(*t)
+            }
+            (QuadraticRoots::Two(t0, _), 0) => {
+                self.index = 1;
+                Some(*t0)
+            }
+            (QuadraticRoots::Two(_, t1), 1) => {
+                self.index = 2;
+                Some(*t1)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl IntoIterator for QuadraticRoots {
+    type Item = f64;
+    type IntoIter = QuadraticRootsIter;
+
+    fn into_iter(self) -> QuadraticRootsIter {
+        QuadraticRootsIter {
+            roots: self,
+            index: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_distinct_real_roots() {
+        let roots = solve_quadratic(1.0, 3.0, 2.0);
+        assert!(matches!(roots, QuadraticRoots::Two(..)));
+        if let QuadraticRoots::Two(t0, t1) = roots {
+            assert!((t0 + 2.0).abs() < 1e-12);
+            assert!((t1 + 1.0).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn one_double_root() {
+        let roots = solve_quadratic(1.0, 2.0, 1.0);
+        assert!(matches!(roots, QuadraticRoots::One(..)));
+        if let QuadraticRoots::One(t0) = roots {
+            assert!((t0 + 1.0).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn no_real_roots() {
+        let roots = solve_quadratic(1.0, 0.0, 1.0);
+        assert!(matches!(roots, QuadraticRoots::None));
+    }
+
+    #[test]
+    fn linear_case() {
+        let roots = solve_quadratic(0.0, 2.0, -4.0);
+        assert!(matches!(roots, QuadraticRoots::One(..)));
+        if let QuadraticRoots::One(t0) = roots {
+            assert!((t0 - 2.0).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn cancellation_case() {
+        let roots = solve_quadratic(1.0, 1_000_000.0, 1.0);
+        assert!(matches!(roots, QuadraticRoots::Two(..)));
+        if let QuadraticRoots::Two(t0, t1) = roots {
+            // roots should be approximately -1e6 and approximately -1e-6
+            assert!(t0 < -1e5 && t0 > -2e6);
+            assert!(t1 < -1e-7 && t1 > -1e-5);
+            // verify they satisfy the quadratic within reasonable tolerance
+            let eval_at_t0 = 1.0 * t0 * t0 + 1_000_000.0 * t0 + 1.0;
+            let eval_at_t1 = 1.0 * t1 * t1 + 1_000_000.0 * t1 + 1.0;
+            assert!(eval_at_t0.abs() < 1e-6);
+            assert!(eval_at_t1.abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn discriminant_exactly_zero() {
+        let roots = solve_quadratic(1.0, 2.0, 1.0);
+        assert!(matches!(roots, QuadraticRoots::One(..)));
+        if let QuadraticRoots::One(t0) = roots {
+            assert!((t0 + 1.0).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn negative_discriminant() {
+        let roots = solve_quadratic(1.0, 1.0, 2.0);
+        assert!(matches!(roots, QuadraticRoots::None));
+    }
+
+    #[test]
+    fn near_linear() {
+        let roots = solve_quadratic(1e-13, 2.0, -4.0);
+        assert!(matches!(roots, QuadraticRoots::One(..)));
+        if let QuadraticRoots::One(t0) = roots {
+            assert!((t0 - 2.0).abs() < 1e-10);
+        }
+    }
+
+    #[test]
+    fn near_constant() {
+        let roots = solve_quadratic(1e-13, 1e-13, 5.0);
+        assert!(matches!(roots, QuadraticRoots::None));
+    }
+}

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -51,6 +51,8 @@ export function normalizeGeometricData(
       return normalizeGeometricVirtual(config, name, geometricData);
     case 'disk':
       return normalizeGeometricDisk(config, name, geometricData);
+    case 'bilinear_patch':
+      return normalizeGeometricBilinearPatch(config, name, geometricData);
   }
 }
 
@@ -66,7 +68,8 @@ export type NormalizedGeometricData =
   | NormalizedGeometricTriangle
   | NormalizedGeometricConstantVolume
   | NormalizedGeometricVirtual
-  | NormalizedGeometricDisk;
+  | NormalizedGeometricDisk
+  | NormalizedGeometricBilinearPatch;
 
 export type RawGeometricData =
   | RawGeometricBox
@@ -80,7 +83,8 @@ export type RawGeometricData =
   | RawGeometricTriangle
   | RawGeometricConstantVolume
   | RawGeometricVirtual
-  | RawGeometricDisk;
+  | RawGeometricDisk
+  | RawGeometricBilinearPatch;
 
 export function isGeometricData(data: unknown): data is GeometricData {
   return (
@@ -98,6 +102,7 @@ export function isGeometricData(data: unknown): data is GeometricData {
       'sphere',
       'triangle',
       'disk',
+      'bilinear_patch',
       'constant_volume',
       'virtual',
     ].includes(data.type)
@@ -126,6 +131,7 @@ export function getReferencedMaterialNames(
   switch (data.type) {
     case 'box':
     case 'disk':
+    case 'bilinear_patch':
     case 'obj_model':
     case 'parallelogram':
     case 'plane':
@@ -278,6 +284,12 @@ export function getCenterPoint(
       ];
     case 'disk':
       return data.center;
+    case 'bilinear_patch':
+      return [
+        (data.p00[0] + data.p10[0] + data.p01[0] + data.p11[0]) / 4,
+        (data.p00[1] + data.p10[1] + data.p01[1] + data.p11[1]) / 4,
+        (data.p00[2] + data.p10[2] + data.p01[2] + data.p11[2]) / 4,
+      ];
   }
 }
 
@@ -395,9 +407,9 @@ export function defaultGeometricForType(
     case 'parallelogram':
       return {
         type: 'parallelogram',
-        lower_left: [0, 0, 0],
-        u: [0, 0, 0],
-        v: [0, 0, 0],
+        lower_left: [-0.5, -0.5, 0],
+        u: [1, 0, 0],
+        v: [0, 1, 0],
         material: '__lambertian_white',
       };
     case 'plane':
@@ -417,9 +429,9 @@ export function defaultGeometricForType(
     case 'triangle':
       return {
         type: 'triangle',
-        a: [0, 0, 0],
-        b: [0, 0, 0],
-        c: [0, 0, 0],
+        a: [-0.5, -0.5, 0],
+        b: [0.5, -0.5, 0],
+        c: [0, 0.5, 0],
         material: '__lambertian_white',
       };
     case 'constant_volume':
@@ -442,6 +454,15 @@ export function defaultGeometricForType(
         radius: 1,
         inner_radius: 0,
         is_culled: false,
+        material: '__lambertian_white',
+      };
+    case 'bilinear_patch':
+      return {
+        type: 'bilinear_patch',
+        p00: [-0.5, 0, -0.5],
+        p10: [0.5, 0, -0.5],
+        p01: [-0.5, 0, 0.5],
+        p11: [0.5, 0, 0.5],
         material: '__lambertian_white',
       };
   }
@@ -1060,6 +1081,54 @@ export type RawGeometricDisk = {
   material: string | RawMaterialData;
 };
 
+export const GeometricBilinearPatchSchema = z.object({
+  type: z.literal('bilinear_patch'),
+  p00: z.tuple([z.number(), z.number(), z.number()]),
+  p10: z.tuple([z.number(), z.number(), z.number()]),
+  p01: z.tuple([z.number(), z.number(), z.number()]),
+  p11: z.tuple([z.number(), z.number(), z.number()]),
+  material: z.string().nonempty(),
+});
+
+export type GeometricBilinearPatch = NormalizedGeometricBilinearPatch;
+
+export function normalizeGeometricBilinearPatch(
+  config: RenderConfig,
+  name: string,
+  geometricData: RawGeometricBilinearPatch,
+): NormalizedGeometricBilinearPatch {
+  const geometric = geometricData;
+
+  if (typeof geometric.material !== 'string') {
+    if (!config.materials) {
+      config.materials = {};
+    }
+
+    const materialName = getNextUniqueName(config.materials, `${name}_${geometric.material.type}`);
+    config.materials[materialName] = normalizeMaterialData(
+      config,
+      materialName,
+      geometric.material,
+    );
+    geometric.material = materialName;
+  }
+
+  return geometric as NormalizedGeometricBilinearPatch;
+}
+
+export type NormalizedGeometricBilinearPatch = Omit<RawGeometricBilinearPatch, 'material'> & {
+  material: string;
+};
+
+export type RawGeometricBilinearPatch = {
+  type: 'bilinear_patch';
+  p00: [number, number, number];
+  p10: [number, number, number];
+  p01: [number, number, number];
+  p11: [number, number, number];
+  material: string | RawMaterialData;
+};
+
 const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   box: GeometricBoxSchema,
   list: GeometricListSchema,
@@ -1075,6 +1144,7 @@ const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   triangle: GeometricTriangleSchema,
   constant_volume: GeometricConstantVolumeSchema,
   virtual: GeometricVirtualSchema,
+  bilinear_patch: GeometricBilinearPatchSchema,
 };
 
 export const GeometricDataSchema = z.any().superRefine((data, ctx) => {
@@ -1115,6 +1185,7 @@ export function wrapGeometric(
 
   const typeLabels: Record<string, string> = {
     box: 'Box',
+    bilinear_patch: 'Bilinear Patch',
     sphere: 'Sphere',
     triangle: 'Triangle',
     parallelogram: 'Parallelogram',

--- a/ui/src/views/renders/new/Controls/index.tsx
+++ b/ui/src/views/renders/new/Controls/index.tsx
@@ -93,6 +93,12 @@ export function Controls(props: ControlsProps) {
                   description: 'Flat disc defined by center, normal, and radius.',
                 },
                 {
+                  subtype: 'bilinear_patch',
+                  label: 'Bilinear Patch',
+                  description:
+                    'Doubly-ruled curved surface defined by four corner points - a hyperbolic paraboloid.',
+                },
+                {
                   subtype: 'list',
                   label: 'List',
                   description: 'A group of geometrics rendered together.',

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -203,6 +203,40 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <GeometricMaterialSelect form={form} name={name} items={materialItems} />
         </>
       );
+    case 'bilinear_patch':
+      return (
+        <>
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.p00`}
+            label="P00 (corner 0,0)"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.p10`}
+            label="P10 (corner 1,0)"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.p01`}
+            label="P01 (corner 0,1)"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.p11`}
+            label="P11 (corner 1,1)"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+        </>
+      );
     case 'rotate_x':
     case 'rotate_y':
     case 'rotate_z': {

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -301,6 +301,101 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       );
     }
 
+    case 'bilinear_patch': {
+      const emissiveInfo = getEmissiveInfo(config, data.material);
+
+      // build subdivided bilinear patch mesh (8x8 grid)
+      const divs = 8;
+      const positions: number[] = [];
+      const normals: number[] = [];
+      const indices: number[] = [];
+
+      // helper: evaluate bilinear patch P(u,v)
+      const evalPatch = (u: number, v: number): [number, number, number] => {
+        const w00 = (1 - u) * (1 - v);
+        const w10 = u * (1 - v);
+        const w01 = (1 - u) * v;
+        const w11 = u * v;
+        return [
+          w00 * data.p00[0] + w10 * data.p10[0] + w01 * data.p01[0] + w11 * data.p11[0],
+          w00 * data.p00[1] + w10 * data.p10[1] + w01 * data.p01[1] + w11 * data.p11[1],
+          w00 * data.p00[2] + w10 * data.p10[2] + w01 * data.p01[2] + w11 * data.p11[2],
+        ];
+      };
+
+      // generate vertices and normals (divs+1 x divs+1 grid)
+      for (let j = 0; j <= divs; j++) {
+        const v = j / divs;
+        for (let i = 0; i <= divs; i++) {
+          const u = i / divs;
+          positions.push(...evalPatch(u, v));
+
+          // compute normal from partial derivatives
+          const eps = 0.001;
+          const du_u = Math.min(u + eps, 1.0);
+          const dv_v = Math.min(v + eps, 1.0);
+          const du = evalPatch(du_u, v);
+          const dv = evalPatch(u, dv_v);
+          const p = [
+            positions[positions.length - 3],
+            positions[positions.length - 2],
+            positions[positions.length - 1],
+          ];
+
+          const dp_du = [du[0] - p[0], du[1] - p[1], du[2] - p[2]];
+          const dp_dv = [dv[0] - p[0], dv[1] - p[1], dv[2] - p[2]];
+
+          // cross product dp_du x dp_dv
+          const nx = dp_du[1] * dp_dv[2] - dp_du[2] * dp_dv[1];
+          const ny = dp_du[2] * dp_dv[0] - dp_du[0] * dp_dv[2];
+          const nz = dp_du[0] * dp_dv[1] - dp_du[1] * dp_dv[0];
+          const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
+          normals.push(nx / len, ny / len, nz / len);
+        }
+      }
+
+      // generate triangle indices (two per grid cell)
+      for (let j = 0; j < divs; j++) {
+        for (let i = 0; i < divs; i++) {
+          const a = j * (divs + 1) + i;
+          const b = a + 1;
+          const c = a + (divs + 1);
+          const d = c + 1;
+          indices.push(a, b, d);
+          indices.push(a, d, c);
+        }
+      }
+
+      return (
+        <>
+          <mesh rotation={rotation} castShadow={!emissiveInfo} receiveShadow>
+            <bufferGeometry>
+              <bufferAttribute
+                attach="attributes-position"
+                args={[new Float32Array(positions), 3]}
+              />
+              <bufferAttribute attach="attributes-normal" args={[new Float32Array(normals), 3]} />
+              <bufferAttribute attach="index" args={[new Uint16Array(indices), 1]} />
+            </bufferGeometry>
+            <MaterialResolver
+              config={config}
+              materialName={data.material}
+              side={THREE.DoubleSide}
+              shadowSide={THREE.BackSide}
+            />
+          </mesh>
+          {emissiveInfo && (
+            <pointLight
+              color={emissiveInfo.color}
+              intensity={emissiveInfo.intensity}
+              position={getCenterPoint(config, data)}
+              castShadow
+            />
+          )}
+        </>
+      );
+    }
+
     case 'obj_model':
     case 'constant_volume':
       // todo: not yet implemented


### PR DESCRIPTION
Closes #182

## Summary

Adds a bilinear patch geometric primitive — a doubly-ruled curved surface interpolating four corner points. Uses the GARP intersection algorithm (Reshetov 2019), which is faster than approximating with two triangles while representing curvature exactly.

## Changes

### Backend (Rust)
- **`src/utils/quadratic.rs`** — Cancellation-safe `solve_quadratic` utility with 9 tests, `QuadraticRoots` enum, and `IntoIterator` impl
- **`src/geometry/primitives/bilinear_patch.rs`** — `BilinearPatch` struct implementing the `Geometric` trait:
  - GARP intersection: solves quadratic for ruling parameter `u`, intersects ray with ruling to find `v`
  - Coplanar (flat) case handled by linear fallback when `a ≈ 0`
  - Native `(u,v)` texture coordinates from bilinear parameterization
  - Normal from partial derivatives at hit point
  - Two-triangle proxy via `List` for surface area, sampling, and PDF (perfectly consistent)
  - Always double-sided
- **`src/deserialization/geometrics.rs`** — `PrimitiveBilinearPatch` variant: `p00`, `p10`, `p01`, `p11`, `material`
- **`src/utils.rs`**, **`src/geometry/primitives.rs`** — Module declarations and re-exports
- **`src/deserialization.rs`** — Exhaustive match coverage

### Frontend (TypeScript/React)
- **`ui/src/utils/render/geometric.ts`** — Type, Zod schema, normalization, visible default (unit square in XZ plane), center point, material references
- **`GeometricFormControls/index.tsx`** — Four corner point controls + material select
- **`GeometricRenderer.tsx`** — 8×8 subdivided mesh with per-vertex normals, double-sided material
- **`Controls/index.tsx`** — Added to geometric type picker dropdown
- Fixed degenerate defaults for `triangle` and `parallelogram` to use visible, non-degenerate shapes

## Design Decisions
| Decision | Rationale |
|---|---|
| Always double-sided | Simpler surface model, matching issue spec |
| Hit point via bilinear function | Better numerical consistency than `O + tD` |
| `List` proxy for sampling/PDF | Reuses existing compound, eliminates duplicated Möller-Trumbore, guarantees sampling consistency |
| `QuadraticRoots` as iterable enum | Zero-allocation `for u in solve_quadratic(...)` ergonomics |