### PR TITLE
chore: migrate data-entry modals to local useAppForm pattern

### DIFF
--- a/.opencode/skills/react-code-conventions/SKILL.md
+++ b/.opencode/skills/react-code-conventions/SKILL.md
@@ -59,9 +59,34 @@ All TypeScript code in `ui/src/` must follow these conventions.
 8. **One component per file** — Each file must contain at most one React component (exported or unexported). If a parent component needs sub-components that are only used by it, those sub-components must live in their own separate files within a folder (see Rule 7). Non-component helper/utility functions and type definitions may co-exist in the same file as the component.
 
 9. **Strict type safety** — the TypeScript type system must be relied on as much as possible. The following are forbidden:
-   - Typing any variable, parameter, or return type as `any`
-   - Suppressing the `no-explicit-any` lint rule with `// eslint-disable-next-line @typescript-eslint/no-explicit-any` or similar comments
-   - `as` type assertions (casts) are strongly discouraged. If an `as` cast is truly unavoidable, it MUST be accompanied by a comment immediately above it explaining **why** the cast is necessary (e.g., "// the API response shape is known but the generated type is incomplete", or "// narrowing after a runtime guard that TS can't track"). Blind `as` casts with no justification are forbidden.
+    - Typing any variable, parameter, or return type as `any`
+    - Suppressing the `no-explicit-any` lint rule with `// eslint-disable-next-line @typescript-eslint/no-explicit-any` or similar comments
+    - `as` type assertions (casts) are strongly discouraged. If an `as` cast is truly unavoidable, it MUST be accompanied by a comment immediately above it explaining **why** the cast is necessary (e.g., "// the API response shape is known but the generated type is incomplete", or "// narrowing after a runtime guard that TS can't track"). Blind `as` casts with no justification are forbidden.
+
+10. **Form state uses a local TanStack Form instance** — Any component that collects user input for submission (modals, form bodies, pickers) must manage that input with a local `useAppForm` instance (`@/hooks/useAppForm`), not raw `useState`.
+    - Declare all submitted values (and helper fields) in `defaultValues`; validate with a Zod `onChange` validator when the form has validity rules.
+    - Wire inputs through `form.AppField` using the registered field controls (`FormTextField`, `SelectControl`, `ToggleControl`, `RangeControl`, `TextArrayInputControl`, `InstancesBuilderControl`) or `field.state.value` / `field.handleChange` for bespoke widgets.
+    - Read reactive values with `useSelector(form.store, selector)`; disable submit buttons via `state.isValid`.
+    - Transform-on-submit: form fields don't need to map 1:1 to the API payload — read `form.state.values` in the submit handler and map there.
+    - Reset with `form.reset()` on cancel and after successful submit.
+    - Reference implementation: `ui/src/views/admin/QuotaEditModal.tsx`.
+
+    ✅ Correct — a local `useAppForm` instance for all submitted values:
+    ```tsx
+    const form = useAppForm({
+      defaultValues: { name: "", count: 0 },
+      validators: { onChange: formSchema },
+    });
+    ```
+    Wire inputs via `form.AppField`, or use `field.state.value` / `field.handleChange` for bespoke widgets. Read reactive values with `useSelector(form.store, ...)`. Disable submit via `form.state.isValid`. Reset on cancel or after successful submit.
+
+    ❌ Anti-pattern — raw `useState` for input that gets submitted:
+    ```tsx
+    const [name, setName] = useState("");
+    const [count, setCount] = useState(0);
+    ```
+
+    **Permitted exceptions for raw `useState`:** transient/imperative state that is not a submitted value — e.g. `File` objects from file inputs, submit-time error messages, in-flight flags (`isValidating`), and purely visual UI state (open/expanded/copied). Reference: `ui/src/views/resources/UploadResourceModal.tsx`.
 
 ## Example
 
