### PR TITLE
FEAT: Cache decoded textures in ResourceManager to avoid re-fetch + re-decode per checkpoint

### DIFF
--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -90,9 +90,12 @@ async fn main() -> Result<(), String> {
             }
         };
 
+    // create resource manager (must be constructed before render manager)
+    let resource_manager = Arc::new(ResourceManager::new(Arc::clone(&resource_storage)));
+
     // create render manager
     let render_manager = Arc::new(
-        RenderManager::new(Arc::clone(&render_storage), Arc::clone(&resource_storage))
+        RenderManager::new(Arc::clone(&render_storage), Arc::clone(&resource_manager))
             .await
             .map_err(|e| format!("Failed to initialize render manager: {}", e))?,
     );
@@ -103,9 +106,6 @@ async fn main() -> Result<(), String> {
         &config,
         &secrets.auth,
     ));
-
-    // create resource manager
-    let resource_manager = Arc::new(ResourceManager::new(Arc::clone(&resource_storage)));
 
     let router = build_router(&config).with_state(LuxideState::new_with_generated_key(
         Arc::clone(&render_manager),

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -17,8 +17,8 @@ use luxide::{
         textures::{Checker, Image8Bit, Noise, SolidColor},
     },
     tracing::{
-        FileStorage, InMemoryStorage, RenderManager, RenderState, RenderStorage, Scene, SceneWorld,
-        User,
+        FileStorage, InMemoryStorage, RenderManager, RenderState, RenderStorage, ResourceManager,
+        Scene, SceneWorld, User,
     },
     utils::{Angle, Around},
 };
@@ -62,9 +62,12 @@ async fn main() -> Result<(), String> {
     let render_config: RenderConfig = serde_json::from_str(&render_config_str)
         .map_err(|err| format!("Failed to parse configuration file: {}", err))?;
 
+    // create resource manager (for CLI, in-memory storage; no eviction task needed)
+    let resource_manager = Arc::new(ResourceManager::new(Arc::new(InMemoryStorage::new())));
+
     // create render manager
     let render_manager = Arc::new(
-        RenderManager::new(Arc::clone(&storage), Arc::new(InMemoryStorage::new()))
+        RenderManager::new(Arc::clone(&storage), Arc::clone(&resource_manager))
             .await
             .map_err(|e| format!("Failed to initialize render manager: {}", e))?,
     );

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -10,6 +10,7 @@ use textures::TextureRefOrInline;
 use crate::{
     camera::Camera,
     geometry::Geometric,
+    shading::textures::Image8Bit,
     shading::{ColorRgb, Texture, materials::Material},
     tracing::ResourceID,
     tracing::{RenderParameters, Scene},
@@ -42,11 +43,11 @@ pub struct Builts<'a> {
     materials: IndexMap<String, Arc<dyn Material>>,
     textures: IndexMap<String, Arc<dyn Texture>>,
 
-    resources: Option<&'a IndexMap<ResourceID, Vec<u8>>>,
+    resources: Option<&'a IndexMap<(ResourceID, u64), Arc<Image8Bit>>>,
 }
 
 impl<'a> Builts<'a> {
-    fn new(resources: Option<&'a IndexMap<ResourceID, Vec<u8>>>) -> Self {
+    fn new(resources: Option<&'a IndexMap<(ResourceID, u64), Arc<Image8Bit>>>) -> Self {
         Self {
             scenes: IndexMap::new(),
             cameras: IndexMap::new(),
@@ -106,7 +107,7 @@ pub struct RenderConfig {
 impl RenderConfig {
     pub fn compile(
         &self,
-        resources: Option<&IndexMap<ResourceID, Vec<u8>>>,
+        resources: Option<&IndexMap<(ResourceID, u64), Arc<Image8Bit>>>,
     ) -> Result<RenderData, String> {
         let mut builts = Builts::new(resources);
 

--- a/src/deserialization/textures.rs
+++ b/src/deserialization/textures.rs
@@ -63,25 +63,26 @@ impl Build<Arc<dyn Texture>> for TextureData {
                 Ok(Arc::new(Checker::new(*scale, even, odd)))
             }
             Self::Image { resource_id, gamma } => {
-                let data = match builts.resources {
+                match builts.resources {
                     // validation mode — return a 1x1 placeholder, no DB fetch needed
-                    None => {
-                        return Ok(Arc::new(Image8Bit::new(image::RgbaImage::from_pixel(
-                            1,
-                            1,
-                            image::Rgba([255, 0, 255, 255]),
-                        ))));
+                    None => Ok(Arc::new(Image8Bit::new(image::RgbaImage::from_pixel(
+                        1,
+                        1,
+                        image::Rgba([255, 0, 255, 255]),
+                    )))),
+                    Some(resources) => {
+                        let texture =
+                            resources
+                                .get(&(*resource_id, gamma.to_bits()))
+                                .ok_or_else(|| {
+                                    format!(
+                                        "Resource {} with gamma {} not found in pre-loaded data",
+                                        resource_id, gamma
+                                    )
+                                })?;
+                        Ok(Arc::clone(texture) as Arc<dyn Texture>)
                     }
-                    Some(resources) => resources.get(resource_id).ok_or_else(|| {
-                        format!("Resource {} not found in pre-loaded data", resource_id)
-                    })?,
-                };
-
-                let image_texture = Image8Bit::from_bytes(data, *gamma).map_err(|err| {
-                    format!("Error loading image from resource {}: {}", resource_id, err)
-                })?;
-
-                Ok(Arc::new(image_texture))
+                }
             }
             Self::SolidColor { color } => Ok(Arc::new(SolidColor::from(ColorRgb::from(*color)))),
         }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -7,6 +7,8 @@ pub use render_manager::*;
 mod resource_manager;
 pub use resource_manager::*;
 
+mod texture_cache;
+
 mod scene;
 pub use scene::*;
 

--- a/src/tracing/render_manager.rs
+++ b/src/tracing/render_manager.rs
@@ -21,15 +21,12 @@ use super::{Render, RenderCheckpoint, RenderID, RenderStorage, Role, StorageErro
 
 use std::collections::HashSet;
 
-use indexmap::IndexMap;
-
-use crate::deserialization::TextureData;
-use crate::tracing::{ResourceID, ResourceStorage};
+use crate::tracing::ResourceManager;
 
 #[derive(Clone)]
 pub struct RenderManager {
     storage: Arc<dyn RenderStorage>,
-    resource_storage: Arc<dyn ResourceStorage>,
+    resource_manager: Arc<ResourceManager>,
     global_thread_pool: Option<Arc<rayon::ThreadPool>>,
     running_renders: Arc<Mutex<HashSet<RenderID>>>,
     render_state_streams: Arc<RenderStreamRegistry>,
@@ -40,19 +37,19 @@ const POLLING_INTERVAL_MS: u64 = 100;
 impl RenderManager {
     pub async fn new(
         storage: Arc<dyn RenderStorage>,
-        resource_storage: Arc<dyn ResourceStorage>,
+        resource_manager: Arc<ResourceManager>,
     ) -> Result<Self, String> {
-        Self::new_with_optional_global_thread_pool(storage, resource_storage, None).await
+        Self::new_with_optional_global_thread_pool(storage, resource_manager, None).await
     }
 
     pub async fn new_with_global_thread_pool(
         storage: Arc<dyn RenderStorage>,
-        resource_storage: Arc<dyn ResourceStorage>,
+        resource_manager: Arc<ResourceManager>,
         threads: Threads,
     ) -> Result<Self, String> {
         Self::new_with_optional_global_thread_pool(
             storage,
-            resource_storage,
+            resource_manager,
             Some(Arc::new(
                 rayon::ThreadPoolBuilder::new()
                     .num_threads(threads.effective_count())
@@ -65,7 +62,7 @@ impl RenderManager {
 
     pub async fn new_with_optional_global_thread_pool(
         storage: Arc<dyn RenderStorage>,
-        resource_storage: Arc<dyn ResourceStorage>,
+        resource_manager: Arc<ResourceManager>,
         thread_pool: Option<Arc<rayon::ThreadPool>>,
     ) -> Result<Self, String> {
         // find any renders that were left in Running or Pausing state
@@ -95,7 +92,7 @@ impl RenderManager {
 
         Ok(Self {
             storage,
-            resource_storage,
+            resource_manager,
             global_thread_pool: thread_pool,
             running_renders: Arc::new(Mutex::new(HashSet::new())),
             render_state_streams: Arc::new(RenderStreamRegistry::default()),
@@ -175,7 +172,7 @@ impl RenderManager {
 
         let running_renders = Arc::clone(&self.running_renders);
         let storage = Arc::clone(&self.storage);
-        let resource_storage = Arc::clone(&self.resource_storage);
+        let resource_manager = Arc::clone(&self.resource_manager);
         let thread_pool = self.global_thread_pool.as_ref().cloned();
         let render_state_streams = Arc::clone(&self.render_state_streams);
 
@@ -232,9 +229,7 @@ impl RenderManager {
             };
 
             let resources =
-                match Self::preload_resource_data_from_storage(&render.config, &*resource_storage)
-                    .await
-                {
+                match resource_manager.get_textures_for_config(&render.config).await {
                     Ok(data) => data,
                     Err(e) => {
                         println!(
@@ -1043,27 +1038,6 @@ impl RenderManager {
         &self.render_state_streams
     }
 
-    /// Pre-load resource data referenced by textures in a render config.
-    /// This is needed because the spawn closure can't call `self`.
-    async fn preload_resource_data_from_storage(
-        config: &RenderConfig,
-        resource_storage: &dyn ResourceStorage,
-    ) -> Result<IndexMap<ResourceID, Vec<u8>>, StorageError> {
-        let mut ids = std::collections::HashSet::new();
-        for texture in config.textures.values() {
-            if let TextureData::Image { resource_id, .. } = texture {
-                ids.insert(*resource_id);
-            }
-        }
-
-        let mut result = IndexMap::new();
-        for id in ids {
-            if let Some(resource) = resource_storage.get_resource(id).await? {
-                result.insert(id, resource.data);
-            }
-        }
-        Ok(result)
-    }
 }
 
 #[derive(Clone, Copy, Serialize)]

--- a/src/tracing/resource_manager.rs
+++ b/src/tracing/resource_manager.rs
@@ -14,14 +14,68 @@ use super::{
     Resource, ResourceID, ResourceMeta, ResourceStorage, ResourceType, StorageError, User, UserID,
 };
 
+use std::collections::HashSet;
+
+use super::texture_cache::TextureCache;
+
+use indexmap::IndexMap;
+
+use crate::deserialization::{RenderConfig, TextureData};
+
 #[derive(Clone)]
 pub struct ResourceManager {
     storage: Arc<dyn ResourceStorage>,
+    texture_cache: Arc<TextureCache>,
 }
 
 impl ResourceManager {
     pub fn new(storage: Arc<dyn ResourceStorage>) -> Self {
-        Self { storage }
+        Self {
+            storage,
+            texture_cache: TextureCache::new(),
+        }
+    }
+
+    // preload all image textures referenced by a render config.
+    // checks the cache first; on miss, fetches from storage, decodes, and caches.
+    pub async fn get_textures_for_config(
+        &self,
+        config: &RenderConfig,
+    ) -> Result<IndexMap<(ResourceID, u64), Arc<Image8Bit>>, StorageError> {
+        // collect unique (resource_id, gamma) pairs from config
+        let mut pairs = HashSet::new();
+        for texture in config.textures.values() {
+            if let TextureData::Image { resource_id, gamma } = texture {
+                pairs.insert((*resource_id, gamma.to_bits()));
+            }
+        }
+
+        let mut result = IndexMap::new();
+        for (resource_id, gamma_bits) in pairs {
+            let key = (resource_id, gamma_bits);
+
+            // check cache first
+            if let Some(texture) = self.texture_cache.get(&key) {
+                result.insert(key, texture);
+                continue;
+            }
+
+            // cache miss: fetch from storage, decode, cache
+            if let Some(resource) = self.storage.get_resource(resource_id).await? {
+                let gamma = f64::from_bits(gamma_bits);
+                let image = Image8Bit::from_bytes(&resource.data, gamma).map_err(|e| {
+                    StorageError(format!(
+                        "Failed to decode image for resource {}: {}",
+                        resource_id, e
+                    ))
+                })?;
+                let texture = Arc::new(image);
+                self.texture_cache.insert(key, Arc::clone(&texture));
+                result.insert(key, texture);
+            }
+        }
+
+        Ok(result)
     }
 
     pub async fn create_resource(

--- a/src/tracing/texture_cache.rs
+++ b/src/tracing/texture_cache.rs
@@ -1,0 +1,68 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
+
+use crate::shading::textures::Image8Bit;
+
+use super::ResourceID;
+
+pub(crate) const TEXTURE_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+pub(crate) const TEXTURE_CACHE_EVICTION_INTERVAL: Duration = Duration::from_secs(30);
+
+struct CacheEntry {
+    texture: Arc<Image8Bit>,
+    last_accessed: Instant,
+}
+
+pub(crate) struct TextureCache {
+    entries: RwLock<HashMap<(ResourceID, u64), CacheEntry>>,
+}
+
+impl TextureCache {
+    pub(crate) fn new() -> Arc<Self> {
+        let cache = Arc::new(Self {
+            entries: RwLock::new(HashMap::new()),
+        });
+
+        // spawn periodic eviction
+        let cache_clone = Arc::clone(&cache);
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(TEXTURE_CACHE_EVICTION_INTERVAL).await;
+                cache_clone.evict_expired(TEXTURE_CACHE_TTL);
+            }
+        });
+
+        cache
+    }
+
+    // returns a clone if found, and updates last_accessed
+    pub(crate) fn get(&self, key: &(ResourceID, u64)) -> Option<Arc<Image8Bit>> {
+        let mut entries = self.entries.write().unwrap();
+        if let Some(entry) = entries.get_mut(key) {
+            entry.last_accessed = Instant::now();
+            Some(Arc::clone(&entry.texture))
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn insert(&self, key: (ResourceID, u64), texture: Arc<Image8Bit>) {
+        let mut entries = self.entries.write().unwrap();
+        entries.insert(
+            key,
+            CacheEntry {
+                texture,
+                last_accessed: Instant::now(),
+            },
+        );
+    }
+
+    pub(crate) fn evict_expired(&self, ttl: Duration) {
+        let now = Instant::now();
+        let mut entries = self.entries.write().unwrap();
+        entries.retain(|_, entry| now.duration_since(entry.last_accessed) < ttl);
+    }
+}


### PR DESCRIPTION
Closes #216.

## Problem

Resources (image textures) were re-fetched from storage and re-decoded with gamma correction on **every checkpoint iteration** of a running render. Zero in-memory caching.

## Solution

Added a `TextureCache` inside `ResourceManager` that caches **decoded** `Arc<Image8Bit>` textures keyed by `(resource_id, gamma_bits)` with access-time TTL eviction (5 min).

### Architecture

```
Before (every checkpoint):                    After (first checkpoint only):
  Storage.get_resource()  ←─ DB I/O             TextureCache.get()  ←─ RAM hit
  Image8Bit::from_bytes() ←─ CPU decode+γ            │ miss
  compile() → render                                Storage.get_resource()
       ↓ repeat × N                                 Image8Bit::from_bytes()
                                               compile() → render
                                                    ↓
                                               checkpoint N: cache hit (Arc::clone)
```

- **Cache hits**: `Arc::clone` — instant, no I/O, no decode
- **Eviction**: background tokio task every 30s removes entries idle for 5+ minutes
- **Scope**: shared across renders — if two concurrent renders use the same texture, it's cached once

### Changes (8 files)

| File | Change |
|------|--------|
| `src/tracing/texture_cache.rs` | New — `TextureCache` with `RwLock<HashMap>`, access-time TTL, auto-spawning tokio eviction task |
| `src/tracing/resource_manager.rs` | Owns `Arc<TextureCache>`, adds `get_textures_for_config()` cache-first preload method |
| `src/deserialization.rs` | `Builts.resources` type: raw bytes → pre-decoded `Arc<Image8Bit>` keyed by `(ResourceID, u64)` |
| `src/deserialization/textures.rs` | `TextureData::Image::build` — skips decode, clones cached `Arc` |
| `src/tracing/render_manager.rs` | Uses `Arc<ResourceManager>` instead of raw `ResourceStorage`, removes `preload_resource_data_from_storage` |
| `src/bin/api.rs` | Constructs `ResourceManager` first, passes to `RenderManager` |
| `src/bin/cli.rs` | Same construction order for CLI builds |
| `src/tracing.rs` | Module declaration for `texture_cache` |