### PR TITLE
FEAT: Add Cylinder primitive with positional two-endpoint design

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -294,7 +294,7 @@ impl Camera {
 
                     let (incident_direction, index_of_strategy) = pdf.sample();
 
-                    let cos_theta = ray_hit.normal.dot(incident_direction).max(0.0);
+                    let cos_theta = ray_hit.normal.dot(incident_direction).abs();
                     let brdf_val = ray_hit.material.brdf(
                         outgoing_direction,
                         incident_direction,

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -235,6 +235,7 @@ fn get_geometric_dependencies(geometric: &GeometricData) -> Vec<String> {
         | GeometricData::PrimitivePlane { .. }
         | GeometricData::PrimitiveSphere { .. }
         | GeometricData::PrimitiveBilinearPatch { .. }
+        | GeometricData::PrimitiveCylinder { .. }
         | GeometricData::PrimitiveTriangle { .. } => {}
     }
     deps

--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -7,7 +7,9 @@ use crate::{
         Geometric, Vector3,
         compounds::{AxisAlignedPBox, Bvh, List, ModelObj, Virtual},
         instances::{RotateXAxis, RotateYAxis, RotateZAxis, Scale, Translate},
-        primitives::{BilinearPatch, Disk, Parallelogram, Plane, Sphere, Triangle},
+        primitives::{
+            BilinearPatch, Cylinder, CylinderEnd, Disk, Parallelogram, Plane, Sphere, Triangle,
+        },
         volumes,
     },
     utils::{Angle, Around},
@@ -151,6 +153,15 @@ pub enum GeometricData {
         inner_radius: Option<f64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         is_culled: Option<bool>,
+        material: MaterialRefOrInline,
+    },
+    #[serde(rename = "cylinder")]
+    PrimitiveCylinder {
+        a: [f64; 3],
+        a_end: CylinderEnd,
+        b: [f64; 3],
+        b_end: CylinderEnd,
+        radius: f64,
         material: MaterialRefOrInline,
     },
     #[serde(rename = "constant_volume")]
@@ -372,6 +383,25 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
                     *radius,
                     (*inner_radius).unwrap_or(0.0),
                     (*is_culled).unwrap_or(false),
+                    material,
+                )?))
+            }
+            Self::PrimitiveCylinder {
+                a,
+                a_end,
+                b,
+                b_end,
+                radius,
+                material,
+            } => {
+                let material = material.build(builts)?;
+
+                Ok(Arc::new(Cylinder::new(
+                    (*a).into(),
+                    *a_end,
+                    (*b).into(),
+                    *b_end,
+                    *radius,
                     material,
                 )?))
             }

--- a/src/geometry/primitives.rs
+++ b/src/geometry/primitives.rs
@@ -15,3 +15,7 @@ pub use disk::Disk;
 
 mod bilinear_patch;
 pub use bilinear_patch::BilinearPatch;
+
+mod cylinder;
+pub use cylinder::Cylinder;
+pub use cylinder::CylinderEnd;