@@ -98,7 +123,7 @@ export function Foo(props: FooProps) {
 
 ## When creating a new component
 
-Apply all nine rules from the start. If the component will likely exceed 500 lines, start it as a folder with `index.tsx` from the beginning.
+Apply all ten rules from the start. If the component will likely exceed 500 lines, start it as a folder with `index.tsx` from the beginning.
 
 ## When editing an existing file
 
@@ -116,4 +141,5 @@ The checklist is:
 7. The component is under ~500 lines; if approaching that threshold, it is a folder with `index.tsx` and child component files
 8. The file contains at most one React component (sub-components are separate files within a folder)
 9. No `any` types or unjustified `as` casts anywhere in the file
-10. Run `just validate` from the repo root to confirm the changes pass all checks (TypeScript, ESLint, Rust checks, clippy, tests)
+10. Any user-input collection uses a local `useAppForm` instance; raw `useState` only holds transient/imperative state (files, submit errors, in-flight flags, visual UI state)
+11. Run `just validate` from the repo root to confirm the changes pass all checks (TypeScript, ESLint, Rust checks, clippy, tests)

--- a/ui/src/components/form-controls/InstancesBuilderControl.tsx
+++ b/ui/src/components/form-controls/InstancesBuilderControl.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { useFieldContext } from '@/hooks/formContext';
+import { Button, Label, Select } from 'flowbite-react';
+import { HiPlus, HiXMark } from 'react-icons/hi2';
+
+export type InstanceType = 'translate' | 'rotate_x' | 'rotate_y' | 'rotate_z' | 'scale';
+
+const INSTANCE_LABELS: Record<InstanceType, string> = {
+  rotate_x: 'Rotate X',
+  rotate_y: 'Rotate Y',
+  rotate_z: 'Rotate Z',
+  scale: 'Scale',
+  translate: 'Translate',
+};
+
+export type InstancesBuilderControlProps = {
+  label?: string;
+};
+
+export function InstancesBuilderControl(props: InstancesBuilderControlProps) {
+  const { label = 'Instances' } = props;
+
+  const field = useFieldContext<InstanceType[]>();
+  const [pendingInstanceType, setPendingInstanceType] = useState<InstanceType>('translate');
+
+  const instances = field.state.value;
+
+  function handleRemoveInstance(index: number) {
+    field.handleChange(instances.filter((_, j) => j !== index));
+  }
+
+  function handleAddInstance() {
+    field.handleChange([...instances, pendingInstanceType]);
+  }
+
+  return (
+    <fieldset className="flex flex-col gap-2 rounded-lg border border-zinc-700 py-3">
+      <Label className="text-zinc-300">{label}</Label>
+      {instances.length > 0 ? (
+        <div className="flex flex-col gap-1">
+          {instances.map((inst, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between rounded-lg bg-zinc-800 px-3 py-2 text-sm"
+            >
+              <span className="text-zinc-300">
+                [{i + 1}] {INSTANCE_LABELS[inst]}
+              </span>
+              <button
+                type="button"
+                onClick={() => handleRemoveInstance(i)}
+                className="rounded p-1 text-zinc-500 transition-colors hover:bg-zinc-700 hover:text-red-400"
+                aria-label={`Remove ${INSTANCE_LABELS[inst]}`}
+              >
+                <HiXMark className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-zinc-500">No transforms applied.</p>
+      )}
+      <div className="flex items-center gap-2">
+        <Select
+          value={pendingInstanceType}
+          onChange={(e) => {
+            // flowbite-react Select onChange yields a generic HTMLSelectElement
+            // event whose value is string; the options are all valid InstanceType values
+            setPendingInstanceType(e.target.value as InstanceType);
+          }}
+          sizing="sm"
+          className="flex-1"
+        >
+          <option value="rotate_x">Rotate X</option>
+          <option value="rotate_y">Rotate Y</option>
+          <option value="rotate_z">Rotate Z</option>
+          <option value="scale">Scale</option>
+          <option value="translate">Translate</option>
+        </Select>
+        <Button color="light" size="sm" onClick={handleAddInstance}>
+          <HiPlus className="mr-1 h-4 w-4" />
+          Add
+        </Button>
+      </div>
+    </fieldset>
+  );
+}

--- a/ui/src/hooks/useAppForm.ts
+++ b/ui/src/hooks/useAppForm.ts
@@ -5,6 +5,7 @@ import { SelectControl } from '@/components/form-controls/SelectControl';
 import { RangeControl } from '@/components/form-controls/RangeControl';
 import { ToggleControl } from '@/components/form-controls/ToggleControl';
 import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
+import { InstancesBuilderControl } from '@/components/form-controls/InstancesBuilderControl';
 
 export const { useAppForm } = createFormHook({
   fieldContext,
@@ -15,6 +16,7 @@ export const { useAppForm } = createFormHook({
     SelectControl,
     RangeControl,
     ToggleControl,
+    InstancesBuilderControl,
   },
   formComponents: {},
 });

--- a/ui/src/views/renders/CreateRenderModal/ImportConfigModal/ImportConfigBody.tsx
+++ b/ui/src/views/renders/CreateRenderModal/ImportConfigModal/ImportConfigBody.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef } from 'react';
 import { Button, ModalHeader, ModalBody, ModalFooter } from 'flowbite-react';
+import { useAppForm } from '@/hooks/useAppForm';
 import { HiFolderOpen } from 'react-icons/hi2';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { RenderConfigSchema, normalizeRenderConfig } from '@/utils/render/config';
@@ -14,24 +15,32 @@ export type ImportConfigBodyProps = {
 export function ImportConfigBody(props: ImportConfigBodyProps) {
   const { onImportSuccess, onCancel } = props;
 
-  const [jsonText, setJsonText] = useState('');
+  const form = useAppForm({
+    defaultValues: {
+      jsonText: '',
+    },
+  });
   const [error, setError] = useState<string | null>(null);
   const [isValidating, setIsValidating] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
-    if (!file) return;
+    if (!file) {
+      return;
+    }
     const reader = new FileReader();
     reader.onload = () => {
-      setJsonText(reader.result as string);
+      // the FileReader result is guaranteed to be a string after readAsText
+      form.setFieldValue('jsonText', reader.result as string);
       setError(null);
     };
     reader.readAsText(file);
     e.target.value = '';
-  }, []);
+  }
 
-  const handleImportConfig = useCallback(async () => {
+  async function handleImportConfig() {
+    const jsonText = form.state.values.jsonText;
     if (!jsonText.trim()) {
       setError('Please enter or import a JSON configuration.');
       return;
@@ -61,7 +70,7 @@ export function ImportConfigBody(props: ImportConfigBodyProps) {
     } finally {
       setIsValidating(false);
     }
-  }, [jsonText, onImportSuccess, onCancel]);
+  }
 
   return (
     <>
@@ -81,13 +90,17 @@ export function ImportConfigBody(props: ImportConfigBodyProps) {
               hidden
             />
           </div>
-          <RenderConfigEditor
-            value={jsonText}
-            onChange={(value) => {
-              setJsonText(value);
-              setError(null);
-            }}
-          />
+          <form.AppField name="jsonText">
+            {(field) => (
+              <RenderConfigEditor
+                value={field.state.value}
+                onChange={(value) => {
+                  field.handleChange(value);
+                  setError(null);
+                }}
+              />
+            )}
+          </form.AppField>
           {error && (
             <div className="rounded-lg bg-red-900/30 p-3 text-sm whitespace-pre-wrap text-red-300">
               {error}

--- a/ui/src/views/renders/new/Controls/shared/AddEntityModal.tsx
+++ b/ui/src/views/renders/new/Controls/shared/AddEntityModal.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Modal,
   ModalHeader,
@@ -9,19 +8,12 @@ import {
   Select,
   TextInput,
 } from 'flowbite-react';
-import { HiPlus, HiXMark } from 'react-icons/hi2';
+import { useSelector } from '@tanstack/react-store';
+import { useAppForm } from '@/hooks/useAppForm';
+import { z } from 'zod';
+import type { InstanceType } from '@/components/form-controls/InstancesBuilderControl';
 import type { EntityType, EntitySubType, AddEntityDropdownOption } from './AddEntityDropdown';
 import { useAllResourceMetadataQuery } from '@/hooks/useResources';
-
-export type InstanceType = 'translate' | 'rotate_x' | 'rotate_y' | 'rotate_z' | 'scale';
-
-const INSTANCE_LABELS: Record<InstanceType, string> = {
-  rotate_x: 'Rotate X',
-  rotate_y: 'Rotate Y',
-  rotate_z: 'Rotate Z',
-  scale: 'Scale',
-  translate: 'Translate',
-};
 
 export type AddEntityCreateConfig = {
   customName?: string;
@@ -44,40 +36,58 @@ export function AddEntityModal<T extends EntityType>(props: AddEntityModalProps<
   const { entityType, option, open, onClose, onCreate } = props;
 
   const isGeometrics = entityType === 'geometrics';
-  const [customName, setCustomName] = useState('');
-  const [instances, setInstances] = useState<InstanceType[]>([]);
-  const [pendingInstanceType, setPendingInstanceType] = useState<InstanceType>('translate');
-  const [isConstantVolume, setIsConstantVolume] = useState(false);
-  const [isVirtual, setIsVirtual] = useState(false);
-  const [selectedResourceId, setSelectedResourceId] = useState<number | null>(null);
+  const isImageTexture = entityType === 'textures' && option.subtype === 'image';
 
   const { data: resources } = useAllResourceMetadataQuery();
 
+  const form = useAppForm({
+    defaultValues: {
+      customName: '',
+      // `[]` is inferred as `never[]` without the explicit cast
+      instances: [] as InstanceType[],
+      isConstantVolume: false,
+      isVirtual: false,
+      selectedResourceId: '',
+    },
+    validators: {
+      onChange: z
+        .object({
+          customName: z.string(),
+          instances: z.array(z.enum(['translate', 'rotate_x', 'rotate_y', 'rotate_z', 'scale'])),
+          isConstantVolume: z.boolean(),
+          isVirtual: z.boolean(),
+          selectedResourceId: z.string(),
+        })
+        .superRefine((data, ctx) => {
+          // an image texture is meaningless without a backing resource
+          if (isImageTexture && data.selectedResourceId === '') {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'A resource must be selected',
+              path: ['selectedResourceId'],
+            });
+          }
+        }),
+    },
+  });
+
+  const isFormValid = useSelector(form.store, (state) => state.isValid);
+
   function handleCreate() {
+    const values = form.state.values;
     onCreate({
-      customName: customName.trim() || undefined,
-      instances,
-      isConstantVolume,
-      isVirtual,
-      resourceId: selectedResourceId ?? undefined,
+      customName: values.customName.trim() || undefined,
+      instances: values.instances,
+      isConstantVolume: values.isConstantVolume,
+      isVirtual: values.isVirtual,
+      resourceId: values.selectedResourceId ? Number(values.selectedResourceId) : undefined,
     });
-    // reset all state
-    setCustomName('');
-    setInstances([]);
-    setPendingInstanceType('translate');
-    setIsConstantVolume(false);
-    setIsVirtual(false);
-    setSelectedResourceId(null);
+    form.reset();
     onClose();
   }
 
   function handleCancel() {
-    setCustomName('');
-    setInstances([]);
-    setPendingInstanceType('translate');
-    setIsConstantVolume(false);
-    setIsVirtual(false);
-    setSelectedResourceId(null);
+    form.reset();
     onClose();
   }
 
@@ -103,14 +113,20 @@ export function AddEntityModal<T extends EntityType>(props: AddEntityModalProps<
       <ModalHeader>{option.label}</ModalHeader>
       <ModalBody>
         {/* name input */}
-        <div className="mb-3">
-          <label className="mb-1 block text-sm font-medium text-gray-300">Name (optional)</label>
-          <TextInput
-            placeholder={`New ${option.label}`}
-            value={customName}
-            onChange={(e) => setCustomName(e.target.value)}
-          />
-        </div>
+        <form.AppField name="customName">
+          {(field) => (
+            <div className="mb-3">
+              <label className="mb-1 block text-sm font-medium text-gray-300">
+                Name (optional)
+              </label>
+              <TextInput
+                placeholder={`New ${option.label}`}
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+            </div>
+          )}
+        </form.AppField>
 
         {/* description */}
         {option.description && <p className="mb-4 text-sm text-gray-400">{option.description}</p>}
@@ -118,112 +134,74 @@ export function AddEntityModal<T extends EntityType>(props: AddEntityModalProps<
         {/* geometric-specific: instances and constant volume */}
         {isGeometrics && (
           <>
-            {/* stacked instances builder */}
-            <div className="mb-4">
-              <label className="mb-1 block text-sm font-medium text-gray-300">Instances</label>
-              {instances.length > 0 ? (
-                <div className="mb-2 space-y-1">
-                  {instances.map((inst, i) => (
-                    <div
-                      key={i}
-                      className="flex items-center justify-between rounded bg-zinc-800 px-2 py-1 text-sm"
-                    >
-                      <span className="text-gray-300">
-                        [{i + 1}] {INSTANCE_LABELS[inst]}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => setInstances(instances.filter((_, j) => j !== i))}
-                        className="text-gray-500 hover:text-red-400"
-                        aria-label={`Remove ${INSTANCE_LABELS[inst]}`}
-                      >
-                        <HiXMark className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="mb-2 text-xs text-gray-500">No transforms applied.</p>
-              )}
-              <div className="flex gap-2">
-                <Select
-                  value={pendingInstanceType}
-                  onChange={(e) => setPendingInstanceType(e.target.value as InstanceType)}
-                  sizing="sm"
-                >
-                  <option value="rotate_x">Rotate X</option>
-                  <option value="rotate_y">Rotate Y</option>
-                  <option value="rotate_z">Rotate Z</option>
-                  <option value="scale">Scale</option>
-                  <option value="translate">Translate</option>
-                </Select>
-                <Button
-                  color="light"
-                  size="xs"
-                  onClick={() => setInstances([...instances, pendingInstanceType])}
-                >
-                  <HiPlus className="mr-1 h-3.5 w-3.5" />
-                  Add
-                </Button>
-              </div>
-            </div>
+            <form.AppField name="instances">
+              {(field) => <field.InstancesBuilderControl />}
+            </form.AppField>
 
             {/* constant volume toggle */}
-            <div className="mb-3 flex items-center gap-3">
-              <ToggleSwitch
-                checked={isConstantVolume}
-                onChange={setIsConstantVolume}
-                label="Create as Constant Volume?"
-              />
-            </div>
+            <form.AppField name="isConstantVolume">
+              {(field) => (
+                <div className="mb-3 flex items-center gap-3">
+                  <ToggleSwitch
+                    checked={field.state.value}
+                    onChange={(checked) => field.handleChange(checked)}
+                    label="Create as Constant Volume?"
+                  />
+                </div>
+              )}
+            </form.AppField>
 
             {/* virtual toggle */}
-            <div className="mb-3 flex items-center gap-3">
-              <ToggleSwitch
-                checked={isVirtual}
-                onChange={setIsVirtual}
-                label="Create as Virtual?"
-              />
-            </div>
+            <form.AppField name="isVirtual">
+              {(field) => (
+                <div className="mb-3 flex items-center gap-3">
+                  <ToggleSwitch
+                    checked={field.state.value}
+                    onChange={(checked) => field.handleChange(checked)}
+                    label="Create as Virtual?"
+                  />
+                </div>
+              )}
+            </form.AppField>
           </>
         )}
 
         {/* image texture: resource picker */}
         {entityType === 'textures' && option.subtype === 'image' && (
-          <div className="mb-4">
-            <label className="mb-1 block text-sm font-medium text-gray-300">Select Resource</label>
-            {resources && resources.length > 0 ? (
-              <Select
-                value={selectedResourceId ?? ''}
-                onChange={(e) =>
-                  setSelectedResourceId(e.target.value ? Number(e.target.value) : null)
-                }
-                sizing="sm"
-              >
-                <option value="">-- Choose a resource --</option>
-                {resources.map((r) => (
-                  <option key={r.id} value={r.id}>
-                    {r.name} ({r.mime_type})
-                  </option>
-                ))}
-              </Select>
-            ) : (
-              <p className="text-sm text-yellow-400">
-                No resources available. Upload one on the Resources page.
-              </p>
+          <form.AppField name="selectedResourceId">
+            {(field) => (
+              <div className="mb-4">
+                <label className="mb-1 block text-sm font-medium text-gray-300">
+                  Select Resource
+                </label>
+                {resources && resources.length > 0 ? (
+                  <Select
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    sizing="sm"
+                  >
+                    <option value="">-- Choose a resource --</option>
+                    {resources.map((r) => (
+                      <option key={r.id} value={r.id}>
+                        {r.name} ({r.mime_type})
+                      </option>
+                    ))}
+                  </Select>
+                ) : (
+                  <p className="text-sm text-yellow-400">
+                    No resources available. Upload one on the Resources page.
+                  </p>
+                )}
+              </div>
             )}
-          </div>
+          </form.AppField>
         )}
       </ModalBody>
       <ModalFooter>
         <Button color="light" onClick={handleCancel}>
           Cancel
         </Button>
-        <Button
-          color="default"
-          onClick={handleCreate}
-          disabled={entityType === 'textures' && option.subtype === 'image' && !selectedResourceId}
-        >
+        <Button color="default" onClick={handleCreate} disabled={!isFormValid}>
           Create
         </Button>
       </ModalFooter>

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricMoreOptionsDropdown/AddToListModal.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricMoreOptionsDropdown/AddToListModal.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'flowbite-react';
+import { useSelector } from '@tanstack/react-store';
+import { useAppForm } from '@/hooks/useAppForm';
+import { z } from 'zod';
 
 export type ListOption = {
   name: string;
@@ -17,18 +19,30 @@ export type AddToListModalProps = {
 export function AddToListModal(props: AddToListModalProps) {
   const { geometricName, lists, open, onClose, onSelect } = props;
 
-  const [selectedList, setSelectedList] = useState<string | null>(null);
+  const form = useAppForm({
+    defaultValues: {
+      selectedList: '',
+    },
+    validators: {
+      onChange: z.object({
+        selectedList: z.string().min(1),
+      }),
+    },
+  });
+
+  const isFormValid = useSelector(form.store, (state) => state.isValid);
 
   function handleAdd() {
-    if (selectedList) {
-      onSelect(selectedList);
-      setSelectedList(null);
+    const selected = form.state.values.selectedList;
+    if (selected) {
+      onSelect(selected);
+      form.reset();
       onClose();
     }
   }
 
   function handleCancel() {
-    setSelectedList(null);
+    form.reset();
     onClose();
   }
 
@@ -41,37 +55,41 @@ export function AddToListModal(props: AddToListModalProps) {
             No lists available. Create one from the + Add menu first.
           </p>
         ) : (
-          <div className="space-y-2">
-            {lists.map((list) => (
-              <label
-                key={list.name}
-                className="flex cursor-pointer items-center gap-3 rounded bg-zinc-800 px-3 py-2 hover:bg-zinc-700"
-              >
-                <input
-                  type="radio"
-                  name="listSelect"
-                  checked={selectedList === list.name}
-                  onChange={() => {
-                    setSelectedList(list.name);
-                  }}
-                  className="h-4 w-4"
-                />
-                <div>
-                  <span className="text-sm font-medium text-gray-200">{list.name}</span>
-                  <span className="ml-2 text-xs text-gray-500">
-                    ({list.childCount} geometric{list.childCount !== 1 ? 's' : ''})
-                  </span>
-                </div>
-              </label>
-            ))}
-          </div>
+          <form.AppField name="selectedList">
+            {(field) => (
+              <div className="space-y-2">
+                {lists.map((list) => (
+                  <label
+                    key={list.name}
+                    className="flex cursor-pointer items-center gap-3 rounded bg-zinc-800 px-3 py-2 hover:bg-zinc-700"
+                  >
+                    <input
+                      type="radio"
+                      name="listSelect"
+                      checked={field.state.value === list.name}
+                      onChange={() => {
+                        field.handleChange(list.name);
+                      }}
+                      className="h-4 w-4"
+                    />
+                    <div>
+                      <span className="text-sm font-medium text-gray-200">{list.name}</span>
+                      <span className="ml-2 text-xs text-gray-500">
+                        ({list.childCount} geometric{list.childCount !== 1 ? 's' : ''})
+                      </span>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            )}
+          </form.AppField>
         )}
       </ModalBody>
       <ModalFooter>
         <Button color="light" onClick={handleCancel}>
           Cancel
         </Button>
-        <Button color="default" onClick={handleAdd} disabled={!selectedList}>
+        <Button color="default" onClick={handleAdd} disabled={!isFormValid}>
           Add
         </Button>
       </ModalFooter>

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricMoreOptionsDropdown/WrapGeometricModal.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricMoreOptionsDropdown/WrapGeometricModal.tsx
@@ -1,24 +1,6 @@
-import { useState } from 'react';
-import {
-  Modal,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  Button,
-  ToggleSwitch,
-  Select,
-} from 'flowbite-react';
-import { HiPlus, HiXMark } from 'react-icons/hi2';
-
-export type InstanceType = 'translate' | 'rotate_x' | 'rotate_y' | 'rotate_z' | 'scale';
-
-const INSTANCE_LABELS: Record<InstanceType, string> = {
-  rotate_x: 'Rotate X',
-  rotate_y: 'Rotate Y',
-  rotate_z: 'Rotate Z',
-  scale: 'Scale',
-  translate: 'Translate',
-};
+import { useAppForm } from '@/hooks/useAppForm';
+import { Modal, ModalHeader, ModalBody, ModalFooter, Button, ToggleSwitch } from 'flowbite-react';
+import type { InstanceType } from '@/components/form-controls/InstancesBuilderControl';
 
 export type WrapGeometricConfig = {
   instances: InstanceType[];
@@ -36,30 +18,28 @@ export type WrapGeometricModalProps = {
 export function WrapGeometricModal(props: WrapGeometricModalProps) {
   const { geometricName, open, onClose, onWrap } = props;
 
-  const [instances, setInstances] = useState<InstanceType[]>([]);
-  const [pendingInstanceType, setPendingInstanceType] = useState<InstanceType>('translate');
-  const [isConstantVolume, setIsConstantVolume] = useState(false);
-  const [isVirtual, setIsVirtual] = useState(false);
+  // without the cast, TypeScript infers [] as never[]; the form field needs InstanceType[]
+  const form = useAppForm({
+    defaultValues: {
+      instances: [] as InstanceType[],
+      isConstantVolume: false,
+      isVirtual: false,
+    },
+  });
 
   function handleWrap() {
+    const values = form.state.values;
     onWrap({
-      instances,
-      isConstantVolume,
-      isVirtual,
+      instances: values.instances,
+      isConstantVolume: values.isConstantVolume,
+      isVirtual: values.isVirtual,
     });
-    // reset state
-    setInstances([]);
-    setPendingInstanceType('translate');
-    setIsConstantVolume(false);
-    setIsVirtual(false);
+    form.reset();
     onClose();
   }
 
   function handleCancel() {
-    setInstances([]);
-    setPendingInstanceType('translate');
-    setIsConstantVolume(false);
-    setIsVirtual(false);
+    form.reset();
     onClose();
   }
 
@@ -68,76 +48,35 @@ export function WrapGeometricModal(props: WrapGeometricModalProps) {
       <ModalHeader>Wrap {geometricName}</ModalHeader>
       <ModalBody>
         {/* stacked instances builder */}
-        <div className="mb-4">
-          <label className="mb-1 block text-sm font-medium text-gray-300">Instances</label>
-          {instances.length > 0 ? (
-            <div className="mb-2 space-y-1">
-              {instances.map((inst, i) => (
-                <div
-                  key={i}
-                  className="flex items-center justify-between rounded bg-zinc-800 px-2 py-1 text-sm"
-                >
-                  <span className="text-gray-300">
-                    [{i + 1}] {INSTANCE_LABELS[inst]}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setInstances(instances.filter((_, j) => j !== i));
-                    }}
-                    className="text-gray-500 hover:text-red-400"
-                    aria-label={`Remove ${INSTANCE_LABELS[inst]}`}
-                  >
-                    <HiXMark className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="mb-2 text-xs text-gray-500">No transforms applied.</p>
-          )}
-          <div className="flex gap-2">
-            <Select
-              value={pendingInstanceType}
-              onChange={(e) => {
-                // flowbite-react Select onChange yields a generic HTMLSelectElement
-                // event whose value is string; the options are all valid InstanceType values
-                setPendingInstanceType(e.target.value as InstanceType);
-              }}
-              sizing="sm"
-            >
-              <option value="rotate_x">Rotate X</option>
-              <option value="rotate_y">Rotate Y</option>
-              <option value="rotate_z">Rotate Z</option>
-              <option value="scale">Scale</option>
-              <option value="translate">Translate</option>
-            </Select>
-            <Button
-              color="light"
-              size="xs"
-              onClick={() => {
-                setInstances([...instances, pendingInstanceType]);
-              }}
-            >
-              <HiPlus className="mr-1 h-3.5 w-3.5" />
-              Add
-            </Button>
-          </div>
-        </div>
+        <form.AppField name="instances">
+          {(field) => <field.InstancesBuilderControl />}
+        </form.AppField>
 
         {/* constant volume toggle */}
-        <div className="mb-3 flex items-center gap-3">
-          <ToggleSwitch
-            checked={isConstantVolume}
-            onChange={setIsConstantVolume}
-            label="Wrap as Constant Volume?"
-          />
-        </div>
+        <form.AppField name="isConstantVolume">
+          {(field) => (
+            <div className="mb-3 flex items-center gap-3">
+              <ToggleSwitch
+                checked={field.state.value}
+                onChange={(checked) => field.handleChange(checked)}
+                label="Wrap as Constant Volume?"
+              />
+            </div>
+          )}
+        </form.AppField>
 
         {/* virtual toggle */}
-        <div className="mb-3 flex items-center gap-3">
-          <ToggleSwitch checked={isVirtual} onChange={setIsVirtual} label="Wrap as Virtual?" />
-        </div>
+        <form.AppField name="isVirtual">
+          {(field) => (
+            <div className="mb-3 flex items-center gap-3">
+              <ToggleSwitch
+                checked={field.state.value}
+                onChange={(checked) => field.handleChange(checked)}
+                label="Wrap as Virtual?"
+              />
+            </div>
+          )}
+        </form.AppField>
       </ModalBody>
       <ModalFooter>
         <Button color="light" onClick={handleCancel}>


### PR DESCRIPTION
Closes #215

## Summary

Resolves the Issue 215 decision as **migrate + document**: all data-entry modals and form bodies now follow the app's established local TanStack Form pattern (reference: `QuotaEditModal`), and the convention is documented in the react-code-conventions skill.

## Changes

### New shared control
- **`components/form-controls/InstancesBuilderControl.tsx`** — extracts the instances-builder UI (transform list + pending select + Add button) that was duplicated verbatim (~100 lines) between `AddEntityModal` and `WrapGeometricModal`. Owns the `InstanceType` type and labels; binds to an `InstanceType[]` field via `useFieldContext`; the pending-transform select is internal component state. Registered in `useAppForm`. Styled to match `QuotaEditModal`'s bordered-fieldset aesthetic.

### Migrations (raw `useState` → local `useAppForm`)
- **`AddEntityModal`** — 6 `useState` calls → one form with Zod `onChange` validation (image textures require a selected resource, via `superRefine`); transform-on-submit maps the string resource id to `number | undefined`; Create button gated on `isValid`; `form.reset()` on cancel/create
- **`WrapGeometricModal`** — 4 `useState` calls → one form; duplicated `InstanceType`/labels/builder UI deleted in favor of the shared control
- **`AddToListModal`** — selection → form with `z.string().min(1)`; Add button gated on `isValid`
- **`ImportConfigBody`** — `jsonText` → form; submit-time `error`/`isValidating` stay `useState` per the `UploadResourceModal` precedent (imperative JSON.parse + schema validation can't run per-keystroke)

### Docs
- **`react-code-conventions` skill** — new Rule 10 codifying the convention: user-input collection uses a local `useAppForm` instance; raw `useState` is reserved for transient/imperative state (files, submit errors, in-flight flags, visual UI state)

## Notes

- All public contracts unchanged: `AddEntityCreateConfig`, `WrapGeometricConfig`, and every modal props type are identical — no parent components touched
- Net deduplication: ~100 lines of copy-pasted builder UI now live in one control
- Verified: `lint`, `type-check`, and `prettier-check` all pass clean