### PR TITLE
FEAT: Support emissive image textures in the 3D preview (emissiveMap)

### DIFF
--- a/ui/src/utils/three.ts
+++ b/ui/src/utils/three.ts
@@ -1,4 +1,8 @@
-import type { GeometricTriangle, GeometricParallelogram } from './render/geometric';
+import type {
+  GeometricTriangle,
+  GeometricParallelogram,
+  GeometricBilinearPatch,
+} from './render/geometric';
 
 export type TriangleGeometry = {
   vertices: Float32Array;
@@ -120,4 +124,86 @@ export function createParallelogramGeometry(
   const uvs = new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]);
 
   return { vertices, indices, normals, uvs };
+}
+
+export type BilinearPatchGeometry = {
+  vertices: Float32Array;
+  indices: Uint16Array;
+  normals: Float32Array;
+  uvs: Float32Array;
+};
+
+/**
+ * returns raw vertex/index/normal data for a bilinear patch,
+ * subdivided into a 16x16 grid with normals from partial derivatives.
+ */
+export function createBilinearPatchGeometry(
+  geometricData: GeometricBilinearPatch,
+): BilinearPatchGeometry {
+  const { p00, p10, p01, p11 } = geometricData;
+
+  const divs = 16;
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const indices: number[] = [];
+  const uvs: number[] = [];
+
+  const evalPatch = (u: number, v: number): [number, number, number] => {
+    const w00 = (1 - u) * (1 - v);
+    const w10 = u * (1 - v);
+    const w01 = (1 - u) * v;
+    const w11 = u * v;
+    return [
+      w00 * p00[0] + w10 * p10[0] + w01 * p01[0] + w11 * p11[0],
+      w00 * p00[1] + w10 * p10[1] + w01 * p01[1] + w11 * p11[1],
+      w00 * p00[2] + w10 * p10[2] + w01 * p01[2] + w11 * p11[2],
+    ];
+  };
+
+  // generate vertices and normals (divs+1 x divs+1 grid)
+  for (let j = 0; j <= divs; j++) {
+    const v = j / divs;
+    for (let i = 0; i <= divs; i++) {
+      const u = i / divs;
+      const p = evalPatch(u, v);
+      positions.push(...p);
+
+      // compute normal from partial derivatives
+      const eps = 0.001;
+      const du_u = Math.min(u + eps, 1.0 + eps);
+      const dv_v = Math.min(v + eps, 1.0 + eps);
+      const du = evalPatch(du_u, v);
+      const dv = evalPatch(u, dv_v);
+
+      const dp_du = [du[0] - p[0], du[1] - p[1], du[2] - p[2]];
+      const dp_dv = [dv[0] - p[0], dv[1] - p[1], dv[2] - p[2]];
+
+      // cross product dp_du x dp_dv
+      const nx = dp_du[1] * dp_dv[2] - dp_du[2] * dp_dv[1];
+      const ny = dp_du[2] * dp_dv[0] - dp_du[0] * dp_dv[2];
+      const nz = dp_du[0] * dp_dv[1] - dp_du[1] * dp_dv[0];
+      const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
+      normals.push(nx / len, ny / len, nz / len);
+      uvs.push(u, v);
+    }
+  }
+
+  // generate triangle indices (two per grid cell)
+  for (let j = 0; j < divs; j++) {
+    for (let i = 0; i < divs; i++) {
+      const a = j * (divs + 1) + i;
+      const b = a + 1;
+      const c = a + (divs + 1);
+      const d = c + 1;
+      indices.push(a, b, d);
+      indices.push(a, d, c);
+    }
+  }
+
+  return {
+    vertices: new Float32Array(positions),
+    indices: new Uint16Array(indices),
+    normals: new Float32Array(normals),
+    uvs: new Float32Array(uvs),
+  };
 }