--- a/src/geometry/primitives/bilinear_patch.rs
+++ b/src/geometry/primitives/bilinear_patch.rs
@@ -152,13 +152,7 @@ impl Geometric for BilinearPatch {
             // compute normal from partial derivatives at (u, v)
             let dp_du = (1.0 - v) * self.e00_10 + v * self.e01_11;
             let dp_dv = (1.0 - u) * self.e00_01 + u * self.e10_11;
-            let mut normal = dp_du.cross(dp_dv).unit_vector();
-
-            // always face the incoming ray (always double-sided)
-            let dot_ray_normal = ray.direction.dot(normal);
-            if dot_ray_normal > 0.0 {
-                normal = -normal;
-            }
+            let normal = dp_du.cross(dp_dv).unit_vector();
 
             // evaluate hit point via the bilinear function for numerical consistency
             let point = self.point_at(u, v);

--- a/src/geometry/primitives/cylinder.rs
+++ b/src/geometry/primitives/cylinder.rs
@@ -1,0 +1,330 @@
+use std::f64::consts::TAU;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    geometry::{Aabb, Geometric, Onb, Point, Ray, RayHit, Vector3, primitives::Disk},
+    shading::materials::Material,
+    utils::{Interval, solve_quadratic},
+};
+
+/// Describes what happens at one end of a cylinder.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CylinderEnd {
+    /// Cylinder stops here, end-cap disk present.
+    Capped,
+    /// Cylinder stops here, no cap (open tube end).
+    Open,
+    /// Cylinder extends past this point forever along the axis.
+    Infinite,
+}
+
+/// A positionable cylinder defined by two endpoints and an orthonormal
+/// basis (ONB) that orients the axis from `a` to `b`.
+///
+/// Each end can be independently capped, open, or infinite.  When both
+/// ends are finite the cylinder is fully bounded; if either end is
+/// `Infinite` the lateral surface extends without bound in that direction.
+#[derive(Clone, Debug)]
+pub struct Cylinder {
+    a: Point,
+    a_end: CylinderEnd,
+    b: Point,
+    b_end: CylinderEnd,
+    radius: f64,
+    material: Arc<dyn Material>,
+    // precomputed
+    axis: Vector3,
+    height: f64,
+    onb: Onb,
+    bounding_box: Aabb,
+    a_cap: Option<Disk>,
+    b_cap: Option<Disk>,
+    lateral_area: f64,
+}
+
+impl Cylinder {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        a: Point,
+        a_end: CylinderEnd,
+        b: Point,
+        b_end: CylinderEnd,
+        radius: f64,
+        material: Arc<dyn Material>,
+    ) -> Result<Self, String> {
+        if radius <= 0.0 {
+            return Err("cylinder radius must be positive".to_string());
+        }
+        let delta = a.to(b);
+        if delta.squared_length() <= 1e-12 {
+            return Err("cylinder endpoints must be distinct".to_string());
+        }
+
+        let axis = delta.unit_vector();
+        let height = delta.length();
+        let onb = Onb::from_w(axis);
+
+        // bounding box
+        let bounding_box = {
+            let ru = onb.u * radius;
+            let rv = onb.v * radius;
+            let offsets = [ru + rv, ru - rv, -ru + rv, -ru - rv];
+            // collect 8 corner points: a ± r*u ± r*v and b ± r*u ± r*v
+            let mut points = Vec::with_capacity(8);
+            for &offset in &offsets {
+                points.push(a + offset);
+                points.push(b + offset);
+            }
+            let finite_aabb = Aabb::from_points(&points).pad(0.0001);
+
+            if a_end == CylinderEnd::Infinite || b_end == CylinderEnd::Infinite {
+                // for axes where the cylinder axis has a component, expand to UNIVERSE
+                Aabb::new(
+                    if axis.x.abs() > 1e-12 {
+                        Interval::UNIVERSE
+                    } else {
+                        finite_aabb.x_interval
+                    },
+                    if axis.y.abs() > 1e-12 {
+                        Interval::UNIVERSE
+                    } else {
+                        finite_aabb.y_interval
+                    },
+                    if axis.z.abs() > 1e-12 {
+                        Interval::UNIVERSE
+                    } else {
+                        finite_aabb.z_interval
+                    },
+                )
+            } else {
+                finite_aabb
+            }
+        };
+
+        // cap disks (normals point inward, toward the cylinder interior)
+        let a_cap = if a_end == CylinderEnd::Capped {
+            Some(
+                Disk::new(a, -axis, radius, 0.0, false, Arc::clone(&material))
+                    .expect("cap disk parameters are valid"),
+            )
+        } else {
+            None
+        };
+        let b_cap = if b_end == CylinderEnd::Capped {
+            Some(
+                Disk::new(b, axis, radius, 0.0, false, Arc::clone(&material))
+                    .expect("cap disk parameters are valid"),
+            )
+        } else {
+            None
+        };
+
+        // lateral surface area (infinite when either end is unbounded)
+        let lateral_area = if a_end == CylinderEnd::Infinite || b_end == CylinderEnd::Infinite {
+            f64::INFINITY
+        } else {
+            radius * TAU * height
+        };
+
+        Ok(Self {
+            a,
+            a_end,
+            b,
+            b_end,
+            radius,
+            material,
+            axis,
+            height,
+            onb,
+            bounding_box,
+            a_cap,
+            b_cap,
+            lateral_area,
+        })
+    }
+}
+
+impl Geometric for Cylinder {
+    fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
+        let mut hit: Option<RayHit> = None;
+
+        // transform ray to local ONB coordinates where the cylinder axis
+        // is the local Z axis, a is at z = 0, and b is at z = height
+        let delta = ray.origin - self.a;
+        let local_origin = Point::new(
+            delta.dot(self.onb.u),
+            delta.dot(self.onb.v),
+            delta.dot(self.onb.w),
+        );
+        let local_dir = Vector3::new(
+            ray.direction.dot(self.onb.u),
+            ray.direction.dot(self.onb.v),
+            ray.direction.dot(self.onb.w),
+        );
+
+        // lateral surface intersection (quadratic in local x, y)
+        let a_q = local_dir.x * local_dir.x + local_dir.y * local_dir.y;
+        if a_q > 1e-12 {
+            let b_q = 2.0 * (local_origin.0.x * local_dir.x + local_origin.0.y * local_dir.y);
+            let c_q = local_origin.0.x * local_origin.0.x + local_origin.0.y * local_origin.0.y
+                - self.radius * self.radius;
+
+            for t in solve_quadratic(a_q, b_q, c_q) {
+                if t < 1e-8 || !ray_t.contains_excluding(t) {
+                    continue;
+                }
+
+                let local_z = local_origin.0.z + t * local_dir.z;
+
+                // z-clip against cylinder extent
+                if self.a_end != CylinderEnd::Infinite && local_z < -1e-12 {
+                    continue;
+                }
+                if self.b_end != CylinderEnd::Infinite && local_z > self.height + 1e-12 {
+                    continue;
+                }
+
+                let lx = local_origin.0.x + t * local_dir.x;
+                let ly = local_origin.0.y + t * local_dir.y;
+
+                // normal in local space (radial direction in x-y plane)
+                let local_normal = Vector3::new(lx, ly, 0.0).unit_vector();
+                let world_normal = self.onb.to_world(local_normal);
+
+                // uv coordinates
+                let mut phi = ly.atan2(lx);
+                if phi < 0.0 {
+                    phi += TAU;
+                }
+                let u = phi / TAU;
+                let v =
+                    if self.a_end != CylinderEnd::Infinite && self.b_end != CylinderEnd::Infinite {
+                        local_z / self.height
+                    } else {
+                        0.0
+                    };
+
+                let point = ray.at(t);
+                if hit.is_none() || t < hit.as_ref().unwrap().t {
+                    hit = Some(RayHit {
+                        t,
+                        point,
+                        normal: world_normal,
+                        material: Arc::clone(&self.material),
+                        u,
+                        v,
+                    });
+                }
+            }
+        }
+
+        // cap intersections
+        for cap in [&self.a_cap, &self.b_cap] {
+            if let Some(disk) = cap {
+                if let Some(disk_hit) = disk.intersect(ray, ray_t) {
+                    if hit.is_none() || disk_hit.t < hit.as_ref().unwrap().t {
+                        hit = Some(disk_hit);
+                    }
+                }
+            }
+        }
+
+        hit
+    }
+
+    fn is_emissive(&self) -> bool {
+        self.material.is_emissive()
+    }
+
+    fn is_transmissive(&self) -> bool {
+        self.material.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.material.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+
+    fn bounding_box(&self) -> Aabb {
+        self.bounding_box
+    }
+
+    fn surface_area(&self) -> f64 {
+        if self.a_end == CylinderEnd::Infinite || self.b_end == CylinderEnd::Infinite {
+            return f64::INFINITY;
+        }
+
+        let mut area = self.lateral_area;
+        if let Some(ref cap) = self.a_cap {
+            area += cap.surface_area();
+        }
+        if let Some(ref cap) = self.b_cap {
+            area += cap.surface_area();
+        }
+        area
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
+        // infinite cylinders are excluded from the importance sampling system
+        // (direction_pdf returns 0.0, so MIS gives the geometric strategy zero
+        // weight). a direction must still be returned for the mixture PDF, but
+        // computing an accurate sample is not worth the effort — the geometric
+        // strategy contributes nothing regardless.
+        if self.a_end == CylinderEnd::Infinite || self.b_end == CylinderEnd::Infinite {
+            return Vector3::random_unit();
+        }
+
+        let area = self.surface_area();
+        let r = rand::random::<f64>() * area;
+
+        // sample lateral surface
+        if r < self.lateral_area {
+            let z = rand::random::<f64>() * self.height;
+            let phi = rand::random::<f64>() * TAU;
+            let point_on_surface = self.a
+                + self.onb.u * (self.radius * phi.cos())
+                + self.onb.v * (self.radius * phi.sin())
+                + self.onb.w * z;
+            return origin.to(point_on_surface).unit_vector();
+        }
+
+        // sample caps if they exist
+        if let Some(ref cap) = self.a_cap {
+            let cap_area = cap.surface_area();
+            if r < self.lateral_area + cap_area {
+                return cap.sample_direction_from(origin);
+            }
+        }
+        if let Some(ref cap) = self.b_cap {
+            return cap.sample_direction_from(origin);
+        }
+
+        // fallback (should not reach here when area > 0)
+        Vector3::random_unit()
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
+        if self.a_end == CylinderEnd::Infinite || self.b_end == CylinderEnd::Infinite {
+            return 0.0;
+        }
+
+        let ray = Ray::new(origin, dir, 0.0);
+        let Some(hit) = self.intersect(ray, Interval::UNIVERSE) else {
+            return 0.0;
+        };
+
+        let cos_theta = dir.dot(hit.normal).abs();
+        if cos_theta < 1e-8 {
+            return 0.0;
+        }
+
+        let area = self.surface_area();
+        (hit.t * hit.t) / (cos_theta * area)
+    }
+}

