### PR TITLE
chore: rename 'resource' to 'entity' for scene composition terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,18 +44,18 @@ Luxide is a **ray tracing render manager** — a multi-tenant platform where use
 
 ## 5. Development Commands
 
-| Command                         | Description                                                      |
-| ------------------------------- | ---------------------------------------------------------------- |
-| `just run`                      | Build and run via Docker Compose (API + PostgreSQL)              |
-| `just run-local`                | Build API + run PostgreSQL, then start API server locally        |
-| `just run-ui`                   | Start Docker services + Vite dev server on port 5173             |
-| `just run-postgres`             | Start PostgreSQL container + run migrations                      |
-| `just build`                    | Build UI + run migrations + build both Rust binaries (release)   |
-| `just build-api`                | Build UI + run migrations + build luxide-api (release)           |
-| `just build-cli`                | Build luxide-cli (release)                                       |
-| `just build-ui`                 | Setup Node env + build React UI                                  |
-| `just clean`                    | Cargo clean + remove ui/dist + stop Docker                       |
-| `just generate-jwt-keypair-pem` | Generate RSA keypair for JWT signing                             |
+| Command                         | Description                                                    |
+| ------------------------------- | -------------------------------------------------------------- |
+| `just run`                      | Build and run via Docker Compose (API + PostgreSQL)            |
+| `just run-local`                | Build API + run PostgreSQL, then start API server locally      |
+| `just run-ui`                   | Start Docker services + Vite dev server on port 5173           |
+| `just run-postgres`             | Start PostgreSQL container + run migrations                    |
+| `just build`                    | Build UI + run migrations + build both Rust binaries (release) |
+| `just build-api`                | Build UI + run migrations + build luxide-api (release)         |
+| `just build-cli`                | Build luxide-cli (release)                                     |
+| `just build-ui`                 | Setup Node env + build React UI                                |
+| `just clean`                    | Cargo clean + remove ui/dist + stop Docker                     |
+| `just generate-jwt-keypair-pem` | Generate RSA keypair for JWT signing                           |
 
 Note: The `just build-api` and `just run` commands embed the UI's `dist/` folder into the Rust binary at compile time via `include_dir!`. The API server serves the React SPA alongside the API routes.
 

--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ Luxide renders images via Monte Carlo path tracing — simulating how light boun
 ### Scene composition
 
 - **BVH** (Bounding Volume Hierarchy) — SAH-like construction, O(log n) intersection
-- **Named resource references** — define materials, textures, geometrics, and cameras once, reference them by name anywhere
+- **Named entity references** — define materials, textures, geometrics, and cameras once, reference them by name anywhere
 - **Transforms** — translate, rotate around X/Y/Z axes with configurable pivot points
 - **Volumes** — constant-density fog/smoke via an isotropic phase function (Henyey-Greenstein style)
-- **Built-in resource library** — preset Cornell Box components, materials, textures, and cameras with `__` prefix to avoid name collisions
+- **Built-in entity library** — preset Cornell Box components, materials, textures, and cameras with `__` prefix to avoid name collisions
 
 ### Config format
 
 - **JSON** config files with a declarative, composable structure
-- Resources defined in named dictionaries (`geometrics`, `materials`, `textures`, `cameras`, `scenes`)
-- Supports both inline definitions and named references for all resource types
+- Entities defined in named dictionaries (`geometrics`, `materials`, `textures`, `cameras`, `scenes`)
+- Supports both inline definitions and named references for all entity types
 - `active_scene` selects which scene to render and can mix references with inline overrides
 
 ### CLI
@@ -86,7 +86,7 @@ cargo build --release --bin luxide-cli
 
 ## Scene configuration
 
-Config files define a complete scene graph in JSON. Resources are declared in named dictionaries and wired together through references. Here's a minimal Cornell Box with a glass sphere:
+Config files define a complete scene graph in JSON. Entities are declared in named dictionaries and wired together through references. Here's a minimal Cornell Box with a glass sphere:
 
 ```json
 {
@@ -171,7 +171,7 @@ Config files define a complete scene graph in JSON. Resources are declared in na
 }
 ```
 