--- a/ui/src/views/renders/new/Scene/BilinearPatchBufferGeometry.tsx
+++ b/ui/src/views/renders/new/Scene/BilinearPatchBufferGeometry.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { createBilinearPatchGeometry } from '@/utils/three';
+import type { GeometricBilinearPatch } from '@/utils/render/geometric';
+
+export type BilinearPatchBufferGeometryProps = {
+  data: GeometricBilinearPatch;
+};
+
+export function BilinearPatchBufferGeometry(props: BilinearPatchBufferGeometryProps) {
+  const { data } = props;
+
+  // memoize so bufferAttribute args stay referentially stable across
+  // unrelated re-renders; changed args force R3F to reconstruct attributes
+  const geom = useMemo(() => createBilinearPatchGeometry(data), [data]);
+
+  return (
+    <bufferGeometry>
+      <bufferAttribute attach="attributes-position" args={[geom.vertices, 3]} />
+      <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
+      <bufferAttribute attach="attributes-uv" args={[geom.uvs, 2]} />
+      <bufferAttribute attach="index" args={[geom.indices, 1]} />
+    </bufferGeometry>
+  );
+}

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -392,8 +392,8 @@ export function GeometricRenderer(props: GeometricRendererProps) {
     case 'bilinear_patch': {
       const emissiveInfo = getEmissiveInfo(config, data.material);
 
-      // build subdivided bilinear patch mesh (8x8 grid)
-      const divs = 8;
+      // build subdivided bilinear patch mesh (16x16 grid)
+      const divs = 16;
       const positions: number[] = [];
       const normals: number[] = [];
       const indices: number[] = [];
@@ -421,8 +421,8 @@ export function GeometricRenderer(props: GeometricRendererProps) {
 
           // compute normal from partial derivatives
           const eps = 0.001;
-          const du_u = Math.min(u + eps, 1.0);
-          const dv_v = Math.min(v + eps, 1.0);
+          const du_u = Math.min(u + eps, 1.0 + eps);
+          const dv_v = Math.min(v + eps, 1.0 + eps);
           const du = evalPatch(du_u, v);
           const dv = evalPatch(u, dv_v);
           const p = [

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -1,7 +1,9 @@
 import * as THREE from 'three';
 import { getAroundPoint, getGeometricDataSafe } from '@/utils/render/geometric';
 import { toRadians } from '@/utils/render/utils';
-import { createParallelogramGeometry, createTriangleGeometry } from '@/utils/three';
+import { ParallelogramBufferGeometry } from './ParallelogramBufferGeometry';
+import { TriangleBufferGeometry } from './TriangleBufferGeometry';
+import { BilinearPatchBufferGeometry } from './BilinearPatchBufferGeometry';
 import { MaterialResolver } from './MaterialResolver';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { getMaterialDataSafe } from '@/utils/render/material';
@@ -171,19 +173,12 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       );
 
     case 'parallelogram': {
-      const geom = createParallelogramGeometry(data);
-
       const emissiveInfo = getEmissiveInfo(config, data.material);
 
       return (
         <>
           <mesh rotation={rotation} castShadow={!emissiveInfo} receiveShadow>
-            <bufferGeometry>
-              <bufferAttribute attach="attributes-position" args={[geom.vertices, 3]} />
-              <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
-              <bufferAttribute attach="attributes-uv" args={[geom.uvs, 2]} />
-              <bufferAttribute attach="index" args={[geom.indices, 1]} />
-            </bufferGeometry>
+            <ParallelogramBufferGeometry data={data} />
             <MaterialResolver
               config={config}
               materialName={data.material}
@@ -317,19 +312,12 @@ export function GeometricRenderer(props: GeometricRendererProps) {
     }
 
     case 'triangle': {
-      const geom = createTriangleGeometry(data);
-
       const emissiveInfo = getEmissiveInfo(config, data.material);
 
       return (
         <>
           <mesh rotation={rotation} castShadow={!emissiveInfo} receiveShadow>
-            <bufferGeometry>
-              <bufferAttribute attach="attributes-position" args={[geom.vertices, 3]} />
-              <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
-              <bufferAttribute attach="attributes-uv" args={[geom.uvs, 2]} />
-              <bufferAttribute attach="index" args={[geom.indices, 1]} />
-            </bufferGeometry>
+            <TriangleBufferGeometry data={data} />
             <MaterialResolver
               config={config}
               materialName={data.material}
@@ -392,82 +380,10 @@ export function GeometricRenderer(props: GeometricRendererProps) {
     case 'bilinear_patch': {
       const emissiveInfo = getEmissiveInfo(config, data.material);
 
-      // build subdivided bilinear patch mesh (16x16 grid)
-      const divs = 16;
-      const positions: number[] = [];
-      const normals: number[] = [];
-      const indices: number[] = [];
-      const uvs: number[] = [];
-
-      // helper: evaluate bilinear patch P(u,v)
-      const evalPatch = (u: number, v: number): [number, number, number] => {
-        const w00 = (1 - u) * (1 - v);
-        const w10 = u * (1 - v);
-        const w01 = (1 - u) * v;
-        const w11 = u * v;
-        return [
-          w00 * data.p00[0] + w10 * data.p10[0] + w01 * data.p01[0] + w11 * data.p11[0],
-          w00 * data.p00[1] + w10 * data.p10[1] + w01 * data.p01[1] + w11 * data.p11[1],
-          w00 * data.p00[2] + w10 * data.p10[2] + w01 * data.p01[2] + w11 * data.p11[2],
-        ];
-      };
-
-      // generate vertices and normals (divs+1 x divs+1 grid)
-      for (let j = 0; j <= divs; j++) {
-        const v = j / divs;
-        for (let i = 0; i <= divs; i++) {
-          const u = i / divs;
-          positions.push(...evalPatch(u, v));
-
-          // compute normal from partial derivatives
-          const eps = 0.001;
-          const du_u = Math.min(u + eps, 1.0 + eps);
-          const dv_v = Math.min(v + eps, 1.0 + eps);
-          const du = evalPatch(du_u, v);
-          const dv = evalPatch(u, dv_v);
-          const p = [
-            positions[positions.length - 3],
-            positions[positions.length - 2],
-            positions[positions.length - 1],
-          ];
-
-          const dp_du = [du[0] - p[0], du[1] - p[1], du[2] - p[2]];
-          const dp_dv = [dv[0] - p[0], dv[1] - p[1], dv[2] - p[2]];
-
-          // cross product dp_du x dp_dv
-          const nx = dp_du[1] * dp_dv[2] - dp_du[2] * dp_dv[1];
-          const ny = dp_du[2] * dp_dv[0] - dp_du[0] * dp_dv[2];
-          const nz = dp_du[0] * dp_dv[1] - dp_du[1] * dp_dv[0];
-          const len = Math.sqrt(nx * nx + ny * ny + nz * nz) || 1;
-          normals.push(nx / len, ny / len, nz / len);
-          uvs.push(u, v);
-        }
-      }
-
-      // generate triangle indices (two per grid cell)
-      for (let j = 0; j < divs; j++) {
-        for (let i = 0; i < divs; i++) {
-          const a = j * (divs + 1) + i;
-          const b = a + 1;
-          const c = a + (divs + 1);
-          const d = c + 1;
-          indices.push(a, b, d);
-          indices.push(a, d, c);
-        }
-      }
-
       return (
         <>
           <mesh rotation={rotation} castShadow={!emissiveInfo} receiveShadow>
-            <bufferGeometry>
-              <bufferAttribute
-                attach="attributes-position"
-                args={[new Float32Array(positions), 3]}
-              />
-              <bufferAttribute attach="attributes-normal" args={[new Float32Array(normals), 3]} />
-              <bufferAttribute attach="attributes-uv" args={[new Float32Array(uvs), 2]} />
-              <bufferAttribute attach="index" args={[new Uint16Array(indices), 1]} />
-            </bufferGeometry>
+            <BilinearPatchBufferGeometry data={data} />
             <MaterialResolver
               config={config}
               materialName={data.material}

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { MeshTransmissionMaterial } from '@react-three/drei';
 import type * as THREE from 'three';
-import { Color } from 'three';
 import { getMaterialDataSafe } from '@/utils/render/material';
 import { getTextureDataSafe } from '@/utils/render/texture';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
@@ -31,28 +30,30 @@ export function MaterialResolver(props: MaterialResolverProps) {
   const dielectricMaterialRef = useRef<React.ComponentRef<typeof MeshTransmissionMaterial>>(null);
   const specularMaterialRef = useRef<THREE.MeshStandardMaterial>(null);
 
-  useEffect(() => {
-    const refs = [lambertianMaterialRef, dielectricMaterialRef, specularMaterialRef];
-    for (const ref of refs) {
-      if (ref.current) {
-        ref.current.map = reflectanceImageMap;
-        ref.current.emissiveMap = emittanceImageMap;
-        if (emittanceImageMap) {
-          // emissiveMap is multiplied by the emissive color, which defaults
-          // to black. Set white so the map shows at its natural brightness
-          ref.current.emissive = new Color(1, 1, 1);
-        } else {
-          ref.current.emissive = new Color(0, 0, 0);
-        }
-        ref.current.needsUpdate = true;
-      }
-    }
-  }, [reflectanceImageMap, emittanceImageMap]);
-
   const emissiveColor =
     emittanceTexture.type === 'color' && emittanceTexture.color.reduce((a, b) => a + b, 0) > 0
       ? emittanceTexture.color
       : undefined;
+
+  // single source of truth for emissive across all material types
+  const resolvedEmissive: [number, number, number] = emittanceImageMap
+    ? [1, 1, 1] // white so emissiveMap shows at natural brightness
+    : (emissiveColor ?? [0, 0, 0]);
+
+  const hasReflectanceMap = reflectanceImageMap !== null;
+  const hasEmittanceMap = emittanceImageMap !== null;
+
+  // recompile when map/emissiveMap presence toggles (null ↔ texture);
+  // three.js needs this for USE_MAP / USE_EMISSIVEMAP shader defines,
+  // but R3F does not set needsUpdate automatically
+  useEffect(() => {
+    const refs = [lambertianMaterialRef, dielectricMaterialRef, specularMaterialRef];
+    for (const ref of refs) {
+      if (ref.current) {
+        ref.current.needsUpdate = true;
+      }
+    }
+  }, [hasReflectanceMap, hasEmittanceMap]);
 
   switch (materialData.type) {
     case 'dielectric': {
@@ -66,6 +67,8 @@ export function MaterialResolver(props: MaterialResolverProps) {
               ref={dielectricMaterialRef}
               attach="material"
               color={reflectanceTexture.color}
+              map={reflectanceImageMap}
+              emissiveMap={emittanceImageMap}
               thickness={mediumData ? 0.5 : 0}
               transmission={1.0}
               ior={ior}
@@ -82,7 +85,7 @@ export function MaterialResolver(props: MaterialResolverProps) {
                         : undefined,
                   }
                 : {})}
-              {...(!hasHomogeneousMedium && emissiveColor ? { emissive: emissiveColor } : {})}
+              {...(!hasHomogeneousMedium ? { emissive: resolvedEmissive } : {})}
             />
           );
         }
@@ -97,6 +100,8 @@ export function MaterialResolver(props: MaterialResolverProps) {
               ref={dielectricMaterialRef}
               attach="material"
               color={[1, 1, 1]}
+              map={reflectanceImageMap}
+              emissiveMap={emittanceImageMap}
               thickness={mediumData ? 0.5 : 0}
               transmission={1.0}
               ior={ior}
@@ -113,6 +118,7 @@ export function MaterialResolver(props: MaterialResolverProps) {
                         : undefined,
                   }
                 : {})}
+              {...(!hasHomogeneousMedium ? { emissive: resolvedEmissive } : {})}
             />
           );
         }
@@ -124,6 +130,8 @@ export function MaterialResolver(props: MaterialResolverProps) {
               ref={dielectricMaterialRef}
               attach="material"
               color={[1, 1, 1]}
+              map={reflectanceImageMap}
+              emissiveMap={emittanceImageMap}
               thickness={mediumData ? 0.5 : 0}
               transmission={1.0}
               ior={ior}
@@ -140,6 +148,7 @@ export function MaterialResolver(props: MaterialResolverProps) {
                         : undefined,
                   }
                 : {})}
+              {...(!hasHomogeneousMedium ? { emissive: resolvedEmissive } : {})}
             />
           );
         }
@@ -153,10 +162,12 @@ export function MaterialResolver(props: MaterialResolverProps) {
             <meshLambertMaterial
               ref={lambertianMaterialRef}
               attach="material"
-              color={reflectanceTexture.color}
+              color={reflectanceTexture.type === 'color' ? reflectanceTexture.color : [1, 1, 1]}
+              map={reflectanceImageMap}
+              emissiveMap={emittanceImageMap}
+              emissive={resolvedEmissive}
               side={side}
               shadowSide={shadowSide}
-              {...(emissiveColor ? { emissive: emissiveColor } : {})}
             />
           );
         }
@@ -169,6 +180,9 @@ export function MaterialResolver(props: MaterialResolverProps) {
               ref={lambertianMaterialRef}
               attach="material"
               color={[1, 1, 1]}
+              map={reflectanceImageMap}
+              emissiveMap={emittanceImageMap}
+              emissive={resolvedEmissive}
               side={side}
               shadowSide={shadowSide}
             />
@@ -180,6 +194,9 @@ export function MaterialResolver(props: MaterialResolverProps) {
               ref={lambertianMaterialRef}
               attach="material"
               color={[1, 1, 1]}
+              map={reflectanceImageMap}
+              emissiveMap={emittanceImageMap}
+              emissive={resolvedEmissive}
               side={side}
               shadowSide={shadowSide}
             />
@@ -195,10 +212,12 @@ export function MaterialResolver(props: MaterialResolverProps) {
             <meshStandardMaterial
               ref={specularMaterialRef}
               attach="material"
-              color={reflectanceTexture.color}
+              color={reflectanceTexture.type === 'color' ? reflectanceTexture.color : [1, 1, 1]}
+              map={reflectanceImageMap}
+              emissiveMap={emittanceImageMap}
+              emissive={resolvedEmissive}
               side={side}
               shadowSide={shadowSide}
-              {...(emissiveColor ? { emissive: emissiveColor } : {})}
               metalness={1.0}
               roughness={materialData.roughness}
             />
@@ -213,6 +232,9 @@ export function MaterialResolver(props: MaterialResolverProps) {
               ref={specularMaterialRef}
               attach="material"
               color={[1, 1, 1]}
+              map={reflectanceImageMap}
+              emissiveMap={emittanceImageMap}
+              emissive={resolvedEmissive}
               side={side}
               shadowSide={shadowSide}
               metalness={1.0}
@@ -226,6 +248,9 @@ export function MaterialResolver(props: MaterialResolverProps) {
               ref={specularMaterialRef}
               attach="material"
               color={[1, 1, 1]}
+              map={reflectanceImageMap}
+              emissiveMap={emittanceImageMap}
+              emissive={resolvedEmissive}
               side={side}
               shadowSide={shadowSide}
               metalness={1.0}

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { MeshTransmissionMaterial } from '@react-three/drei';
 import type * as THREE from 'three';
+import { Color } from 'three';
 import { getMaterialDataSafe } from '@/utils/render/material';
 import { getTextureDataSafe } from '@/utils/render/texture';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
@@ -22,6 +23,9 @@ export function MaterialResolver(props: MaterialResolverProps) {
   const reflectanceImageMap = useImageMap(
     reflectanceTexture.type === 'image' ? reflectanceTexture.resource_id : undefined,
   );
+  const emittanceImageMap = useImageMap(
+    emittanceTexture.type === 'image' ? emittanceTexture.resource_id : undefined,
+  );
 
   const lambertianMaterialRef = useRef<THREE.MeshLambertMaterial>(null);
   const dielectricMaterialRef = useRef<React.ComponentRef<typeof MeshTransmissionMaterial>>(null);
@@ -32,10 +36,18 @@ export function MaterialResolver(props: MaterialResolverProps) {
     for (const ref of refs) {
       if (ref.current) {
         ref.current.map = reflectanceImageMap;
+        ref.current.emissiveMap = emittanceImageMap;
+        if (emittanceImageMap) {
+          // emissiveMap is multiplied by the emissive color, which defaults
+          // to black. Set white so the map shows at its natural brightness
+          ref.current.emissive = new Color(1, 1, 1);
+        } else {
+          ref.current.emissive = new Color(0, 0, 0);
+        }
         ref.current.needsUpdate = true;
       }
     }
-  }, [reflectanceImageMap]);
+  }, [reflectanceImageMap, emittanceImageMap]);
 
   const emissiveColor =
     emittanceTexture.type === 'color' && emittanceTexture.color.reduce((a, b) => a + b, 0) > 0

--- a/ui/src/views/renders/new/Scene/ParallelogramBufferGeometry.tsx
+++ b/ui/src/views/renders/new/Scene/ParallelogramBufferGeometry.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { createParallelogramGeometry } from '@/utils/three';
+import type { GeometricParallelogram } from '@/utils/render/geometric';
+
+export type ParallelogramBufferGeometryProps = {
+  data: GeometricParallelogram;
+};
+
+export function ParallelogramBufferGeometry(props: ParallelogramBufferGeometryProps) {
+  const { data } = props;
+
+  // memoize so bufferAttribute args stay referentially stable across
+  // unrelated re-renders; changed args force R3F to reconstruct attributes
+  const geom = useMemo(() => createParallelogramGeometry(data), [data]);
+
+  return (
+    <bufferGeometry>
+      <bufferAttribute attach="attributes-position" args={[geom.vertices, 3]} />
+      <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
+      <bufferAttribute attach="attributes-uv" args={[geom.uvs, 2]} />
+      <bufferAttribute attach="index" args={[geom.indices, 1]} />
+    </bufferGeometry>
+  );
+}

--- a/ui/src/views/renders/new/Scene/TriangleBufferGeometry.tsx
+++ b/ui/src/views/renders/new/Scene/TriangleBufferGeometry.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { createTriangleGeometry } from '@/utils/three';
+import type { GeometricTriangle } from '@/utils/render/geometric';
+
+export type TriangleBufferGeometryProps = {
+  data: GeometricTriangle;
+};
+
+export function TriangleBufferGeometry(props: TriangleBufferGeometryProps) {
+  const { data } = props;
+
+  // memoize so bufferAttribute args stay referentially stable across
+  // unrelated re-renders; changed args force R3F to reconstruct attributes
+  const geom = useMemo(() => createTriangleGeometry(data), [data]);
+
+  return (
+    <bufferGeometry>
+      <bufferAttribute attach="attributes-position" args={[geom.vertices, 3]} />
+      <bufferAttribute attach="attributes-normal" args={[geom.normals, 3]} />
+      <bufferAttribute attach="attributes-uv" args={[geom.uvs, 2]} />
+      <bufferAttribute attach="index" args={[geom.indices, 1]} />
+    </bufferGeometry>
+  );
+}


### PR DESCRIPTION
Closes #214

## Summary

Three related fixes that make the 3D preview correctly display emissive image textures (`emissiveMap`) and prevent emissive state from being lost on unrelated material changes.

## Changes

### 1. Emissive image texture support

`MaterialResolver.tsx`:
- Added a second `useImageMap` call for the emittance texture when `emittanceTexture.type === 'image'`
- `emissiveMap` is set on all three material types (lambertian, dielectric, specular) so image emitters glow in the preview
- No derived `pointLight` for image emitters — `getEmissiveInfo` is intentionally unchanged. Image-emissive materials glow via `emissiveMap` only
- `emissiveIntensity` left at the three.js default of 1

### 2. Fix bilinear patch vanishing on emissive toggle

`GeometricRenderer.tsx`:
- Bilinear patch geometry was rebuilt from scratch on every render (fresh `Float32Array` args forced R3F to reconstruct all four `bufferAttribute` children on every commit)
- Extracted memoized geometry into three new components: `BilinearPatchBufferGeometry`, `ParallelogramBufferGeometry`, `TriangleBufferGeometry`
- Moved inline patch math into `createBilinearPatchGeometry` util in `utils/three.ts`
- Also fixed the bilinear patch normal derivative clamp (`1.0 + eps`) and increased subdivision from 8×8 to 16×16

### 3. Declarative emissive state management

`MaterialResolver.tsx`:
- `map`, `emissiveMap`, and `emissive` are now declarative JSX props on all 9 material branches instead of imperatively set in a `useEffect`
- The `useEffect` only sets `needsUpdate = true` when a map's **presence** toggles (null ↔ texture), which is when three.js needs a shader recompile
- Fixes the bug where changing a lambertian material's reflectance color (color→color) would silently lose the emissive glow when the emittance texture was an image

## Validation

`just validate` passes fully: cargo check, cargo test (29 passed), clippy, ESLint (0 errors, 0 warnings), Prettier, and TypeScript type-check.