--- a/src/geometry/primitives/cylinder.rs
+++ b/src/geometry/primitives/cylinder.rs
@@ -31,12 +31,11 @@ pub enum CylinderEnd {
 pub struct Cylinder {
     a: Point,
     a_end: CylinderEnd,
-    b: Point,
     b_end: CylinderEnd,
     radius: f64,
     material: Arc<dyn Material>,
+
     // precomputed
-    axis: Vector3,
     height: f64,
     onb: Onb,
     bounding_box: Aabb,
@@ -132,11 +131,9 @@ impl Cylinder {
         Ok(Self {
             a,
             a_end,
-            b,
             b_end,
             radius,
             material,
-            axis,
             height,
             onb,
             bounding_box,
@@ -222,13 +219,11 @@ impl Geometric for Cylinder {
         }
 
         // cap intersections
-        for cap in [&self.a_cap, &self.b_cap] {
-            if let Some(disk) = cap {
-                if let Some(disk_hit) = disk.intersect(ray, ray_t) {
-                    if hit.is_none() || disk_hit.t < hit.as_ref().unwrap().t {
-                        hit = Some(disk_hit);
-                    }
-                }
+        for disk in [&self.a_cap, &self.b_cap].into_iter().flatten() {
+            if let Some(disk_hit) = disk.intersect(ray, ray_t)
+                && (hit.is_none() || disk_hit.t < hit.as_ref().unwrap().t)
+            {
+                hit = Some(disk_hit);
             }
         }
 

--- a/src/geometry/primitives/disk.rs
+++ b/src/geometry/primitives/disk.rs
@@ -137,17 +137,10 @@ impl Geometric for Disk {
         let d = d_sq.sqrt();
         let v = (self.radius - d) / (self.radius - self.inner_radius);
 
-        // invert the normal if we are not culled and the ray hits the back side
-        let local_normal = if !self.is_culled && denominator > 0.0 {
-            -self.normal
-        } else {
-            self.normal
-        };
-
         Some(RayHit {
             t,
             point: hit_point,
-            normal: local_normal,
+            normal: self.normal,
             material: Arc::clone(&self.material),
             u,
             v,
@@ -287,7 +280,7 @@ mod tests {
         assert!(opt_hit.is_some());
         let hit = opt_hit.unwrap();
 
-        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, -1.0));
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, 1.0));
         assert_eq!(hit.point, Point::new(0.0, 0.0, 0.0));
         assert_eq!(hit.t, 1.0);
     }

--- a/src/geometry/primitives/parallelogram.rs
+++ b/src/geometry/primitives/parallelogram.rs
@@ -90,17 +90,10 @@ impl Geometric for Parallelogram {
         let u = alpha;
         let v = beta;
 
-        // invert the normal if we are are not culled and the ray hits the back side
-        let local_normal = if !self.is_culled && denominator > 0.0 {
-            -self.normal
-        } else {
-            self.normal
-        };
-
         Some(RayHit {
             t,
             point,
-            normal: local_normal,
+            normal: self.normal,
             material: Arc::clone(&self.material),
             u,
             v,
@@ -207,7 +200,7 @@ mod tests {
         assert!(opt_hit.is_some());
         let hit = opt_hit.unwrap();
 
-        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, -1.0));
+        assert_eq!(hit.normal, Vector3::new(0.0, 0.0, 1.0));
         assert_eq!(hit.u, 0.5);
         assert_eq!(hit.v, 0.5);
         assert_eq!(hit.point, Point::new(0.5, 0.5, 0.0));

--- a/src/geometry/primitives/plane.rs
+++ b/src/geometry/primitives/plane.rs
@@ -74,13 +74,6 @@ impl Geometric for Plane {
 
         let hit_point = ray.at(t);
 
-        // invert the normal if we are not culled and the ray hits the back side
-        let local_normal = if !self.is_culled && denominator > 0.0 {
-            -self.normal
-        } else {
-            self.normal
-        };
-
         // unbounded UV coordinates — plane extends infinitely
         let u = (hit_point - self.point).dot(self.onb.u);
         let v = (hit_point - self.point).dot(self.onb.v);
@@ -88,7 +81,7 @@ impl Geometric for Plane {
         Some(RayHit {
             t,
             point: hit_point,
-            normal: local_normal,
+            normal: self.normal,
             material: Arc::clone(&self.material),
             u,
             v,

--- a/src/geometry/primitives/triangle.rs
+++ b/src/geometry/primitives/triangle.rs
@@ -129,13 +129,6 @@ impl Triangle {
         // find normal for the specific point on the triangle we hit
         let local_normal = self.normal_at(barycentric_alpha, barycentric_beta, barycentric_gamma);
 
-        // invert the normal if we are are not culled and the ray hits the back side
-        let local_normal = if !self.is_culled && determinant < 0.0 {
-            -local_normal
-        } else {
-            local_normal
-        };
-
         Some(RayHit {
             t,
             point: ray.at(t),

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -65,13 +65,16 @@ impl Material for Lambertian {
 
     fn scatter(
         &self,
-        _ray: Ray,
+        ray: Ray,
         ray_hit: &RayHit,
         _hw: &HeroWavelengths<HERO_WAVELENGTH_COUNT>,
     ) -> Option<ScatterRecord> {
-        Some(ScatterRecord::Pdf(Pdf::CosineHemisphere(Onb::from_w(
-            ray_hit.normal,
-        ))))
+        let ns = if ray.direction.dot(ray_hit.normal) > 0.0 {
+            -ray_hit.normal
+        } else {
+            ray_hit.normal
+        };
+        Some(ScatterRecord::Pdf(Pdf::CosineHemisphere(Onb::from_w(ns))))
     }
 
     fn brdf(

--- a/src/shading/materials/specular.rs
+++ b/src/shading/materials/specular.rs
@@ -78,7 +78,14 @@ impl Material for Specular {
             ray.current_medium,
         );
 
-        if scattered.direction.dot(ray_hit.normal) > 0.0 {
+        // validate the roughened ray stays on the reflection side
+        let ns = if ray.direction.dot(ray_hit.normal) > 0.0 {
+            -ray_hit.normal
+        } else {
+            ray_hit.normal
+        };
+
+        if scattered.direction.dot(ns) > 0.0 {
             Some(ScatterRecord::Delta { scattered })
         } else {
             None

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -56,6 +56,8 @@ export function normalizeGeometricData(
       return normalizeGeometricDisk(config, name, geometricData);
     case 'bilinear_patch':
       return normalizeGeometricBilinearPatch(config, name, geometricData);
+    case 'cylinder':
+      return normalizeGeometricCylinder(config, name, geometricData);
   }
 }
 
@@ -73,7 +75,8 @@ export type NormalizedGeometricData =
   | NormalizedGeometricConstantVolume
   | NormalizedGeometricVirtual
   | NormalizedGeometricDisk
-  | NormalizedGeometricBilinearPatch;
+  | NormalizedGeometricBilinearPatch
+  | NormalizedGeometricCylinder;
 
 export type RawGeometricData =
   | RawGeometricBox
@@ -89,7 +92,8 @@ export type RawGeometricData =
   | RawGeometricConstantVolume
   | RawGeometricVirtual
   | RawGeometricDisk
-  | RawGeometricBilinearPatch;
+  | RawGeometricBilinearPatch
+  | RawGeometricCylinder;
 
 export function isGeometricData(data: unknown): data is GeometricData {
   return (
@@ -109,6 +113,7 @@ export function isGeometricData(data: unknown): data is GeometricData {
       'triangle',
       'disk',
       'bilinear_patch',
+      'cylinder',
       'constant_volume',
       'virtual',
     ].includes(data.type)
@@ -141,6 +146,7 @@ export function getReferencedMaterialNames(
   const materials: string[] = [];
   switch (data.type) {
     case 'box':
+    case 'cylinder':
     case 'disk':
     case 'bilinear_patch':
     case 'obj_model':
@@ -301,6 +307,12 @@ export function getCenterPoint(
       ];
     case 'disk':
       return data.center;
+    case 'cylinder':
+      return [
+        (data.a[0] + data.b[0]) / 2,
+        (data.a[1] + data.b[1]) / 2,
+        (data.a[2] + data.b[2]) / 2,
+      ];
     case 'bilinear_patch':
       return [
         (data.p00[0] + data.p10[0] + data.p01[0] + data.p11[0]) / 4,
@@ -492,6 +504,16 @@ export function defaultGeometricForType(
         p10: [0.5, 0, -0.5],
         p01: [-0.5, 0, 0.5],
         p11: [0.5, 0, 0.5],
+        material: '__lambertian_white',
+      };
+    case 'cylinder':
+      return {
+        type: 'cylinder',
+        a: [0, 0, 0],
+        a_end: 'capped',
+        b: [0, 1, 0],
+        b_end: 'capped',
+        radius: 1,
         material: '__lambertian_white',
       };
   }
@@ -1205,6 +1227,70 @@ export type RawGeometricBilinearPatch = {
   material: string | RawMaterialData;
 };
 
+const CylinderEndSchema = z.enum(['capped', 'open', 'infinite']);
+
+export const GeometricCylinderSchema = z
+  .object({
+    type: z.literal('cylinder'),
+    a: z.tuple([z.number(), z.number(), z.number()]),
+    a_end: CylinderEndSchema,
+    b: z.tuple([z.number(), z.number(), z.number()]),
+    b_end: CylinderEndSchema,
+    radius: z.number().positive(),
+    material: z.string().nonempty(),
+  })
+  .refine(
+    (data) => {
+      const dx = data.b[0] - data.a[0];
+      const dy = data.b[1] - data.a[1];
+      const dz = data.b[2] - data.a[2];
+      return dx * dx + dy * dy + dz * dz > 1e-12;
+    },
+    {
+      message: 'Points a and b must be different',
+    },
+  );
+
+export type GeometricCylinder = NormalizedGeometricCylinder;
+
+export function normalizeGeometricCylinder(
+  config: RenderConfig,
+  name: string,
+  geometricData: RawGeometricCylinder,
+): NormalizedGeometricCylinder {
+  const geometric = geometricData;
+
+  if (typeof geometric.material !== 'string') {
+    if (!config.materials) {
+      config.materials = {};
+    }
+
+    const materialName = getNextUniqueName(config.materials, `${name}_${geometric.material.type}`);
+    config.materials[materialName] = normalizeMaterialData(
+      config,
+      materialName,
+      geometric.material,
+    );
+    geometric.material = materialName;
+  }
+
+  return geometric as NormalizedGeometricCylinder;
+}
+
+export type NormalizedGeometricCylinder = Omit<RawGeometricCylinder, 'material'> & {
+  material: string;
+};
+
+export type RawGeometricCylinder = {
+  type: 'cylinder';
+  a: [number, number, number];
+  a_end: 'capped' | 'open' | 'infinite';
+  b: [number, number, number];
+  b_end: 'capped' | 'open' | 'infinite';
+  radius: number;
+  material: string | RawMaterialData;
+};
+
 const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   box: GeometricBoxSchema,
   list: GeometricListSchema,
@@ -1222,6 +1308,7 @@ const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   constant_volume: GeometricConstantVolumeSchema,
   virtual: GeometricVirtualSchema,
   bilinear_patch: GeometricBilinearPatchSchema,
+  cylinder: GeometricCylinderSchema,
 };
 
 export const GeometricDataSchema = z.any().superRefine((data, ctx) => {
@@ -1270,6 +1357,7 @@ export function wrapGeometric(
   const typeLabels: Record<string, string> = {
     box: 'Box',
     bilinear_patch: 'Bilinear Patch',
+    cylinder: 'Cylinder',
     sphere: 'Sphere',
     triangle: 'Triangle',
     parallelogram: 'Parallelogram',

--- a/ui/src/views/renders/new/Controls/index.tsx
+++ b/ui/src/views/renders/new/Controls/index.tsx
@@ -99,6 +99,12 @@ export function Controls(props: ControlsProps) {
                     'Doubly-ruled curved surface defined by four corner points - a hyperbolic paraboloid.',
                 },
                 {
+                  subtype: 'cylinder',
+                  label: 'Cylinder',
+                  description:
+                    'Cylinder aligned to Z axis with optional finite bounds, caps, and angular sector.',
+                },
+                {
                   subtype: 'list',
                   label: 'List',
                   description: 'A group of geometrics rendered together.',

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -203,6 +203,57 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <GeometricMaterialSelect form={form} name={name} items={materialItems} />
         </>
       );
+    case 'cylinder':
+      return (
+        <>
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.a`}
+            label="Endpoint A"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <form.AppField name={`geometrics.${name}.a_end`}>
+            {(field) => (
+              <field.SelectControl
+                label="End A"
+                items={[
+                  { label: 'Capped', value: 'capped' },
+                  { label: 'Open', value: 'open' },
+                  { label: 'Infinite', value: 'infinite' },
+                ]}
+              />
+            )}
+          </form.AppField>
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.b`}
+            label="Endpoint B"
+            valueLabels={['x', 'y', 'z']}
+            type="number"
+          />
+          <form.AppField name={`geometrics.${name}.b_end`}>
+            {(field) => (
+              <field.SelectControl
+                label="End B"
+                items={[
+                  { label: 'Capped', value: 'capped' },
+                  { label: 'Open', value: 'open' },
+                  { label: 'Infinite', value: 'infinite' },
+                ]}
+              />
+            )}
+          </form.AppField>
+          <TextInputControl
+            form={form}
+            fieldName={`geometrics.${name}.radius`}
+            label="Radius"
+            valueLabel="radius"
+            type="number"
+          />
+          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+        </>
+      );
     case 'bilinear_patch':
       return (
         <>

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -244,6 +244,77 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       );
     }
 
+    case 'cylinder': {
+      const aVec = new THREE.Vector3(data.a[0], data.a[1], data.a[2]);
+      const bVec = new THREE.Vector3(data.b[0], data.b[1], data.b[2]);
+      const axis = bVec.clone().sub(aVec).normalize();
+      const height = aVec.distanceTo(bVec);
+      const aInfinite = data.a_end === 'infinite';
+      const bInfinite = data.b_end === 'infinite';
+
+      let displayHeight: number;
+      let center: THREE.Vector3;
+
+      const infiniteProxyLength = 10_000;
+
+      if (aInfinite && bInfinite) {
+        // both infinite — center at midpoint, large proxy height
+        displayHeight = infiniteProxyLength;
+        center = aVec.clone().add(bVec).multiplyScalar(0.5);
+      } else if (aInfinite) {
+        // a is infinite, b is finite — extend from b toward a
+        displayHeight = infiniteProxyLength;
+        center = bVec.clone().addScaledVector(axis, -displayHeight / 2);
+      } else if (bInfinite) {
+        // b is infinite, a is finite — extend from a toward b
+        displayHeight = infiniteProxyLength;
+        center = aVec.clone().addScaledVector(axis, displayHeight / 2);
+      } else {
+        // both finite — use actual height and midpoint
+        displayHeight = height;
+        center = aVec.clone().add(bVec).multiplyScalar(0.5);
+      }
+
+      const isInfinite = aInfinite || bInfinite;
+
+      const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), axis);
+      const rot = new THREE.Euler().setFromQuaternion(quat);
+
+      // three.js CylinderGeometry uses a single openEnded boolean for both ends,
+      // so the preview approximates: if either end isn't capped, both lack caps.
+      const openEnded = data.a_end !== 'capped' || data.b_end !== 'capped';
+
+      const emissiveInfo = getEmissiveInfo(config, data.material);
+
+      return (
+        <>
+          <mesh
+            position={[center.x, center.y, center.z]}
+            rotation={[rot.x, rot.y, rot.z]}
+            frustumCulled={!isInfinite}
+            castShadow={!emissiveInfo}
+            receiveShadow
+          >
+            <cylinderGeometry args={[data.radius, data.radius, displayHeight, 64, 1, openEnded]} />
+            <MaterialResolver
+              config={config}
+              materialName={data.material}
+              side={THREE.DoubleSide}
+              shadowSide={THREE.BackSide}
+            />
+          </mesh>
+          {emissiveInfo && (
+            <pointLight
+              color={emissiveInfo.color}
+              intensity={emissiveInfo.intensity}
+              position={[center.x, center.y, center.z]}
+              castShadow
+            />
+          )}
+        </>
+      );
+    }
+
     case 'triangle': {
       const geom = createTriangleGeometry(data);
 


### PR DESCRIPTION
Closes #185

## Summary

Adds a `Cylinder` geometric primitive with positional two-endpoint design. Each endpoint is defined by a point and a `CylinderEnd` enum (`Capped` / `Open` / `Infinite`), matching the Box primitive's `a`/`b` convention.

### Cylinder primitive (`src/geometry/primitives/cylinder.rs`)
- Two points `a`/`b` define the axis, each with an independent `CylinderEnd` condition
- ONB-based local-coordinate intersection (ray transformed to local space, quadratic solved, result transformed back)
- Z-clipping per end condition (Capped/Open stop, Infinite doesn't)
- Pre-built cap disks at `Capped` endpoints
- Area-weighted sampling (lateral + caps)
- Infinite AABB for unbounded ends (Plane pattern)

### Deserialization
- JSON: `{ "type": "cylinder", "a": [0,0,0], "a_end": "capped", "b": [0,0,5], "b_end": "capped", "radius": 1.0, "material": "pipe" }`
- `CylinderEnd` serializes as lowercase `"capped"`/`"open"`/`"infinite"`

### Normal directionality fix (cross-cutting)
All primitives now return the unflipped geometric normal. Materials handle two-sidedness themselves:
- **Lambertian**: orients cosine hemisphere toward incoming ray
- **Specular**: validates roughened ray stays on the correct side using shading normal
- **Camera**: `cos_theta` uses `abs()` instead of `max(0.0)`

### UI
- Form: TextArrayInputs for a/b points, SelectControl dropdowns for end conditions, radius input, material select
- 3D preview: arbitrary-axis cylinder via quaternion rotation, ring geometry caps at `Capped` endpoints, asymmetric infinite extension

### Files changed
16 files, +601 / -49