-The pattern is always the same: define your resources by name, then reference them. Inline definitions work anywhere a reference is accepted, keeping small experiments concise.
+The pattern is always the same: define your entities by name, then reference them. Inline definitions work anywhere a reference is accepted, keeping small experiments concise.
 
 ---
 

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -62,7 +62,7 @@ impl RenderConfigBuilder {
     }
 
     pub fn with_builtins(mut self) -> Self {
-        // builtin resources can be "overwritten" by user-defined resources
+        // builtin entities can be "overwritten" by user-defined entities
         // so we have to make sure that we add them last
         self.0.textures.append(&mut get_builtin_textures());
         self.0.materials.append(&mut get_builtin_materials());
@@ -174,7 +174,7 @@ fn build_textures(
 
     // Build all textures
     for name in texture_data.keys() {
-        build_resource_recursive(
+        build_entity_recursive(
             name,
             texture_data,
             builts,
@@ -258,7 +258,7 @@ fn build_geometrics(
 
     // Build all geometrics
     for name in geometric_data.keys() {
-        build_resource_recursive(
+        build_entity_recursive(
             name,
             geometric_data,
             builts,
@@ -275,21 +275,21 @@ fn build_geometrics(
 const MAX_RECURSION_DEPTH: usize = 100;
 
 #[allow(clippy::too_many_arguments)]
-fn build_resource_recursive<T>(
+fn build_entity_recursive<T>(
     name: &str,
-    resource_data: &IndexMap<String, T>,
+    entity_data: &IndexMap<String, T>,
     builts: &mut Builts,
     building: &mut std::collections::HashSet<String>,
     get_dependencies: impl Fn(&T) -> Vec<String> + Copy,
     build_and_insert: impl Fn(&str, &T, &mut Builts) -> Result<(), String> + Copy,
-    resource_type: &str,
+    entity_type: &str,
     depth: usize,
 ) -> Result<(), String> {
     // Check for maximum recursion depth
     if depth >= MAX_RECURSION_DEPTH {
         return Err(format!(
             "Maximum recursion depth ({}) exceeded while building {} '{}'. This may indicate a cyclic dependency.",
-            MAX_RECURSION_DEPTH, resource_type, name
+            MAX_RECURSION_DEPTH, entity_type, name
         ));
     }
 
@@ -297,35 +297,35 @@ fn build_resource_recursive<T>(
     if building.contains(name) {
         return Err(format!(
             "Cycle detected in {} dependencies involving {}",
-            resource_type, name
+            entity_type, name
         ));
     }
 
-    // Get the resource data
-    let resource = resource_data.get(name).ok_or(format!(
+    // Get the entity data
+    let entity = entity_data.get(name).ok_or(format!(
         "{} {} not found. Is it specified in the {} list?",
-        resource_type, name, resource_type
+        entity_type, name, entity_type
     ))?;
 
-    // Mark that we're building this resource
+    // Mark that we're building this entity
     building.insert(name.to_string());
 
-    // Build any referenced resources first
-    for dep_name in get_dependencies(resource) {
-        build_resource_recursive(
+    // Build any referenced entities first
+    for dep_name in get_dependencies(entity) {
+        build_entity_recursive(
             &dep_name,
-            resource_data,
+            entity_data,
             builts,
             building,
             get_dependencies,
             build_and_insert,
-            resource_type,
+            entity_type,
             depth + 1,
         )?
     }
 
-    // Now build this resource if it hasn't been built yet
-    build_and_insert(name, resource, builts)?;
+    // Now build this entity if it hasn't been built yet
+    build_and_insert(name, entity, builts)?;
     building.remove(name);
 
     Ok(())
@@ -355,10 +355,10 @@ fn build_scenes(
     Ok(())
 }
 
-const BUILT_IN_RESOURCE_PREFIX: &str = "__";
+const BUILT_IN_ENTITY_PREFIX: &str = "__";
 
 fn prefix_builtin_key(key: &str) -> String {
-    format!("{}{}", BUILT_IN_RESOURCE_PREFIX, key)
+    format!("{}{}", BUILT_IN_ENTITY_PREFIX, key)
 }
 
 fn get_builtin_textures() -> IndexMap<String, TextureData> {

--- a/ui/src/utils/render/config.ts
+++ b/ui/src/utils/render/config.ts
@@ -41,7 +41,7 @@ export const RenderConfigSchema = z.object({
 
 export type RenderConfig = RawRenderConfig | NormalizedRenderConfig;
 
-function removeDefaultResources(config: NormalizedRenderConfig): void {
+function removeDefaultEntities(config: NormalizedRenderConfig): void {
   const isNotDefault = (name: string) => !name.startsWith('__');
   config.scenes = filterRecord(config.scenes, isNotDefault);
   config.cameras = filterRecord(config.cameras, isNotDefault);
@@ -95,8 +95,8 @@ export function normalizeRenderConfig(config: RenderConfig): NormalizedRenderCon
     normalizeTextureData(renderConfig, textureName, texture);
   }
 
-  // pass 3: remove default fallback resources
-  removeDefaultResources(renderConfig as NormalizedRenderConfig);
+  // pass 3: remove default fallback entities
+  removeDefaultEntities(renderConfig as NormalizedRenderConfig);
 
   return renderConfig as NormalizedRenderConfig;
 }

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -54,7 +54,7 @@ export function getDefaultRenderConfig(): NormalizedRenderConfig {
 }
 
 export function getEmptyRenderConfig(): NormalizedRenderConfig {
-  return withDefaultResources({
+  return withDefaultEntities({
     name: 'Empty',
     parameters: {
       image_dimensions: [500, 500],
@@ -233,7 +233,7 @@ export function getCornellBoxGlassSpheresRenderConfig(): NormalizedRenderConfig 
 }
 
 export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
-  return withDefaultResources({
+  return withDefaultEntities({
     name: 'Cornell Box — Empty',
     parameters: {
       image_dimensions: [500, 500],
@@ -384,7 +384,7 @@ export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
   });
 }
 
-export function withDefaultResources(config: NormalizedRenderConfig): NormalizedRenderConfig {
+export function withDefaultEntities(config: NormalizedRenderConfig): NormalizedRenderConfig {
   return {
     ...config,
     geometrics: {

--- a/ui/src/views/renders/CreateRenderModal/ExistingRenderPicker.tsx
+++ b/ui/src/views/renders/CreateRenderModal/ExistingRenderPicker.tsx
@@ -3,7 +3,7 @@ import { Button, ModalHeader, ModalBody, ModalFooter, Spinner, Alert } from 'flo
 import { HiArrowLeft } from 'react-icons/hi2';
 import { useRendersQuery } from '@/hooks/useRenders';
 import { normalizeRenderConfig, type NormalizedRenderConfig } from '@/utils/render/config';
-import { withDefaultResources } from '@/utils/render/templates';
+import { withDefaultEntities } from '@/utils/render/templates';
 import {
   isRenderStateCreated,
   isRenderStateRunning,
@@ -49,9 +49,9 @@ export function ExistingRenderPicker(props: ExistingRenderPickerProps) {
   const handleUseConfig = () => {
     if (!selectedRender) return;
     const normalizedConfig = normalizeRenderConfig(selectedRender.config);
-    const configWithDefaults = withDefaultResources(normalizedConfig);
+    const configWithDefaults = withDefaultEntities(normalizedConfig);
 
-    // ensure default resources are present so new materials referencing __white/__black work correctly
+    // ensure default entities are present so new materials referencing __white/__black work correctly
     onSelect(configWithDefaults);
   };
 

--- a/ui/src/views/renders/CreateRenderModal/ImportConfigModal/ImportConfigBody.tsx
+++ b/ui/src/views/renders/CreateRenderModal/ImportConfigModal/ImportConfigBody.tsx
@@ -3,7 +3,7 @@ import { Button, ModalHeader, ModalBody, ModalFooter } from 'flowbite-react';
 import { HiFolderOpen } from 'react-icons/hi2';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { RenderConfigSchema, normalizeRenderConfig } from '@/utils/render/config';
-import { withDefaultResources } from '@/utils/render/templates';
+import { withDefaultEntities } from '@/utils/render/templates';
 import { RenderConfigEditor } from './RenderConfigEditor';
 
 export type ImportConfigBodyProps = {
@@ -42,8 +42,8 @@ export function ImportConfigBody(props: ImportConfigBodyProps) {
       const parsed = JSON.parse(jsonText);
       const normalized = normalizeRenderConfig(parsed);
 
-      // ensure default resources are present so new materials referencing __white/__black work correctly
-      const configWithDefaults = withDefaultResources(normalized);
+      // ensure default entities are present so new materials referencing __white/__black work correctly
+      const configWithDefaults = withDefaultEntities(normalized);
 
       const result = RenderConfigSchema.safeParse(configWithDefaults);
       if (!result.success) {

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderInfo/index.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderInfo/index.tsx
@@ -7,7 +7,7 @@ import { useRenderStatsQuery } from '@/hooks/useRenderStats';
 import { useNavigate } from 'react-router-dom';
 import { HiDocumentDuplicate } from 'react-icons/hi2';
 import { normalizeRenderConfig } from '@/utils/render/config';
-import { withDefaultResources } from '@/utils/render/templates';
+import { withDefaultEntities } from '@/utils/render/templates';
 import { saveRenderDraft } from '@/hooks/useRenderForm';
 
 /**
@@ -67,7 +67,7 @@ export function RenderInfo(props: RenderInfoProps) {
       return;
     }
     const normalizedConfig = normalizeRenderConfig(render.config);
-    const configWithDefaults = withDefaultResources(normalizedConfig);
+    const configWithDefaults = withDefaultEntities(normalizedConfig);
     const modifiedConfig = { ...configWithDefaults, name: `${configWithDefaults.name} (copy)` };
     saveRenderDraft(modifiedConfig);
     navigate('/renders/new', { replace: true });

--- a/ui/src/views/renders/new/Controls/shared/icons/InfoIconDefaultEntity.tsx
+++ b/ui/src/views/renders/new/Controls/shared/icons/InfoIconDefaultEntity.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from 'flowbite-react';
 import { HiInformationCircle } from 'react-icons/hi2';
 
-export function InfoIconDefaultResource() {
+export function InfoIconDefaultEntity() {
   return (
     <Tooltip
       content={

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/index.tsx
@@ -6,7 +6,7 @@ import { useSelector } from '@tanstack/react-store';
 import { AccordionRow } from '../../../shared/AccordionRow';
 import { GeometricFormControls } from './GeometricFormControls';
 import { WarningIconOrphanGeometric } from '../../../shared/icons/WarningIconOrphanGeometric';
-import { InfoIconDefaultResource } from '../../../shared/icons/InfoIconDefaultResource';
+import { InfoIconDefaultEntity } from '../../../shared/icons/InfoIconDefaultEntity';
 import { GeometricMoreOptionsDropdown } from './GeometricMoreOptionsDropdown';
 
 export type GeometricRowProps = {
@@ -25,7 +25,7 @@ export function GeometricRow(props: GeometricRowProps) {
   const afterLabel = (
     <>
       {!isUsedByActiveScene && <WarningIconOrphanGeometric />}
-      {isDefault && <InfoIconDefaultResource />}
+      {isDefault && <InfoIconDefaultEntity />}
     </>
   );
 

--- a/ui/src/views/renders/new/Controls/tabs/MaterialControls/MaterialRow.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/MaterialControls/MaterialRow.tsx
@@ -5,7 +5,7 @@ import type { NormalizedRenderConfig } from '@/utils/render/config';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
 import { WarningIconOrphanGeometric } from '../../shared/icons/WarningIconOrphanGeometric';
-import { InfoIconDefaultResource } from '../../shared/icons/InfoIconDefaultResource';
+import { InfoIconDefaultEntity } from '../../shared/icons/InfoIconDefaultEntity';
 import { DuplicateDropdown } from '../../shared/DuplicateDropdown';
 import { duplicateMaterial } from '@/utils/render/utils';
 import { MediumControls } from './MediumControls';
@@ -24,7 +24,7 @@ export function MaterialRow(props: MaterialRowProps) {
   const afterLabel = (
     <>
       {!isUsedByActiveScene && <WarningIconOrphanGeometric />}
-      {isDefault && <InfoIconDefaultResource />}
+      {isDefault && <InfoIconDefaultEntity />}
     </>
   );
 

--- a/ui/src/views/renders/new/Controls/tabs/TextureControls/TextureRow.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/TextureControls/TextureRow.tsx
@@ -9,7 +9,7 @@ import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
 import { Separator } from '@/components/Separator';
 import { WarningIconOrphanGeometric } from '../../shared/icons/WarningIconOrphanGeometric';
-import { InfoIconDefaultResource } from '../../shared/icons/InfoIconDefaultResource';
+import { InfoIconDefaultEntity } from '../../shared/icons/InfoIconDefaultEntity';
 import { DuplicateDropdown } from '../../shared/DuplicateDropdown';
 import { duplicateTexture } from '@/utils/render/utils';
 
@@ -27,7 +27,7 @@ export function TextureRow(props: TextureRowProps) {
   const afterLabel = (
     <>
       {!isUsedByActiveScene && <WarningIconOrphanGeometric />}
-      {isDefault && <InfoIconDefaultResource />}
+      {isDefault && <InfoIconDefaultEntity />}
     </>
   );
 


### PR DESCRIPTION
## Summary

Standardizes the term **"entity"** for the general class of geometric/texture/material concepts across the entire codebase, replacing inconsistent uses of "resource" for the same meaning.

### Backend
- `src/deserialization.rs`: `build_resource_recursive` → `build_entity_recursive`, `BUILT_IN_RESOURCE_PREFIX` → `BUILT_IN_ENTITY_PREFIX`, plus parameter/local variable names and comments

### Frontend
- `utils/render/templates.ts`: `withDefaultResources` → `withDefaultEntities`
- `utils/render/config.ts`: `removeDefaultResources` → `removeDefaultEntities`
- `icons/InfoIconDefaultResource.tsx` → `icons/InfoIconDefaultEntity.tsx` (renamed)
- Updated imports and usages in 6 component files

### Docs
- `README.md`: 6 lines updated to use "entity" for scene composition context

### Not changed
- "resource quotas" / "resource limits" — refers to system resource limits (render count, checkpoints, pixel count), not scene entities. Left as-is.
- `AGENTS.md` table formatting cleanup is incidental.