### PR TITLE
Add non-uniform Scale transform instance (→ Ellipsoid for free)

### DIFF
--- a/migrations/20260705194312_prevent_render_id_reuse.up.sql
+++ b/migrations/20260705194312_prevent_render_id_reuse.up.sql
@@ -6,7 +6,7 @@ ALTER TABLE renders ADD COLUMN deleted_at TIMESTAMPTZ;
 -- Create sequence for auto-increment IDs that never reuse old IDs
 -- Start after the current max ID to avoid conflicts with existing rows
 CREATE SEQUENCE renders_id_seq;
-SELECT setval('renders_id_seq', COALESCE((SELECT MAX(id) FROM renders), 0));
+SELECT setval('renders_id_seq', COALESCE((SELECT MAX(id) FROM renders), 1));
 
 -- Update the render_states view to exclude soft-deleted renders
 CREATE OR REPLACE VIEW render_states AS

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -218,6 +218,7 @@ fn get_geometric_dependencies(geometric: &GeometricData) -> Vec<String> {
         GeometricData::InstanceRotateXAxis { geometric, .. }
         | GeometricData::InstanceRotateYAxis { geometric, .. }
         | GeometricData::InstanceRotateZAxis { geometric, .. }
+        | GeometricData::InstanceScale { geometric, .. }
         | GeometricData::InstanceTranslate { geometric, .. }
         | GeometricData::VolumeConstant { geometric, .. }
         | GeometricData::Virtual { geometric, .. } => match geometric {

--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -89,6 +89,7 @@ pub enum GeometricData {
     InstanceScale {
         geometric: GeometricRefOrInline,
         scale: [f64; 3],
+        around: Around,
     },
     #[serde(rename = "translate")]
     InstanceTranslate {
@@ -253,10 +254,11 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
             Self::InstanceScale {
                 geometric: geometric_ref,
                 scale,
+                around,
             } => {
                 let geometric = geometric_ref.build(builts)?;
 
-                Ok(Arc::new(Scale::new(geometric, (*scale).into())?))
+                Ok(Arc::new(Scale::new(geometric, (*scale).into(), *around)?))
             }
             Self::InstanceTranslate {
                 geometric: geometric_ref,

--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -6,7 +6,7 @@ use crate::{
     geometry::{
         Geometric, Vector3,
         compounds::{AxisAlignedPBox, Bvh, List, ModelObj, Virtual},
-        instances::{RotateXAxis, RotateYAxis, RotateZAxis, Translate},
+        instances::{RotateXAxis, RotateYAxis, RotateZAxis, Scale, Translate},
         primitives::{BilinearPatch, Disk, Parallelogram, Plane, Sphere, Triangle},
         volumes,
     },
@@ -84,6 +84,11 @@ pub enum GeometricData {
         #[serde(flatten)]
         angle: Angle,
         around: Around,
+    },
+    #[serde(rename = "scale")]
+    InstanceScale {
+        geometric: GeometricRefOrInline,
+        scale: [f64; 3],
     },
     #[serde(rename = "translate")]
     InstanceTranslate {
@@ -244,6 +249,14 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
                 let geometric = geometric_ref.build(builts)?;
 
                 Ok(Arc::new(RotateZAxis::new(geometric, *angle, *around)))
+            }
+            Self::InstanceScale {
+                geometric: geometric_ref,
+                scale,
+            } => {
+                let geometric = geometric_ref.build(builts)?;
+
+                Ok(Arc::new(Scale::new(geometric, (*scale).into())?))
             }
             Self::InstanceTranslate {
                 geometric: geometric_ref,

--- a/src/geometry/instances.rs
+++ b/src/geometry/instances.rs
@@ -9,3 +9,6 @@ pub use rotate_z_axis::RotateZAxis;
 
 mod translate;
 pub use translate::Translate;
+
+mod scale;
+pub use scale::Scale;

--- a/src/geometry/instances/scale.rs
+++ b/src/geometry/instances/scale.rs
@@ -1,0 +1,126 @@
+/// A non-uniform scale transform instance.
+///
+/// Scales a geometric object by a non-uniform scale factor along each axis.
+/// Transforms rays to local (unscaled) space for intersection, then maps
+/// hit points and normals back to world space.
+use std::sync::Arc;
+
+use crate::{
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
+    utils::Interval,
+};
+
+#[derive(Clone, Debug)]
+pub struct Scale {
+    geometric: Arc<dyn Geometric>,
+    scale: Vector3,
+    inv_scale: Vector3,
+    bounding_box: Aabb,
+}
+
+impl Scale {
+    pub fn new(geometric: Arc<dyn Geometric>, scale: Vector3) -> Result<Self, String> {
+        if scale.x == 0.0 || scale.y == 0.0 || scale.z == 0.0 {
+            return Err("scale factors must be non-zero in all axes".to_string());
+        }
+
+        let inv_scale = Vector3::new(1.0 / scale.x, 1.0 / scale.y, 1.0 / scale.z);
+
+        let bbox = geometric.bounding_box();
+        let mut min_extent = Point::INFINITY;
+        let mut max_extent = -Point::INFINITY;
+
+        for i in 0..2 {
+            for j in 0..2 {
+                for k in 0..2 {
+                    let x = i as f64 * bbox.x_interval.maximum
+                        + (1 - i) as f64 * bbox.x_interval.minimum;
+                    let y = j as f64 * bbox.y_interval.maximum
+                        + (1 - j) as f64 * bbox.y_interval.minimum;
+                    let z = k as f64 * bbox.z_interval.maximum
+                        + (1 - k) as f64 * bbox.z_interval.minimum;
+
+                    let corner = Point::new(x, y, z);
+                    let scaled_corner = Point::from_vector3(corner.0 * scale);
+
+                    min_extent = min_extent.min_components_point(scaled_corner);
+                    max_extent = max_extent.max_components_point(scaled_corner);
+                }
+            }
+        }
+
+        Ok(Self {
+            geometric: Arc::clone(&geometric),
+            scale,
+            inv_scale,
+            bounding_box: Aabb::from_points(&[min_extent, max_extent]),
+        })
+    }
+}
+
+impl Geometric for Scale {
+    fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
+        // transform ray from world space to local (unscaled) space
+        let local_origin = Point::from_vector3(ray.origin.0 / self.scale);
+        let local_direction = ray.direction / self.scale;
+        let local_ray = Ray::new(local_origin, local_direction, ray.time);
+
+        self.geometric.intersect(local_ray, ray_t).map(|mut rh| {
+            // transform hit point to world space
+            rh.point.0 *= self.scale;
+            // transform normal via inverse-transpose
+            rh.normal = (rh.normal * self.inv_scale).unit_vector();
+            rh
+        })
+    }
+
+    fn surface_area(&self) -> f64 {
+        let sx = self.scale.x.abs();
+        let sy = self.scale.y.abs();
+        let sz = self.scale.z.abs();
+        self.geometric.surface_area() * (sy * sz + sx * sz + sx * sy) / 3.0
+    }
+
+    fn is_emissive(&self) -> bool {
+        self.geometric.is_emissive()
+    }
+
+    fn is_transmissive(&self) -> bool {
+        self.geometric.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.geometric.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.geometric.is_empty()
+    }
+
+    fn bounding_box(&self) -> Aabb {
+        self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
+        let local_origin = Point::from_vector3(origin.0 / self.scale);
+        let local_dir = self.geometric.sample_direction_from(local_origin);
+        (local_dir * self.scale).unit_vector()
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
+        let local_origin = Point::from_vector3(origin.0 / self.scale);
+        let local_dir = (dir / self.scale).unit_vector();
+
+        let p_local = self.geometric.direction_pdf(local_origin, local_dir);
+
+        // solid-angle Jacobian for the direction map ω → normalize(scale * ω):
+        // p_world = p_local / |J|  where  |J| = |det(S)| / |S·ω_local|³
+        let a_sq = self.scale.x * self.scale.x * local_dir.x * local_dir.x
+            + self.scale.y * self.scale.y * local_dir.y * local_dir.y
+            + self.scale.z * self.scale.z * local_dir.z * local_dir.z;
+        let det = self.scale.x.abs() * self.scale.y.abs() * self.scale.z.abs();
+        let jacobian = det / (a_sq * a_sq.sqrt());
+
+        p_local / jacobian
+    }
+}

--- a/src/geometry/instances/scale.rs
+++ b/src/geometry/instances/scale.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
+    geometry::{
+        Aabb, Geometric, Point, Ray, RayHit, Vector3,
+        instances::Translate,
+    },
     utils::{Around, Interval},
 };
 
@@ -51,8 +54,17 @@ impl Scale {
             }
         }
 
+        // Wrap the inner geometric in a Translate so its pivot appears at origin.
+        // Without this, the inner's world-space coordinates would disagree with
+        // the pivot-centered local coordinate system used in intersect/sampling.
+        let shifted = if translation.x != 0.0 || translation.y != 0.0 || translation.z != 0.0 {
+            Arc::new(Translate::new(Arc::clone(&geometric), -translation)) as Arc<dyn Geometric>
+        } else {
+            Arc::clone(&geometric) as Arc<dyn Geometric>
+        };
+
         Ok(Self {
-            geometric: Arc::clone(&geometric),
+            geometric: shifted,
             translation,
             scale,
             inv_scale,
@@ -63,8 +75,9 @@ impl Scale {
 
 impl Geometric for Scale {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
-        // transform ray from world space to local (unscaled) space
-        let local_origin = Point::from_vector3((ray.origin.0 - self.translation) / self.scale);
+        // transform ray from world space to local (unscaled) space.
+        // the inner Translate wrapper already handles the pivot shift.
+        let local_origin = Point::from_vector3(ray.origin.0 / self.scale);
         let local_direction = ray.direction / self.scale;
         let local_ray = Ray::new(local_origin, local_direction, ray.time);
 
@@ -105,13 +118,13 @@ impl Geometric for Scale {
     }
 
     fn sample_direction_from(&self, origin: Point) -> Vector3 {
-        let local_origin = Point::from_vector3((origin.0 - self.translation) / self.scale);
+        let local_origin = Point::from_vector3(origin.0 / self.scale);
         let local_dir = self.geometric.sample_direction_from(local_origin);
         (local_dir * self.scale).unit_vector()
     }
 
     fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
-        let local_origin = Point::from_vector3((origin.0 - self.translation) / self.scale);
+        let local_origin = Point::from_vector3(origin.0 / self.scale);
         let local_dir = (dir / self.scale).unit_vector();
 
         let p_local = self.geometric.direction_pdf(local_origin, local_dir);

--- a/src/geometry/instances/scale.rs
+++ b/src/geometry/instances/scale.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{
-        Aabb, Geometric, Point, Ray, RayHit, Vector3,
-        instances::Translate,
-    },
+    geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
     utils::{Around, Interval},
 };
 
@@ -54,37 +51,32 @@ impl Scale {
             }
         }
 
-        // Wrap the inner geometric in a Translate so its pivot appears at origin.
-        // Without this, the inner's world-space coordinates would disagree with
-        // the pivot-centered local coordinate system used in intersect/sampling.
-        let shifted = if translation.x != 0.0 || translation.y != 0.0 || translation.z != 0.0 {
-            Arc::new(Translate::new(Arc::clone(&geometric), -translation)) as Arc<dyn Geometric>
-        } else {
-            Arc::clone(&geometric) as Arc<dyn Geometric>
-        };
+        let bbox_final = Aabb::from_points(&[min_extent, max_extent]) + translation;
 
         Ok(Self {
-            geometric: shifted,
+            geometric: Arc::clone(&geometric),
             translation,
             scale,
             inv_scale,
-            bounding_box: Aabb::from_points(&[min_extent, max_extent]) + translation,
+            bounding_box: bbox_final,
         })
     }
 }
 
 impl Geometric for Scale {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
-        // transform ray from world space to local (unscaled) space.
-        // the inner Translate wrapper already handles the pivot shift.
-        let local_origin = Point::from_vector3(ray.origin.0 / self.scale);
+        // transform ray to pivot-centered scaled local space.
+        // matches RotateYAxis pattern: subtract pivot, apply transform, add pivot back.
+        let local_origin =
+            Point::from_vector3((ray.origin.0 - self.translation) / self.scale + self.translation);
         let local_direction = ray.direction / self.scale;
         let local_ray = Ray::new(local_origin, local_direction, ray.time);
 
-        self.geometric.intersect(local_ray, ray_t).map(|mut rh| {
-            // transform hit point to world space
-            rh.point.0 = rh.point.0 * self.scale + self.translation;
-            // transform normal via inverse-transpose
+        let hit = self.geometric.intersect(local_ray, ray_t);
+        hit.map(|mut rh| {
+            // transform hit back: subtract pivot, scale, add pivot
+            rh.point.0 = (rh.point.0 - self.translation) * self.scale + self.translation;
+            // transform normal via inverse-transpose (translation invariant)
             rh.normal = (rh.normal * self.inv_scale).unit_vector();
             rh
         })
@@ -118,13 +110,15 @@ impl Geometric for Scale {
     }
 
     fn sample_direction_from(&self, origin: Point) -> Vector3 {
-        let local_origin = Point::from_vector3(origin.0 / self.scale);
+        let local_origin =
+            Point::from_vector3((origin.0 - self.translation) / self.scale + self.translation);
         let local_dir = self.geometric.sample_direction_from(local_origin);
         (local_dir * self.scale).unit_vector()
     }
 
     fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
-        let local_origin = Point::from_vector3(origin.0 / self.scale);
+        let local_origin =
+            Point::from_vector3((origin.0 - self.translation) / self.scale + self.translation);
         let local_dir = (dir / self.scale).unit_vector();
 
         let p_local = self.geometric.direction_pdf(local_origin, local_dir);

--- a/src/geometry/instances/scale.rs
+++ b/src/geometry/instances/scale.rs
@@ -1,44 +1,46 @@
-/// A non-uniform scale transform instance.
-///
-/// Scales a geometric object by a non-uniform scale factor along each axis.
-/// Transforms rays to local (unscaled) space for intersection, then maps
-/// hit points and normals back to world space.
 use std::sync::Arc;
 
 use crate::{
     geometry::{Aabb, Geometric, Point, Ray, RayHit, Vector3},
-    utils::Interval,
+    utils::{Around, Interval},
 };
 
 #[derive(Clone, Debug)]
 pub struct Scale {
     geometric: Arc<dyn Geometric>,
+    translation: Vector3,
     scale: Vector3,
     inv_scale: Vector3,
     bounding_box: Aabb,
 }
 
 impl Scale {
-    pub fn new(geometric: Arc<dyn Geometric>, scale: Vector3) -> Result<Self, String> {
+    pub fn new(
+        geometric: Arc<dyn Geometric>,
+        scale: Vector3,
+        around: Around,
+    ) -> Result<Self, String> {
         if scale.x == 0.0 || scale.y == 0.0 || scale.z == 0.0 {
             return Err("scale factors must be non-zero in all axes".to_string());
         }
 
         let inv_scale = Vector3::new(1.0 / scale.x, 1.0 / scale.y, 1.0 / scale.z);
+        let translation = around.point(&geometric).0;
 
-        let bbox = geometric.bounding_box();
+        let geometric_bbox = geometric.bounding_box() - translation;
+
         let mut min_extent = Point::INFINITY;
         let mut max_extent = -Point::INFINITY;
 
         for i in 0..2 {
             for j in 0..2 {
                 for k in 0..2 {
-                    let x = i as f64 * bbox.x_interval.maximum
-                        + (1 - i) as f64 * bbox.x_interval.minimum;
-                    let y = j as f64 * bbox.y_interval.maximum
-                        + (1 - j) as f64 * bbox.y_interval.minimum;
-                    let z = k as f64 * bbox.z_interval.maximum
-                        + (1 - k) as f64 * bbox.z_interval.minimum;
+                    let x = i as f64 * geometric_bbox.x_interval.maximum
+                        + (1 - i) as f64 * geometric_bbox.x_interval.minimum;
+                    let y = j as f64 * geometric_bbox.y_interval.maximum
+                        + (1 - j) as f64 * geometric_bbox.y_interval.minimum;
+                    let z = k as f64 * geometric_bbox.z_interval.maximum
+                        + (1 - k) as f64 * geometric_bbox.z_interval.minimum;
 
                     let corner = Point::new(x, y, z);
                     let scaled_corner = Point::from_vector3(corner.0 * scale);
@@ -51,9 +53,10 @@ impl Scale {
 
         Ok(Self {
             geometric: Arc::clone(&geometric),
+            translation,
             scale,
             inv_scale,
-            bounding_box: Aabb::from_points(&[min_extent, max_extent]),
+            bounding_box: Aabb::from_points(&[min_extent, max_extent]) + translation,
         })
     }
 }
@@ -61,13 +64,13 @@ impl Scale {
 impl Geometric for Scale {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
         // transform ray from world space to local (unscaled) space
-        let local_origin = Point::from_vector3(ray.origin.0 / self.scale);
+        let local_origin = Point::from_vector3((ray.origin.0 - self.translation) / self.scale);
         let local_direction = ray.direction / self.scale;
         let local_ray = Ray::new(local_origin, local_direction, ray.time);
 
         self.geometric.intersect(local_ray, ray_t).map(|mut rh| {
             // transform hit point to world space
-            rh.point.0 *= self.scale;
+            rh.point.0 = rh.point.0 * self.scale + self.translation;
             // transform normal via inverse-transpose
             rh.normal = (rh.normal * self.inv_scale).unit_vector();
             rh
@@ -102,13 +105,13 @@ impl Geometric for Scale {
     }
 
     fn sample_direction_from(&self, origin: Point) -> Vector3 {
-        let local_origin = Point::from_vector3(origin.0 / self.scale);
+        let local_origin = Point::from_vector3((origin.0 - self.translation) / self.scale);
         let local_dir = self.geometric.sample_direction_from(local_origin);
         (local_dir * self.scale).unit_vector()
     }
 
     fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
-        let local_origin = Point::from_vector3(origin.0 / self.scale);
+        let local_origin = Point::from_vector3((origin.0 - self.translation) / self.scale);
         let local_dir = (dir / self.scale).unit_vector();
 
         let p_local = self.geometric.direction_pdf(local_origin, local_dir);

--- a/src/utils/around.rs
+++ b/src/utils/around.rs
@@ -31,7 +31,7 @@ impl Around {
 /// Upgrades legacy `around` values in a `serde_json::Value` tree so
 /// they match the current `Around` serde format.
 ///
-/// For any object with `"type": "rotate_x" | "rotate_y" | "rotate_z"`:
+/// For any object with `"type": "rotate_x" | "rotate_y" | "rotate_z" | "scale"`:
 /// - Bare array `[x, y, z]` → wraps as `{"point": [x, y, z]}`
 /// - Missing `"around"` key → inserts `"around": "origin"`
 /// - Already a string or object → left unchanged
@@ -42,20 +42,18 @@ pub fn upgrade_legacy_around(value: &mut serde_json::Value) {
         serde_json::Value::Object(map) => {
             // only act on rotation geometrics
             if let Some(serde_json::Value::String(type_str)) = map.get("type")
-                && matches!(type_str.as_str(), "rotate_x" | "rotate_y" | "rotate_z")
+                && matches!(
+                    type_str.as_str(),
+                    "rotate_x" | "rotate_y" | "rotate_z" | "scale"
+                )
             {
                 match map.get("around") {
                     // bare array → wrap in {"point": [...]}
                     Some(serde_json::Value::Array(arr)) => {
                         let mut point_obj = serde_json::Map::new();
-                        point_obj.insert(
-                            "point".to_string(),
-                            serde_json::Value::Array(arr.clone()),
-                        );
-                        map.insert(
-                            "around".to_string(),
-                            serde_json::Value::Object(point_obj),
-                        );
+                        point_obj
+                            .insert("point".to_string(), serde_json::Value::Array(arr.clone()));
+                        map.insert("around".to_string(), serde_json::Value::Object(point_obj));
                     }
                     // missing → insert "origin"
                     None => {

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -8,6 +8,7 @@ import {
   isAroundCenter,
   isAroundOrigin,
   isTypedObject,
+  nonZeroNumber,
   toRadians,
   type Angle,
   type Around,
@@ -35,6 +36,8 @@ export function normalizeGeometricData(
       return normalizeGeometricInstanceRotate(config, name, geometricData);
     case 'rotate_z':
       return normalizeGeometricInstanceRotate(config, name, geometricData);
+    case 'scale':
+      return normalizeGeometricInstanceScale(config, name, geometricData);
     case 'translate':
       return normalizeGeometricInstanceTranslate(config, name, geometricData);
     case 'parallelogram':
@@ -61,6 +64,7 @@ export type NormalizedGeometricData =
   | NormalizedGeometricList
   | NormalizedGeometricObjModel
   | NormalizedGeometricInstanceRotate
+  | NormalizedGeometricInstanceScale
   | NormalizedGeometricInstanceTranslate
   | NormalizedGeometricParallelogram
   | NormalizedGeometricPlane
@@ -76,6 +80,7 @@ export type RawGeometricData =
   | RawGeometricList
   | RawGeometricObjModel
   | RawGeometricInstanceRotate
+  | RawGeometricInstanceScale
   | RawGeometricInstanceTranslate
   | RawGeometricParallelogram
   | RawGeometricPlane
@@ -96,6 +101,7 @@ export function isGeometricData(data: unknown): data is GeometricData {
       'rotate_x',
       'rotate_y',
       'rotate_z',
+      'scale',
       'translate',
       'parallelogram',
       'plane',
@@ -111,12 +117,17 @@ export function isGeometricData(data: unknown): data is GeometricData {
 
 export function isComposite(
   data: GeometricData,
-): data is GeometricList | GeometricInstanceRotate | GeometricInstanceTranslate {
+): data is
+  | GeometricList
+  | GeometricInstanceRotate
+  | GeometricInstanceScale
+  | GeometricInstanceTranslate {
   return (
     data.type === 'list' ||
     data.type === 'rotate_x' ||
     data.type === 'rotate_y' ||
     data.type === 'rotate_z' ||
+    data.type === 'scale' ||
     data.type === 'translate' ||
     data.type === 'virtual'
   );
@@ -149,6 +160,7 @@ export function getReferencedMaterialNames(
     case 'rotate_x':
     case 'rotate_y':
     case 'rotate_z':
+    case 'scale':
     case 'translate':
     case 'constant_volume':
     case 'virtual':
@@ -252,10 +264,14 @@ export function getCenterPoint(
       const pivot = getAroundPoint(data.around, config, data.geometric);
       return rotatePoint(childCenter, data.type, angleRad, pivot);
     }
-    case 'constant_volume':
-    case 'virtual': {
+    case 'scale': {
       const { data: subData } = getGeometricDataSafe(config, data.geometric);
-      return getCenterPoint(config, subData);
+      const childCenter = getCenterPoint(config, subData);
+      return [
+        childCenter[0] * data.scale[0],
+        childCenter[1] * data.scale[1],
+        childCenter[2] * data.scale[2],
+      ];
     }
     case 'translate': {
       const { data: subData } = getGeometricDataSafe(config, data.geometric);
@@ -290,6 +306,11 @@ export function getCenterPoint(
         (data.p00[1] + data.p10[1] + data.p01[1] + data.p11[1]) / 4,
         (data.p00[2] + data.p10[2] + data.p01[2] + data.p11[2]) / 4,
       ];
+    case 'constant_volume':
+    case 'virtual': {
+      const { data: subData } = getGeometricDataSafe(config, data.geometric);
+      return getCenterPoint(config, subData);
+    }
   }
 }
 
@@ -397,6 +418,12 @@ export function defaultGeometricForType(
         geometric: '__unit_box',
         degrees: 0,
         around: 'center',
+      };
+    case 'scale':
+      return {
+        type: 'scale',
+        geometric: '__unit_box',
+        scale: [1, 1, 1],
       };
     case 'translate':
       return {
@@ -721,6 +748,51 @@ export type RawGeometricInstanceTranslate = {
   type: 'translate';
   geometric: string | RawGeometricData;
   translation: [number, number, number];
+};
+
+export const GeometricInstanceScaleSchema = z.object({
+  type: z.literal('scale'),
+  geometric: z.string().nonempty(),
+  scale: z.tuple([nonZeroNumber, nonZeroNumber, nonZeroNumber]),
+});
+
+export type GeometricInstanceScale = NormalizedGeometricInstanceScale;
+
+export function normalizeGeometricInstanceScale(
+  config: RenderConfig,
+  name: string,
+  geometricData: RawGeometricInstanceScale,
+): NormalizedGeometricInstanceScale {
+  const geometric = geometricData;
+
+  if (typeof geometric.geometric !== 'string') {
+    if (!config.geometrics) {
+      config.geometrics = {};
+    }
+
+    const geometricName = getNextUniqueName(
+      config.geometrics,
+      `${name}_${geometric.geometric.type}`,
+    );
+    config.geometrics[geometricName] = normalizeGeometricData(
+      config,
+      geometricName,
+      geometric.geometric,
+    );
+    geometric.geometric = geometricName;
+  }
+
+  return geometric as NormalizedGeometricInstanceScale;
+}
+
+export type NormalizedGeometricInstanceScale = Omit<RawGeometricInstanceScale, 'geometric'> & {
+  geometric: string;
+};
+
+export type RawGeometricInstanceScale = {
+  type: 'scale';
+  geometric: string | RawGeometricData;
+  scale: [number, number, number];
 };
 
 export const GeometricParallelogramSchema = z.object({
@@ -1136,6 +1208,7 @@ const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   rotate_x: GeometricInstanceRotateXSchema,
   rotate_y: GeometricInstanceRotateYSchema,
   rotate_z: GeometricInstanceRotateZSchema,
+  scale: GeometricInstanceScaleSchema,
   translate: GeometricInstanceTranslateSchema,
   parallelogram: GeometricParallelogramSchema,
   disk: GeometricDiskSchema,
@@ -1176,7 +1249,14 @@ export const GeometricDataSchema = z.any().superRefine((data, ctx) => {
 export function wrapGeometric(
   config: NormalizedRenderConfig,
   geometricName: string,
-  wrapperType: 'translate' | 'rotate_x' | 'rotate_y' | 'rotate_z' | 'constant_volume' | 'virtual',
+  wrapperType:
+    | 'rotate_x'
+    | 'rotate_y'
+    | 'rotate_z'
+    | 'scale'
+    | 'translate'
+    | 'constant_volume'
+    | 'virtual',
 ): { config: NormalizedRenderConfig; wrapperName: string } {
   const geometrics = config.geometrics;
   if (!geometrics || !(geometricName in geometrics)) {
@@ -1195,6 +1275,7 @@ export function wrapGeometric(
     rotate_x: 'Rotate X',
     rotate_y: 'Rotate Y',
     rotate_z: 'Rotate Z',
+    scale: 'Scale',
     translate: 'Translate',
     constant_volume: 'Constant Volume',
     virtual: 'Virtual',
@@ -1215,6 +1296,7 @@ export function wrapGeometric(
       case 'rotate_x':
       case 'rotate_y':
       case 'rotate_z':
+      case 'scale':
       case 'translate':
       case 'constant_volume':
       case 'virtual': {

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -267,10 +267,11 @@ export function getCenterPoint(
     case 'scale': {
       const { data: subData } = getGeometricDataSafe(config, data.geometric);
       const childCenter = getCenterPoint(config, subData);
+      const pivot = getAroundPoint(data.around, config, data.geometric);
       return [
-        childCenter[0] * data.scale[0],
-        childCenter[1] * data.scale[1],
-        childCenter[2] * data.scale[2],
+        pivot[0] + (childCenter[0] - pivot[0]) * data.scale[0],
+        pivot[1] + (childCenter[1] - pivot[1]) * data.scale[1],
+        pivot[2] + (childCenter[2] - pivot[2]) * data.scale[2],
       ];
     }
     case 'translate': {
@@ -424,6 +425,7 @@ export function defaultGeometricForType(
         type: 'scale',
         geometric: '__unit_box',
         scale: [1, 1, 1],
+        around: 'center',
       };
     case 'translate':
       return {
@@ -754,6 +756,7 @@ export const GeometricInstanceScaleSchema = z.object({
   type: z.literal('scale'),
   geometric: z.string().nonempty(),
   scale: z.tuple([nonZeroNumber, nonZeroNumber, nonZeroNumber]),
+  around: AroundSchema,
 });
 
 export type GeometricInstanceScale = NormalizedGeometricInstanceScale;
@@ -793,6 +796,7 @@ export type RawGeometricInstanceScale = {
   type: 'scale';
   geometric: string | RawGeometricData;
   scale: [number, number, number];
+  around: Around;
 };
 
 export const GeometricParallelogramSchema = z.object({

--- a/ui/src/utils/render/utils.ts
+++ b/ui/src/utils/render/utils.ts
@@ -17,6 +17,7 @@ export function getTopLevelGeometricNames(config: NormalizedRenderConfig) {
             case 'rotate_x':
             case 'rotate_y':
             case 'rotate_z':
+            case 'scale':
             case 'translate':
             case 'constant_volume':
             case 'virtual':
@@ -117,6 +118,10 @@ export const AroundSchema = z.union([
   z.object({ point: z.tuple([z.number(), z.number(), z.number()]) }),
 ]);
 
+export const nonZeroNumber = z.number().refine((val) => val !== 0, {
+  message: 'Number must be non-zero',
+});
+
 /**
  * fixes dangling references after a geometric, material, or texture is deleted.
  * replaces broken references with default values (__white, __black, __lambertian_white, __unit_box).
@@ -187,6 +192,7 @@ export function fixReferences(config: NormalizedRenderConfig): NormalizedRenderC
       case 'rotate_x':
       case 'rotate_y':
       case 'rotate_z':
+      case 'scale':
       case 'translate':
       case 'constant_volume':
       case 'virtual':
@@ -365,6 +371,7 @@ export function renameGeometric(
       case 'rotate_x':
       case 'rotate_y':
       case 'rotate_z':
+      case 'scale':
       case 'translate':
       case 'constant_volume':
       case 'virtual': {

--- a/ui/src/views/renders/new/Controls/shared/AddEntityModal.tsx
+++ b/ui/src/views/renders/new/Controls/shared/AddEntityModal.tsx
@@ -12,13 +12,14 @@ import {
 import { HiPlus, HiXMark } from 'react-icons/hi2';
 import type { EntityType, EntitySubType, AddEntityDropdownOption } from './AddEntityDropdown';
 
-export type InstanceType = 'translate' | 'rotate_x' | 'rotate_y' | 'rotate_z';
+export type InstanceType = 'translate' | 'rotate_x' | 'rotate_y' | 'rotate_z' | 'scale';
 
 const INSTANCE_LABELS: Record<InstanceType, string> = {
-  translate: 'Translate',
   rotate_x: 'Rotate X',
   rotate_y: 'Rotate Y',
   rotate_z: 'Rotate Z',
+  scale: 'Scale',
+  translate: 'Translate',
 };
 
 export type AddEntityCreateConfig = {
@@ -142,10 +143,11 @@ export function AddEntityModal<T extends EntityType>(props: AddEntityModalProps<
                   onChange={(e) => setPendingInstanceType(e.target.value as InstanceType)}
                   sizing="sm"
                 >
-                  <option value="translate">Translate</option>
                   <option value="rotate_x">Rotate X</option>
                   <option value="rotate_y">Rotate Y</option>
                   <option value="rotate_z">Rotate Z</option>
+                  <option value="scale">Scale</option>
+                  <option value="translate">Translate</option>
                 </Select>
                 <Button
                   color="light"

--- a/ui/src/views/renders/new/Controls/shared/geometricTree.ts
+++ b/ui/src/views/renders/new/Controls/shared/geometricTree.ts
@@ -14,10 +14,11 @@ export type GeometricDisplayNode = {
 // or an empty array if it has no children (leaf type).
 function getChildGeometricNames(geo: NormalizedGeometricData): string[] {
   switch (geo.type) {
-    case 'translate':
     case 'rotate_x':
     case 'rotate_y':
     case 'rotate_z':
+    case 'scale':
+    case 'translate':
     case 'constant_volume':
     case 'virtual':
       return [geo.geometric];

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/AroundVariantControls.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/AroundVariantControls.tsx
@@ -8,10 +8,11 @@ import { AnimatedSeparator } from '@/components/AnimatedSeparator';
 export type AroundVariantControlsProps = {
   form: RenderForm;
   geometricName: string;
+  pivotLabel: string;
 };
 
 export function AroundVariantControls(props: AroundVariantControlsProps) {
-  const { form, geometricName } = props;
+  const { form, geometricName, pivotLabel } = props;
 
   return (
     <form.AppField name={`geometrics.${geometricName}.around`}>
@@ -22,7 +23,7 @@ export function AroundVariantControls(props: AroundVariantControlsProps) {
           <>
             <AnimatedSeparator visible={isPoint} />
             <field.SelectControl
-              label="Rotation Point"
+              label={pivotLabel}
               items={[
                 { label: 'Geometric Center', value: 'center' },
                 { label: 'World Origin', value: 'origin' },
@@ -54,7 +55,7 @@ export function AroundVariantControls(props: AroundVariantControlsProps) {
                 <TextArrayInputControl
                   form={form}
                   fieldName={`geometrics.${geometricName}.around.point`}
-                  label="Custom Rotation Point"
+                  label={`Custom ${pivotLabel}`}
                   valueLabels={['x', 'y', 'z']}
                   type="number"
                 />

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -257,6 +257,18 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
         </>
       );
     }
+    case 'scale':
+      return (
+        <>
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.scale`}
+            label="Scale"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+        </>
+      );
     case 'translate':
       return (
         <>

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -253,7 +253,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
               />
             )}
           </form.AppField>
-          <AroundVariantControls form={form} geometricName={name} />
+          <AroundVariantControls form={form} geometricName={name} pivotLabel="Rotation Point" />
         </>
       );
     }
@@ -267,7 +267,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
-          <AroundVariantControls form={form} geometricName={name} />
+          <AroundVariantControls form={form} geometricName={name} pivotLabel="Scale Point" />
         </>
       );
     case 'translate':

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -267,6 +267,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
+          <AroundVariantControls form={form} geometricName={name} />
         </>
       );
     case 'translate':

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricMoreOptionsDropdown/WrapGeometricModal.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricMoreOptionsDropdown/WrapGeometricModal.tsx
@@ -10,13 +10,14 @@ import {
 } from 'flowbite-react';
 import { HiPlus, HiXMark } from 'react-icons/hi2';
 
-export type InstanceType = 'translate' | 'rotate_x' | 'rotate_y' | 'rotate_z';
+export type InstanceType = 'translate' | 'rotate_x' | 'rotate_y' | 'rotate_z' | 'scale';
 
 const INSTANCE_LABELS: Record<InstanceType, string> = {
-  translate: 'Translate',
   rotate_x: 'Rotate X',
   rotate_y: 'Rotate Y',
   rotate_z: 'Rotate Z',
+  scale: 'Scale',
+  translate: 'Translate',
 };
 
 export type WrapGeometricConfig = {
@@ -105,10 +106,11 @@ export function WrapGeometricModal(props: WrapGeometricModalProps) {
               }}
               sizing="sm"
             >
-              <option value="translate">Translate</option>
               <option value="rotate_x">Rotate X</option>
               <option value="rotate_y">Rotate Y</option>
               <option value="rotate_z">Rotate Z</option>
+              <option value="scale">Scale</option>
+              <option value="translate">Translate</option>
             </Select>
             <Button
               color="light"

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -148,12 +148,20 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       );
     }
 
-    case 'scale':
+    case 'scale': {
+      const pivot = getAroundPoint(data.around, config, data.geometric);
       return (
-        <group scale={[data.scale[0], data.scale[1], data.scale[2]]} rotation={rotation}>
-          <GeometricRenderer config={config} name={data.geometric} />
+        <group rotation={rotation}>
+          <group position={pivot}>
+            <group scale={[data.scale[0], data.scale[1], data.scale[2]]}>
+              <group position={[-pivot[0], -pivot[1], -pivot[2]]}>
+                <GeometricRenderer config={config} name={data.geometric} />
+              </group>
+            </group>
+          </group>
         </group>
       );
+    }
 
     case 'translate':
       return (

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -148,6 +148,13 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       );
     }
 
+    case 'scale':
+      return (
+        <group scale={[data.scale[0], data.scale[1], data.scale[2]]} rotation={rotation}>
+          <GeometricRenderer config={config} name={data.geometric} />
+        </group>
+      );
+
     case 'translate':
       return (
         <group position={data.translation}>


### PR DESCRIPTION
Closes #183.

## Summary

Adds a non-uniform `Scale` transform instance — enables ellipsoids (Sphere + Scale) and scaled variants of all primitives with zero new intersection code.

## Backend

- **New**: `src/geometry/instances/scale.rs` — `Scale` struct with full `Geometric` trait implementation
  - Transform-to-local-space `intersect`
  - Inverse-transpose normal transform (handles non-uniform scale correctly)
  - Exact solid-angle Jacobian for `direction_pdf`
  - `surface_area` heuristic (exact for boxes, approximate otherwise)
  - `around` pivot support (mirrors `Around` from `Rotate*Axis`)
  - Returns `Result` for validation (zero scale rejected, negative allowed)
- **`src/geometry/instances.rs`** — registered `Scale` module
- **`src/deserialization/geometrics.rs`** — JSON deserialization for `{ "type": "scale", "scale": [sx, sy, sz], "geometric": ..., "around": ... }`
- **`src/utils/around.rs`** — `upgrade_legacy_around` also handles `"scale"` type

## Frontend

- **`ui/src/utils/render/geometric.ts`** — `GeometricInstanceScale` type, Zod schema, normalization, defaults, `getCenterPoint`, `wrapGeometric` support
- **`ui/src/utils/render/utils.ts`** — shared `nonZeroNumber` Zod schema
- **`GeometricFormControls`** — scale factor inputs + `AroundVariantControls` ("Scale Point" label)
- **`GeometricRenderer.tsx`** — 3D preview with pivot-aware scale
- **`WrapGeometricModal` / `AddEntityModal`** — Scale added as a wrap option
- **`geometricTree.ts`** — Scale handled in child resolution

## Migration

- **`migrations/20260705194312`** — fixed `setval` COALESCE from 0 to 1 (prevents DB startup failure on empty table)