### PR TITLE
FEAT: Add dielectric medium absorption, emission, and thin-walled BSDF

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -12,7 +12,7 @@ use luxide::{
         volumes,
     },
     shading::{
-        ColorRgb, ColorSpectrum, Texture,
+        ColorRgb, ColorSpectrum, Medium, Texture,
         materials::{Dielectric, Lambertian, Material, Specular},
         textures::{Checker, Image8Bit, Noise, SolidColor},
     },
@@ -167,6 +167,7 @@ fn final_scene() -> Scene {
         Arc::clone(&solid_white),
         Arc::clone(&solid_black),
         1.5,
+        Some(Medium::Vacuum),      // interior_medium (volumetric, clear)
     ));
     let specular_frosted_metal: Arc<dyn Material> = Arc::new(Specular::new(
         Arc::clone(&solid_light_grey_frosted_metal),
@@ -750,6 +751,7 @@ fn earth() -> Scene {
         Arc::clone(&solid_white),
         Arc::clone(&solid_black),
         1.5,
+        Some(Medium::Vacuum),      // interior_medium (volumetric, clear)
     ));
 
     // Primitives
@@ -875,6 +877,7 @@ fn random_spheres() -> Scene {
         Arc::clone(&solid_white),
         Arc::clone(&solid_black),
         1.5,
+        Some(Medium::Vacuum),      // interior_medium (volumetric, clear)
     ));
     let lambertian_brown: Arc<dyn Material> = Arc::new(Lambertian::new(
         Arc::clone(&solid_brown),
@@ -942,6 +945,7 @@ fn random_spheres() -> Scene {
                         Arc::clone(&albedo),
                         Arc::clone(&solid_black),
                         1.5,
+                        Some(Medium::Vacuum),      // interior_medium (volumetric, clear)
                     ));
                     world_list.push(Arc::new(Sphere::new(center, 0.2, dielectric)));
                 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -9,6 +9,7 @@ use crate::{
         color_spectrum::SPECTRAL_SAMPLE_COUNT,
         hero_wavelengths::HERO_WAVELENGTH_COUNT,
         materials::{ScatterRecord, SpectralScatter},
+        medium::Medium,
         pdf::Pdf,
     },
     tracing::{BouncesConfig, ImportanceSamplingConfig, RenderParameters, Scene, SceneWorld},
@@ -177,6 +178,7 @@ impl Camera {
         hw: &HeroWavelengths<N>,
         scene_world: &SceneWorld,
         mut bounces: u32,
+        mut medium_stack: Vec<Medium>,
     ) -> Vector<N> {
         let mut rng = rand::rng();
 
@@ -189,6 +191,17 @@ impl Camera {
             .world
             .intersect(ray, Interval::new(0.001, f64::INFINITY))
         {
+            // volume emission: accumulate glow from the medium segment
+            // before attenuating throughput. Uses coupled Kirchhoff model:
+            // emitted = L_e * (1 - Tr).
+            let distance = ray_hit.t;
+            let emission = ray.current_medium.emission(hw, distance);
+            accumulated += attenuation * emission;
+
+            // apply Beer-Lambert attenuation for the distance traveled
+            // through the current medium (vacuum returns Vector::ONE = no-op)
+            attenuation *= ray.current_medium.transmittance(hw, distance);
+
             // emissive contribution at each hero wavelength
             let emittance = ray_hit
                 .material
@@ -221,20 +234,41 @@ impl Camera {
                 return accumulated;
             };
 
+            let entering = ray.direction.dot(ray_hit.normal) < 0.0;
+
             let outgoing_direction = (-ray.direction).unit_vector();
 
             match srec {
                 ScatterRecord::Spectral(ss) => {
                     let SpectralScatter { rays, reflectance } = *ss;
-                    // dispersive dielectric — trace each hero wavelength independently
+                    // dispersive dielectric — trace each hero wavelength independently,
+                    // managing the medium stack for entering/exiting transitions.
                     for i in 0..N {
-                        if let Some(refracted) = rays[i] {
+                        if let Some(mut refracted_or_reflected_ray) = rays[i] {
+                            let refracted =
+                                ray.direction.dot(refracted_or_reflected_ray.direction) > 0.0;
+
+                            // if we're transitioning between materials, we are experiencing a change in medium.
+                            if refracted {
+                                if entering {
+                                    // for the case of entering a new medium, the ray will already have the correct medium
+                                    // attached, from the material.
+                                    //
+                                    // all we need to do is make sure we keep track of the medium
+                                    // that we're moving out of, so that we can restore it when we exit.
+                                    medium_stack.push(ray.current_medium);
+                                } else {
+                                    let outer_medium = medium_stack.pop().unwrap_or(Medium::Vacuum);
+                                    refracted_or_reflected_ray.current_medium = outer_medium;
+                                }
+                            }
                             let single_hw = HeroWavelengths::new([hw[i]; 1]);
                             let contrib = self.trace_spectral::<1>(
-                                refracted,
+                                refracted_or_reflected_ray,
                                 &single_hw,
                                 scene_world,
                                 bounces + 1,
+                                medium_stack.clone(),
                             );
                             accumulated[i] += attenuation[i] * reflectance[i] * contrib[0];
                         }
@@ -289,7 +323,12 @@ impl Camera {
                         attenuation *= brdf_val.sample(hw) * (cos_theta / pdf_val);
                     }
 
-                    ray = Ray::new(ray_hit.point, incident_direction, ray.time);
+                    ray = Ray::new_with_medium(
+                        ray_hit.point,
+                        incident_direction,
+                        ray.time,
+                        ray.current_medium,
+                    );
                 }
             }
 
@@ -315,7 +354,8 @@ impl Camera {
 
     pub fn ray_color(&self, ray: Ray, scene_world: &SceneWorld) -> ColorRgb {
         let hw = HeroWavelengths::<HERO_WAVELENGTH_COUNT>::new_distributed();
-        let accumulated = self.trace_spectral::<HERO_WAVELENGTH_COUNT>(ray, &hw, scene_world, 0);
+        let accumulated =
+            self.trace_spectral::<HERO_WAVELENGTH_COUNT>(ray, &hw, scene_world, 0, Vec::new());
         hw.to_color_rgb(accumulated)
     }
 }

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -25,7 +25,7 @@ mod geometrics;
 use self::geometrics::GeometricData;
 
 mod materials;
-use self::materials::MaterialData;
+use self::materials::{MaterialData, MediumData};
 
 mod textures;
 use self::textures::TextureData;
@@ -436,16 +436,19 @@ fn get_builtin_materials() -> IndexMap<String, MaterialData> {
             reflectance_texture: texture_fn("white"),
             emittance_texture: texture_fn("black"),
             index_of_refraction: 1.52,
+            medium_data: Some(MediumData::Vacuum),
         },
         prefix_builtin_key("dielectric_water") => MaterialData::Dielectric {
             reflectance_texture: texture_fn("white"),
             emittance_texture: texture_fn("black"),
             index_of_refraction: 1.333,
+            medium_data: Some(MediumData::Vacuum),
         },
         prefix_builtin_key("dielectric_diamond") => MaterialData::Dielectric {
             reflectance_texture: texture_fn("white"),
             emittance_texture: texture_fn("black"),
             index_of_refraction: 2.417,
+            medium_data: Some(MediumData::Vacuum),
         },
 
         // cornell box materials

--- a/src/deserialization/materials.rs
+++ b/src/deserialization/materials.rs
@@ -70,6 +70,7 @@ pub enum MaterialData {
         reflectance_texture: TextureRefOrInline,
         emittance_texture: TextureRefOrInline,
         index_of_refraction: f64,
+        #[serde(skip_serializing_if = "Option::is_none")]
         medium_data: Option<MediumData>,
     },
     Lambertian {

--- a/src/deserialization/materials.rs
+++ b/src/deserialization/materials.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crate::shading::materials::{Dielectric, Lambertian, Material, Specular};
+use crate::shading::{
+    ColorRgb, ColorSpectrum, Medium,
+    materials::{Dielectric, Lambertian, Material, Specular},
+};
 
 use super::{Build, Builts, textures::TextureRefOrInline};
 
@@ -25,6 +28,41 @@ impl Build<Arc<dyn Material>> for MaterialRefOrInline {
     }
 }
 
+/// Serializable representation of an interior medium.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MediumData {
+    /// Transparent interior — no absorption or emission.
+    Vacuum,
+    /// Homogeneous absorbing and emitting medium.
+    Homogeneous {
+        attenuation_distance: f64,
+        transmittance: [f64; 3],
+        emittance: [f64; 3],
+    },
+}
+
+impl From<MediumData> for Medium {
+    fn from(data: MediumData) -> Self {
+        match data {
+            MediumData::Vacuum => Medium::Vacuum,
+            MediumData::Homogeneous {
+                attenuation_distance,
+                transmittance,
+                emittance,
+            } => {
+                let transmittance = ColorSpectrum::from(ColorRgb::from(transmittance));
+                let emittance = ColorSpectrum::from(ColorRgb::from(emittance));
+                Medium::Homogeneous {
+                    attenuation_distance,
+                    transmittance,
+                    emittance,
+                }
+            }
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type", deny_unknown_fields)]
 pub enum MaterialData {
@@ -32,6 +70,7 @@ pub enum MaterialData {
         reflectance_texture: TextureRefOrInline,
         emittance_texture: TextureRefOrInline,
         index_of_refraction: f64,
+        medium_data: Option<MediumData>,
     },
     Lambertian {
         reflectance_texture: TextureRefOrInline,
@@ -51,14 +90,29 @@ impl Build<Arc<dyn Material>> for MaterialData {
                 reflectance_texture,
                 emittance_texture,
                 index_of_refraction,
+                medium_data,
             } => {
                 let reflectance_texture = reflectance_texture.build(builts)?;
                 let emittance_texture = emittance_texture.build(builts)?;
+
+                if let Some(MediumData::Homogeneous {
+                    attenuation_distance,
+                    ..
+                }) = medium_data
+                    && *attenuation_distance <= 0.0
+                {
+                    return Err(format!(
+                        "attenuation_distance must be positive, got {attenuation_distance}",
+                    ));
+                }
+
+                let medium = medium_data.clone().map(Medium::from);
 
                 Ok(Arc::new(Dielectric::new(
                     reflectance_texture,
                     emittance_texture,
                     *index_of_refraction,
+                    medium,
                 )))
             }
             Self::Lambertian {

--- a/src/deserialization/textures.rs
+++ b/src/deserialization/textures.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::shading::{
-    Texture,
+    ColorRgb, Texture,
     textures::{Checker, Image8Bit, SolidColor},
 };
 
@@ -65,9 +65,7 @@ impl Build<Arc<dyn Texture>> for TextureData {
 
                 Ok(Arc::new(image_texture))
             }
-            Self::SolidColor { color } => {
-                Ok(Arc::new(SolidColor::from_rgb(color[0], color[1], color[2])))
-            }
+            Self::SolidColor { color } => Ok(Arc::new(SolidColor::from(ColorRgb::from(*color)))),
         }
     }
 }

--- a/src/geometry/instances/scale.rs
+++ b/src/geometry/instances/scale.rs
@@ -66,20 +66,20 @@ impl Scale {
 impl Geometric for Scale {
     fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
         // transform ray to pivot-centered scaled local space.
-        // matches RotateYAxis pattern: subtract pivot, apply transform, add pivot back.
-        let local_origin =
+        // subtract pivot, apply transform, add pivot back.
+        let mut local_ray = ray;
+        local_ray.origin =
             Point::from_vector3((ray.origin.0 - self.translation) / self.scale + self.translation);
-        let local_direction = ray.direction / self.scale;
-        let local_ray = Ray::new(local_origin, local_direction, ray.time);
+        local_ray.direction = ray.direction / self.scale;
 
-        let hit = self.geometric.intersect(local_ray, ray_t);
-        hit.map(|mut rh| {
-            // transform hit back: subtract pivot, scale, add pivot
-            rh.point.0 = (rh.point.0 - self.translation) * self.scale + self.translation;
-            // transform normal via inverse-transpose (translation invariant)
-            rh.normal = (rh.normal * self.inv_scale).unit_vector();
-            rh
-        })
+        let mut rayhit = self.geometric.intersect(local_ray, ray_t)?;
+
+        // transform hit back: subtract pivot, scale, add pivot
+        rayhit.point.0 = (rayhit.point.0 - self.translation) * self.scale + self.translation;
+        // transform normal via inverse-transpose (translation invariant)
+        rayhit.normal = (rayhit.normal * self.inv_scale).unit_vector();
+
+        Some(rayhit)
     }
 
     fn surface_area(&self) -> f64 {

--- a/src/geometry/ray.rs
+++ b/src/geometry/ray.rs
@@ -1,18 +1,37 @@
 use super::{Point, Vector3};
+use crate::shading::medium::Medium;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Ray {
     pub origin: Point,
     pub direction: Vector3,
     pub time: f64,
+    pub current_medium: Medium,
 }
 
 impl Ray {
+    /// Create a ray in the default `Vacuum` medium.
     pub fn new(origin: Point, direction: Vector3, time: f64) -> Self {
         Self {
             origin,
             direction,
             time,
+            current_medium: Medium::Vacuum,
+        }
+    }
+
+    /// Create a ray traveling through the specified medium.
+    pub fn new_with_medium(
+        origin: Point,
+        direction: Vector3,
+        time: f64,
+        current_medium: Medium,
+    ) -> Self {
+        Self {
+            origin,
+            direction,
+            time,
+            current_medium,
         }
     }
 

--- a/src/shading.rs
+++ b/src/shading.rs
@@ -11,3 +11,6 @@ pub mod materials;
 pub mod pdf;
 pub mod textures;
 pub use textures::Texture;
+
+pub mod medium;
+pub use medium::Medium;

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -232,12 +232,13 @@ impl Dielectric {
                     ray.current_medium,
                 ));
                 let t_total = 1.0 - r_total[i];
-                // no volume means no absorption. An infinitely thin sheet
-                //
-                // The Medium::Vacuum transmittance is always 1.0, so this is a no-op.
-                // It's left here only so it's VERY CLEAR what's happening.
-                let tint_i = Medium::Vacuum.transmittance_at(hw[i]);
-                reflectance[i] = t_total * tint_i;
+                // Thin sheets have no interior — the reflectance texture
+                // IS the material's color. Apply to transmission as well.
+                let tint = self
+                    .reflectance_texture
+                    .value(ray_hit.u, ray_hit.v, ray_hit.point)
+                    .sample_wavelength(hw[i]);
+                reflectance[i] = t_total * tint;
             }
         }
 

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -198,14 +198,14 @@ impl Dielectric {
         let mut rays: [Option<Ray>; HERO_WAVELENGTH_COUNT] = std::array::from_fn(|_| None);
         let mut reflectance = Vector::<HERO_WAVELENGTH_COUNT>::ZERO;
 
-        let outgoing = (-ray.direction).unit_vector();
-
         // single direction decision: reflect or transmit straight through.
         // This matches the Mitsuba thindielectric / PBRT thin-dielectric
         // behavior — one decision for all wavelengths.
         if rand::random::<f64>() < avg_r {
             // reflect: both faces contribute via the analytic sum
-            let reflected = outgoing.reflect_around(ray_hit.normal);
+            let reflected = (-ray.direction)
+                .unit_vector()
+                .reflect_around(ray_hit.normal);
             for i in 0..HERO_WAVELENGTH_COUNT {
                 rays[i] = Some(Ray::new_with_medium(
                     ray_hit.point,
@@ -227,7 +227,7 @@ impl Dielectric {
             for i in 0..HERO_WAVELENGTH_COUNT {
                 rays[i] = Some(Ray::new_with_medium(
                     ray_hit.point,
-                    outgoing,
+                    ray.direction.unit_vector(),
                     ray.time,
                     ray.current_medium,
                 ));

--- a/src/shading/materials/dielectric.rs
+++ b/src/shading/materials/dielectric.rs
@@ -6,6 +6,7 @@ use crate::{
         ColorSpectrum, Texture,
         color_spectrum::SPECTRAL_SAMPLE_COUNT,
         hero_wavelengths::{HERO_WAVELENGTH_COUNT, HeroWavelengths},
+        medium::Medium,
     },
 };
 
@@ -16,6 +17,9 @@ pub struct Dielectric {
     reflectance_texture: Arc<dyn Texture>,
     emittance_texture: Arc<dyn Texture>,
     index_of_refraction: f64,
+    /// The interior medium of this dielectric (absorption + emission).
+    /// `None` means thin-walled (straight-through transmission, no volume).
+    pub medium: Option<Medium>,
 }
 
 impl Dielectric {
@@ -23,11 +27,13 @@ impl Dielectric {
         reflectance_texture: Arc<dyn Texture>,
         emittance_texture: Arc<dyn Texture>,
         index_of_refraction: f64,
+        medium: Option<Medium>,
     ) -> Dielectric {
         Dielectric {
             reflectance_texture,
             emittance_texture,
             index_of_refraction,
+            medium,
         }
     }
 
@@ -73,15 +79,14 @@ impl Dielectric {
 
     /// Compute the scattered direction for a specific wavelength using
     /// Fresnel-weighted Monte Carlo: randomly reflects or refracts
-    /// proportional to Schlick reflectance, returning the appropriate
-    /// attenuation weight (1.0 for reflection, 1.0 - reflectance for
-    /// transmission; converges to correct Fresnel over many samples).
+    /// proportional to Schlick reflectance, which converges to
+    /// correct Fresnel over many samples).
     pub fn refract_at(
         &self,
         incident: Vector3,
         normal: Vector3,
         wavelength_nm: f64,
-    ) -> (Vector3, f64) {
+    ) -> (Vector3, bool) {
         let ior = self.index_of_refraction_at(wavelength_nm);
         let (refractive_normal, refraction_ratio) = if incident.dot(normal) < 0.0 {
             (normal, 1.0 / ior)
@@ -98,14 +103,148 @@ impl Dielectric {
 
         if cannot_refract || reflectance > rand::random() {
             // reflect (TIR or Schlick flip chose reflection)
-            (unit_direction.reflect_around(refractive_normal), 1.0)
+            (unit_direction.reflect_around(refractive_normal), true)
         } else {
             // refract
             (
                 unit_direction.refract_around(refractive_normal, refraction_ratio),
-                1.0 - reflectance,
+                false,
             )
         }
+    }
+
+    fn scatter_volumetric(
+        &self,
+        ray: &Ray,
+        ray_hit: &RayHit,
+        hw: &HeroWavelengths<HERO_WAVELENGTH_COUNT>,
+        medium: Medium,
+    ) -> Option<ScatterRecord> {
+        let entering = ray.direction.dot(ray_hit.normal) < 0.0;
+
+        let mut rays: [Option<Ray>; HERO_WAVELENGTH_COUNT] = std::array::from_fn(|_| None);
+        let mut reflectance = Vector::<HERO_WAVELENGTH_COUNT>::ONE;
+
+        for (i, &lambda) in hw.iter().enumerate() {
+            let (next_dir, reflected) = self.refract_at(ray.direction, ray_hit.normal, lambda);
+
+            // apply reflectance texture as an optional reflection tint
+            // (non-physical but useful for coated-glass effects)
+            if reflected {
+                let tint = self
+                    .reflectance_texture
+                    .value(ray_hit.u, ray_hit.v, ray_hit.point);
+                reflectance[i] *= tint.sample_wavelength(lambda);
+            }
+
+            // Determine the medium the outgoing ray travels through.
+            // A refracting ray crosses the interface; a reflecting ray stays.
+            let new_medium = if reflected {
+                ray.current_medium
+            } else if entering {
+                medium
+            } else {
+                // this will be replaced with the true outer media from the caller, since
+                // we have no way here of knowing it.
+                //
+                // (and I didn't want each Ray or the scatter function to
+                // keep track of the full media stack)
+                Medium::Vacuum
+            };
+
+            rays[i] = Some(Ray::new_with_medium(
+                ray_hit.point,
+                next_dir,
+                ray.time,
+                new_medium,
+            ));
+        }
+
+        Some(ScatterRecord::Spectral(Box::new(SpectralScatter {
+            rays,
+            reflectance,
+        })))
+    }
+
+    /// Thin-slab BSDF: analytically sums the geometric series of internal
+    /// Fresnel reflections between two parallel interfaces.
+    ///
+    /// R_total = 2R/(1+R), T_total = (1-R)/(1+R).
+    /// A single random decision chooses reflection vs. straight-through
+    /// transmission for all wavelengths. The transmitted lobe applies
+    /// the `attenuation_color` as a per-crossing multiply.
+    fn scatter_thin(
+        &self,
+        ray: &Ray,
+        ray_hit: &RayHit,
+        hw: &HeroWavelengths<HERO_WAVELENGTH_COUNT>,
+    ) -> Option<ScatterRecord> {
+        // cos_theta uses abs() — both faces of a thin sheet are equivalent
+        let cos_theta = (-ray.direction.unit_vector())
+            .dot(ray_hit.normal)
+            .abs()
+            .min(1.0);
+
+        let mut r_total = Vector::<HERO_WAVELENGTH_COUNT>::ZERO;
+        let mut sum_r = 0.0;
+        for (i, &lambda) in hw.iter().enumerate() {
+            let ior = self.index_of_refraction_at(lambda);
+            let r = Self::schlick_reflectance(cos_theta, ior);
+            r_total[i] = 2.0 * r / (1.0 + r);
+            sum_r += r_total[i];
+        }
+        let avg_r = sum_r / HERO_WAVELENGTH_COUNT as f64;
+
+        let mut rays: [Option<Ray>; HERO_WAVELENGTH_COUNT] = std::array::from_fn(|_| None);
+        let mut reflectance = Vector::<HERO_WAVELENGTH_COUNT>::ZERO;
+
+        let outgoing = (-ray.direction).unit_vector();
+
+        // single direction decision: reflect or transmit straight through.
+        // This matches the Mitsuba thindielectric / PBRT thin-dielectric
+        // behavior — one decision for all wavelengths.
+        if rand::random::<f64>() < avg_r {
+            // reflect: both faces contribute via the analytic sum
+            let reflected = outgoing.reflect_around(ray_hit.normal);
+            for i in 0..HERO_WAVELENGTH_COUNT {
+                rays[i] = Some(Ray::new_with_medium(
+                    ray_hit.point,
+                    reflected,
+                    ray.time,
+                    ray.current_medium,
+                ));
+                let tint = self
+                    .reflectance_texture
+                    .value(ray_hit.u, ray_hit.v, ray_hit.point)
+                    .sample_wavelength(hw[i]);
+                reflectance[i] = r_total[i] * tint;
+            }
+        } else {
+            // "refraction" time
+            //
+            // a "double-paned" infinitely thin sheet HAS NO refraction!
+            // so the Ray essentially continues in the same direction!
+            for i in 0..HERO_WAVELENGTH_COUNT {
+                rays[i] = Some(Ray::new_with_medium(
+                    ray_hit.point,
+                    outgoing,
+                    ray.time,
+                    ray.current_medium,
+                ));
+                let t_total = 1.0 - r_total[i];
+                // no volume means no absorption. An infinitely thin sheet
+                //
+                // The Medium::Vacuum transmittance is always 1.0, so this is a no-op.
+                // It's left here only so it's VERY CLEAR what's happening.
+                let tint_i = Medium::Vacuum.transmittance_at(hw[i]);
+                reflectance[i] = t_total * tint_i;
+            }
+        }
+
+        Some(ScatterRecord::Spectral(Box::new(SpectralScatter {
+            rays,
+            reflectance,
+        })))
     }
 }
 
@@ -154,18 +293,10 @@ impl Material for Dielectric {
         ray_hit: &RayHit,
         hw: &HeroWavelengths<HERO_WAVELENGTH_COUNT>,
     ) -> Option<ScatterRecord> {
-        let mut rays = [None; HERO_WAVELENGTH_COUNT];
-        let mut reflectance = Vector::<HERO_WAVELENGTH_COUNT>::ZERO;
-
-        for (i, &lambda) in hw.iter().enumerate() {
-            let (dir, refl) = self.refract_at(ray.direction, ray_hit.normal, lambda);
-            reflectance[i] = refl;
-            rays[i] = Some(Ray::new(ray_hit.point, dir, ray.time));
+        if let Some(medium) = self.medium {
+            self.scatter_volumetric(&ray, ray_hit, hw, medium)
+        } else {
+            self.scatter_thin(&ray, ray_hit, hw)
         }
-
-        Some(ScatterRecord::Spectral(Box::new(SpectralScatter {
-            rays,
-            reflectance,
-        })))
     }
 }

--- a/src/shading/materials/isotropic.rs
+++ b/src/shading/materials/isotropic.rs
@@ -52,7 +52,12 @@ impl Material for Isotropic {
     ) -> Option<ScatterRecord> {
         // always scatter, and always scatter in a random direction
         Some(ScatterRecord::Delta {
-            scattered: Ray::new(ray_hit.point, Vector3::random_unit(), ray.time),
+            scattered: Ray::new_with_medium(
+                ray_hit.point,
+                Vector3::random_unit(),
+                ray.time,
+                ray.current_medium,
+            ),
         })
     }
 

--- a/src/shading/materials/specular.rs
+++ b/src/shading/materials/specular.rs
@@ -71,10 +71,11 @@ impl Material for Specular {
     ) -> Option<ScatterRecord> {
         let reflected = ray.direction.unit_vector().reflect_around(ray_hit.normal);
 
-        let scattered = Ray::new(
+        let scattered = Ray::new_with_medium(
             ray_hit.point,
             reflected + self.roughness * Vector3::random_unit(),
             ray.time,
+            ray.current_medium,
         );
 
         if scattered.direction.dot(ray_hit.normal) > 0.0 {

--- a/src/shading/medium.rs
+++ b/src/shading/medium.rs
@@ -1,0 +1,99 @@
+use crate::{
+    geometry::Vector,
+    shading::{
+        ColorSpectrum,
+        color_spectrum::SPECTRAL_SAMPLE_COUNT,
+        hero_wavelengths::HeroWavelengths,
+    },
+};
+
+/// The medium a ray is currently traveling through.
+///
+/// `Vacuum` is fully transparent (no absorption at any wavelength).
+/// `Homogeneous` applies homogeneous Beer-Lambert absorption: T(d) = C^(d/d₀),
+/// with C(λ) sampled from the `transmittance` spectrum at each wavelength.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Medium {
+    /// Fully transparent — transmittance is always 1.0, emission is always 0.
+    Vacuum,
+    /// Homogeneous absorbing and emitting medium.
+    Homogeneous {
+        /// Reference distance at which `transmittance` is measured.
+        attenuation_distance: f64,
+        /// Per-wavelength transmittance after traveling `attenuation_distance`.
+        transmittance: ColorSpectrum<SPECTRAL_SAMPLE_COUNT>,
+        /// Target radiance a thick slab converges to (coupled Kirchhoff model).
+        emittance: ColorSpectrum<SPECTRAL_SAMPLE_COUNT>,
+    },
+}
+
+impl Medium {
+    /// Return the per-wavelength transmittance factor for a ray segment
+    /// of length `distance` through this medium. For `Vacuum` this is
+    /// always `Vector::ONE` (no attenuation).
+    pub fn transmittance<const N: usize>(
+        &self,
+        hw: &HeroWavelengths<N>,
+        distance: f64,
+    ) -> Vector<N> {
+        match self {
+            Medium::Vacuum => Vector::ONE,
+            Medium::Homogeneous {
+                attenuation_distance,
+                transmittance,
+                ..
+            } => {
+                let mut factors = Vector::<N>::ZERO;
+                let inv_d0 = 1.0 / attenuation_distance;
+                for (i, &lambda) in hw.iter().enumerate() {
+                    let c = transmittance.sample_wavelength(lambda);
+                    factors[i] = (distance * inv_d0 * c.ln()).exp();
+                }
+                factors
+            }
+        }
+    }
+
+    /// Return the per-wavelength emitted radiance from a ray segment of
+    /// length `distance` through this medium. Uses the coupled emission
+    /// model (Kirchhoff's law): a medium can only emit where it absorbs.
+    /// For `Vacuum`, returns `Vector::ZERO` (no emission).
+    ///
+    /// Formula: `L_e(λ) * (1 - e^(-σ_a(λ) * t))`, which saturates
+    /// to `L_e(λ)` in thick media.
+    pub fn emission<const N: usize>(
+        &self,
+        hw: &HeroWavelengths<N>,
+        distance: f64,
+    ) -> Vector<N> {
+        match self {
+            Medium::Vacuum => Vector::ZERO,
+            Medium::Homogeneous {
+                attenuation_distance,
+                transmittance,
+                emittance,
+            } => {
+                let mut out = Vector::<N>::ZERO;
+                let inv_d0 = 1.0 / attenuation_distance;
+                for (i, &lambda) in hw.iter().enumerate() {
+                    let c = transmittance.sample_wavelength(lambda);
+                    let tr = (distance * inv_d0 * c.ln()).exp();
+                    let le = emittance.sample_wavelength(lambda);
+                    out[i] = le * (1.0 - tr);
+                }
+                out
+            }
+        }
+    }
+
+    /// Return the transmittance at a specific wavelength.
+    /// For `Vacuum`, returns 1.0 (fully transparent).
+    pub fn transmittance_at(&self, wavelength_nm: f64) -> f64 {
+        match self {
+            Medium::Vacuum => 1.0,
+            Medium::Homogeneous {
+                transmittance, ..
+            } => transmittance.sample_wavelength(wavelength_nm),
+        }
+    }
+}

--- a/ui/src/hooks/useRenderForm.ts
+++ b/ui/src/hooks/useRenderForm.ts
@@ -15,8 +15,9 @@ function loadRenderDraft(): NormalizedRenderConfig | undefined {
     }
 
     const parsed = JSON.parse(raw);
-    const { data, success } = RenderConfigSchema.safeParse(parsed);
+    const { data, success, error } = RenderConfigSchema.safeParse(parsed);
     if (!success) {
+      console.warn('Render draft validation failed, falling back to default config', error);
       return undefined;
     }
     return data;

--- a/ui/src/utils/render/material.ts
+++ b/ui/src/utils/render/material.ts
@@ -119,7 +119,7 @@ export function defaultMaterialForType(type: MaterialData['type']): MaterialData
         reflectance_texture: '__white',
         emittance_texture: '__black',
         index_of_refraction: 1.5,
-        medium: { type: 'vacuum' },
+        medium_data: { type: 'vacuum' },
       };
     case 'lambertian':
       return {
@@ -142,7 +142,7 @@ export const MaterialDielectricSchema = z.object({
   reflectance_texture: z.string().nonempty(),
   emittance_texture: z.string().nonempty(),
   index_of_refraction: z.number().min(0),
-  medium: MediumDataSchema.optional(),
+  medium_data: MediumDataSchema.optional(),
 });
 
 export type MaterialDielectric = NormalizedMaterialDielectric;
@@ -197,7 +197,7 @@ export type NormalizedMaterialDielectric = Omit<
 > & {
   reflectance_texture: string;
   emittance_texture: string;
-  medium?: MediumData;
+  medium_data?: MediumData;
 };
 
 export type RawMaterialDielectric = {
@@ -205,7 +205,7 @@ export type RawMaterialDielectric = {
   reflectance_texture: string | RawTextureData;
   emittance_texture: string | RawTextureData;
   index_of_refraction: number;
-  medium?: MediumData;
+  medium_data?: MediumData;
 };
 
 export const MaterialLambertianSchema = z.object({

--- a/ui/src/utils/render/material.ts
+++ b/ui/src/utils/render/material.ts
@@ -3,6 +3,25 @@ import { normalizeTextureData, type RawTextureData } from './texture';
 import { getNextUniqueName, isTypedObject } from './utils';
 import { z } from 'zod';
 
+export type MediumData =
+  | { type: 'vacuum' }
+  | {
+      type: 'homogeneous';
+      attenuation_distance: number;
+      transmittance: [number, number, number];
+      emittance: [number, number, number];
+    };
+
+const MediumDataSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('vacuum') }),
+  z.object({
+    type: z.literal('homogeneous'),
+    attenuation_distance: z.number().positive(),
+    transmittance: z.tuple([z.number(), z.number(), z.number()]),
+    emittance: z.tuple([z.number(), z.number(), z.number()]),
+  }),
+]);
+
 export type MaterialData = NormalizedMaterialData;
 
 export function normalizeMaterialData(
@@ -100,6 +119,7 @@ export function defaultMaterialForType(type: MaterialData['type']): MaterialData
         reflectance_texture: '__white',
         emittance_texture: '__black',
         index_of_refraction: 1.5,
+        medium: { type: 'vacuum' },
       };
     case 'lambertian':
       return {
@@ -122,6 +142,7 @@ export const MaterialDielectricSchema = z.object({
   reflectance_texture: z.string().nonempty(),
   emittance_texture: z.string().nonempty(),
   index_of_refraction: z.number().min(0),
+  medium: MediumDataSchema.optional(),
 });
 
 export type MaterialDielectric = NormalizedMaterialDielectric;
@@ -167,7 +188,7 @@ function normalizeMaterialDielectric(
     material.emittance_texture = textureName;
   }
 
-  return material as NormalizedMaterialDielectric;
+  return material as unknown as NormalizedMaterialDielectric;
 }
 
 export type NormalizedMaterialDielectric = Omit<
@@ -176,6 +197,7 @@ export type NormalizedMaterialDielectric = Omit<
 > & {
   reflectance_texture: string;
   emittance_texture: string;
+  medium?: MediumData;
 };
 
 export type RawMaterialDielectric = {
@@ -183,6 +205,7 @@ export type RawMaterialDielectric = {
   reflectance_texture: string | RawTextureData;
   emittance_texture: string | RawTextureData;
   index_of_refraction: number;
+  medium?: MediumData;
 };
 
 export const MaterialLambertianSchema = z.object({

--- a/ui/src/utils/render/material.ts
+++ b/ui/src/utils/render/material.ts
@@ -188,6 +188,11 @@ function normalizeMaterialDielectric(
     material.emittance_texture = textureName;
   }
 
+  // strip null from medium_data — the backend serializes None as null
+  if (material.medium_data === null) {
+    material.medium_data = undefined;
+  }
+
   return material as unknown as NormalizedMaterialDielectric;
 }
 

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -225,7 +225,7 @@ export function getCornellBoxGlassSpheresRenderConfig(): NormalizedRenderConfig 
         reflectance_texture: 'White',
         emittance_texture: 'Black',
         index_of_refraction: 1.5,
-        medium: { type: 'vacuum' },
+        medium_data: { type: 'vacuum' },
       },
       ...base.materials,
     },

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -225,6 +225,7 @@ export function getCornellBoxGlassSpheresRenderConfig(): NormalizedRenderConfig 
         reflectance_texture: 'White',
         emittance_texture: 'Black',
         index_of_refraction: 1.5,
+        medium: { type: 'vacuum' },
       },
       ...base.materials,
     },

--- a/ui/src/views/renders/new/Controls/tabs/MaterialControls/MaterialRow.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/MaterialControls/MaterialRow.tsx
@@ -8,6 +8,7 @@ import { WarningIconOrphanGeometric } from '../../shared/icons/WarningIconOrphan
 import { InfoIconDefaultResource } from '../../shared/icons/InfoIconDefaultResource';
 import { DuplicateDropdown } from '../../shared/DuplicateDropdown';
 import { duplicateMaterial } from '@/utils/render/utils';
+import { MediumControls } from './MediumControls';
 
 export type MaterialRowProps = {
   form: RenderForm;
@@ -92,6 +93,7 @@ export function MaterialRow(props: MaterialRowProps) {
                 <field.RangeControl label="Index of Refraction" min={1.0} max={10.0} step={0.01} />
               )}
             </form.AppField>
+            <MediumControls form={form} materialName={name} />
             <TextureSelects name={name} />
           </>
         );

--- a/ui/src/views/renders/new/Controls/tabs/MaterialControls/MediumControls.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/MaterialControls/MediumControls.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { useSelector } from '@tanstack/react-store';
+import { ToggleSwitch } from 'flowbite-react';
+import { AnimatedSeparator } from '@/components/AnimatedSeparator';
+import { Separator } from '@/components/Separator';
+import { ExpandableSection } from '@/components/ExpandableSection';
+import { TextInputControl } from '@/components/form-controls/TextInputControl';
+import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
+import type { RenderForm, RenderFormPath } from '@/hooks/useRenderForm';
+import type { MediumData, NormalizedMaterialData } from '@/utils/render/material';
+
+export type MediumControlsProps = {
+  form: RenderForm;
+  materialName: string;
+};
+
+const DEFAULT_MEDIUM: MediumData = { type: 'vacuum' };
+
+export function MediumControls(props: MediumControlsProps) {
+  const { form, materialName } = props;
+
+  const basePath = `materials.${materialName}.medium_data`;
+
+  const renderConfig = useSelector(form.store, (state) => state.values);
+  const material = renderConfig.materials?.[materialName];
+  const medium: MediumData | undefined =
+    material?.type === 'dielectric' ? material.medium_data : undefined;
+
+  const [mediumLocal, setMediumLocal] = useState<MediumData>(medium ?? DEFAULT_MEDIUM);
+
+  const hasInteriorMedium = medium !== undefined;
+  const isHomogeneous = medium?.type === 'homogeneous';
+
+  function setMedium(value: MediumData | undefined) {
+    const materials: Record<string, NormalizedMaterialData> = {
+      ...(renderConfig.materials ?? {}),
+    };
+    materials[materialName] = {
+      ...material,
+      medium_data: value,
+    } as NormalizedMaterialData;
+    form.setFieldValue('materials', materials);
+  }
+
+  function handleToggle(checked: boolean) {
+    if (checked) {
+      setMedium(mediumLocal);
+    } else {
+      setMediumLocal(medium ?? DEFAULT_MEDIUM);
+      setMedium(undefined);
+    }
+  }
+
+  function handleTypeChange(newType: string) {
+    // replace the entire medium object to ensure the discriminated union
+    // is valid — changing only the type would leave missing fields for
+    // the new variant.
+    if (newType === 'homogeneous') {
+      const prev = medium;
+      setMedium({
+        type: 'homogeneous',
+        attenuation_distance: prev?.type === 'homogeneous' ? prev.attenuation_distance : 1.0,
+        transmittance:
+          prev?.type === 'homogeneous'
+            ? (prev.transmittance as [number, number, number])
+            : // tS infers number[]; Zod requires 3-element tuple
+              ([1, 1, 1] as [number, number, number]),
+        emittance:
+          prev?.type === 'homogeneous'
+            ? (prev.emittance as [number, number, number])
+            : // tS infers number[]; Zod requires 3-element tuple
+              ([0, 0, 0] as [number, number, number]),
+      });
+    } else {
+      setMedium({ type: 'vacuum' });
+    }
+  }
+
+  return (
+    <>
+      <AnimatedSeparator visible={hasInteriorMedium} />
+      <div className="flex w-full items-center justify-between py-2">
+        <h6 className="overflow-hidden font-normal">Has Interior Medium?</h6>
+        <ToggleSwitch checked={hasInteriorMedium} onChange={handleToggle} />
+      </div>
+      <ExpandableSection expanded={hasInteriorMedium} onExpandEnd={() => form.validate('change')}>
+        <div className="flex flex-col gap-2 py-2">
+          <form.AppField
+            // template literal not inferable as DeepKeys
+            name={`${basePath}.type` as RenderFormPath}
+          >
+            {(field) => (
+              <field.SelectControl
+                label="Type"
+                items={[
+                  { label: 'Vacuum', value: 'vacuum' },
+                  { label: 'Homogeneous', value: 'homogeneous' },
+                ]}
+                onChange={(value) => handleTypeChange(value)}
+              />
+            )}
+          </form.AppField>
+          {isHomogeneous && (
+            <>
+              <TextArrayInputControl
+                form={form}
+                // template literal not inferable as DeepKeys
+                fieldName={`${basePath}.transmittance` as RenderFormPath}
+                label="Transmittance"
+                valueLabels={['r', 'g', 'b']}
+                type="number"
+                unenforcedStep={0.01}
+              />
+              <TextInputControl
+                form={form}
+                // template literal not inferable as DeepKeys
+                fieldName={`${basePath}.attenuation_distance` as RenderFormPath}
+                label="Attenuation Distance"
+                labelSpacePercentage={60}
+                type="number"
+                valueLabel="units"
+              />
+              <TextArrayInputControl
+                form={form}
+                // template literal not inferable as DeepKeys
+                fieldName={`${basePath}.emittance` as RenderFormPath}
+                label="Emittance"
+                valueLabels={['r', 'g', 'b']}
+                type="number"
+                unenforcedStep={0.01}
+              />
+            </>
+          )}
+        </div>
+      </ExpandableSection>
+      <Separator />
+    </>
+  );
+}

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -28,17 +28,29 @@ export function MaterialResolver(props: MaterialResolverProps) {
       const ior = materialData.index_of_refraction || 1.5;
       switch (reflectanceTexture.type) {
         case 'color': {
+          const mediumData = materialData.medium_data;
+          const hasHomogeneousMedium = mediumData?.type === 'homogeneous';
           return (
             <MeshTransmissionMaterial
               attach="material"
               color={reflectanceTexture.color}
-              thickness={0.5}
+              thickness={mediumData ? 0.5 : 0}
               transmission={1.0}
               ior={ior}
               roughness={0}
               side={side}
               shadowSide={shadowSide}
-              {...(emissiveColor ? { emissive: emissiveColor } : {})}
+              {...(hasHomogeneousMedium
+                ? {
+                    attenuationColor: mediumData.transmittance,
+                    attenuationDistance: mediumData.attenuation_distance,
+                    emissive:
+                      mediumData.emittance.reduce((a, b) => a + b, 0) > 0
+                        ? mediumData.emittance
+                        : undefined,
+                  }
+                : {})}
+              {...(!hasHomogeneousMedium && emissiveColor ? { emissive: emissiveColor } : {})}
             />
           );
         }
@@ -47,15 +59,28 @@ export function MaterialResolver(props: MaterialResolverProps) {
           console.warn(
             `${reflectanceTexture.type} texture not yet supported for dielectric material`,
           );
+          const mediumData = materialData.medium_data;
+          const hasHomogeneousMedium = mediumData?.type === 'homogeneous';
           return (
             <MeshTransmissionMaterial
               attach="material"
               color={[1, 1, 1]}
+              thickness={mediumData ? 0.5 : 0}
               transmission={1.0}
               ior={ior}
               roughness={0}
               side={side}
               shadowSide={shadowSide}
+              {...(hasHomogeneousMedium
+                ? {
+                    attenuationColor: mediumData.transmittance,
+                    attenuationDistance: mediumData.attenuation_distance,
+                    emissive:
+                      mediumData.emittance.reduce((a, b) => a + b, 0) > 0
+                        ? mediumData.emittance
+                        : undefined,
+                  }
+                : {})}
             />
           );
         }


### PR DESCRIPTION
## Summary

Adds physical volume absorption (Beer-Lambert), volume emission (coupled Kirchhoff), and a thin-walled slab BSDF to dielectric materials. Replaces the old hardcoded clear-glass behavior with a configurable interior medium system.

### Backend

- **New `src/shading/medium.rs`** — `Medium` enum (Vacuum | Homogeneous) with `transmittance`, `atttenuation_distance`, and `emittance` fields. Provides `transmittance()` and `emission()` per segment via `ColorSpectrum<8>` with Smits upsampling from RGB.
- **`dielectric.rs`** — `Dielectric` struct gains `medium: Option<Medium>`. `None` = thin-walled (straight-through, no refraction). `Some(Medium)` = volumetric with IOR refraction + medium tracking.
- **`camera.rs`** — Per-segment Beer-Lambert attenuation and Kirchhoff emission. Medium stack for future nested dielectric support.
- **`ray.rs`** — `Ray` gains `current_medium: Medium` field (Copy enum, no allocation).
- **Fresnel fix** — `refract_at` corrected from double-applying `(1-R)` on transmission to returning `1.0` both sides.
- **Deserialization** — `MediumData` with RGB-to-spectral Smits upsampling. Validation rejects `attenuation_distance <= 0`.

### Frontend

- **New `MediumControls.tsx`** — Toggle "Has Interior Medium?" with type selector (Vacuum/Homogeneous) and per-channel transmittance/distance/emittance inputs.
- **`MaterialRow.tsx`** — Integrated into dielectric case.
- **`MaterialResolver.tsx`** — 3D preview wired to `attenuationColor`/`attenuationDistance`/`emissive` on MeshTransmissionMaterial.
- **`material.ts`** — `medium_data` field on dielectric types, Zod schema with `.positive()` guard.