### PR TITLE
chore: reword misleading OBJ model disabledReason copy

### DIFF
--- a/ui/src/views/renders/new/Controls/index.tsx
+++ b/ui/src/views/renders/new/Controls/index.tsx
@@ -117,7 +117,7 @@ export function Controls(props: ControlsProps) {
                   description: 'Import a 3D model from an OBJ file.',
                   disabled: true,
                   disabledReason:
-                    'OBJ model creation requires file upload support, which is not yet implemented in the UI.',
+                    'Resource uploads currently support texture images only; OBJ file uploads are not yet available.',
                 },
               ]}
               type="geometrics"


### PR DESCRIPTION
## Summary

Rewords the `disabledReason` for the disabled **OBJ Model** option in the geometrics "Add Entity" dropdown.

The previous copy claimed file upload support "is not yet implemented in the UI," which is misleading now that the Resources page supports uploads (texture images only). The new copy is accurate:

> Resource uploads currently support texture images only; OBJ file uploads are not yet available.

## Changes

- `ui/src/views/renders/new/Controls/index.tsx` — one-line `disabledReason` copy change for the `obj_model` option. The option's label, description, and disabled state are unchanged.

## Validation

- `eslint`, `prettier --check`, and `tsc -b --noEmit` all pass.