### PR TITLE
chore: sign refresh_token cookie with a static key from secrets

### DIFF
--- a/justfile
+++ b/justfile
@@ -124,3 +124,7 @@ setup-ui-env:
 generate-jwt-keypair-pem:
     openssl genpkey -algorithm RSA -out jwt-key-private.pem -pkeyopt rsa_keygen_bits:2048
     openssl rsa -in jwt-key-private.pem -pubout -out jwt-key-public.pem
+
+[group('misc')]
+generate-cookie-jar-signing-key:
+    @openssl rand -base64 64 | tr -d '\n'; echo

--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -1,5 +1,7 @@
 use std::{path::PathBuf, sync::Arc};
 
+use axum_extra::extract::cookie::Key;
+use base64::Engine as _;
 use clap::{Parser, ValueEnum};
 use luxide::{
     config::{
@@ -107,10 +109,22 @@ async fn main() -> Result<(), String> {
         &secrets.auth,
     ));
 
-    let router = build_router(&config).with_state(LuxideState::new_with_generated_key(
+    // build the cookie signing key from secrets so signed cookies survive restarts
+    let cookie_key_bytes = base64::engine::general_purpose::STANDARD
+        .decode(&secrets.auth.cookie_jar_signing_key)
+        .map_err(|e| format!("Failed to base64-decode auth.cookie_jar_signing_key: {}", e))?;
+    let cookie_jar_key = Key::try_from(cookie_key_bytes.as_slice()).map_err(|e| {
+        format!(
+            "Invalid auth.cookie_jar_signing_key (need at least 64 decoded bytes): {}",
+            e
+        )
+    })?;
+
+    let router = build_router(&config).with_state(LuxideState::new(
         Arc::clone(&render_manager),
         Arc::clone(&auth_manager),
         Arc::clone(&resource_manager),
+        cookie_jar_key,
     ));
 
     let (_, serve_result) = tokio::join!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,14 +60,15 @@ pub struct ApiSecrets {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct AuthSecrets {
+    pub cookie_jar_signing_key: String,
     pub github: GitHubSecrets,
     pub jwt: JwtSecrets,
-    pub admin_github_ids: Vec<GithubID>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct GitHubSecrets {
+    pub admin_user_ids: Vec<GithubID>,
     pub client_id: String,
     pub client_secret: String,
 }

--- a/src/server/auth_manager.rs
+++ b/src/server/auth_manager.rs
@@ -90,7 +90,7 @@ impl AuthManager {
 
         Self {
             storage,
-            admin_github_ids: secrets.admin_github_ids.clone(),
+            admin_github_ids: secrets.github.admin_user_ids.clone(),
             jwt_encoding_secret: EncodingKey::from_rsa_pem(&jwt_private_key)
                 .expect("Failed to parse JWT encoding secret PEM"),
             jwt_decoding_secret: DecodingKey::from_rsa_pem(&jwt_public_key)

--- a/src/server/handlers/auth_refresh.rs
+++ b/src/server/handlers/auth_refresh.rs
@@ -23,6 +23,9 @@ pub async fn auth_refresh(
     let refresh_token = match cookie_jar.get("refresh_token") {
         Some(cookie) => cookie.value().to_string(),
         None => {
+            eprintln!(
+                "Refresh attempt with missing or unverifiable refresh_token cookie (possible cookie signing key mismatch)"
+            );
             return (
                 StatusCode::UNAUTHORIZED,
                 Json(serde_json::json!({
@@ -54,7 +57,7 @@ pub async fn auth_refresh(
                 .into_response()
         }
         Err(e) => {
-            eprintln!("Failed to refresh token: {}", e);
+            eprintln!("Refresh token rejected: {}", e);
             (
                 StatusCode::UNAUTHORIZED,
                 Json(serde_json::json!({

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -30,19 +30,6 @@ impl LuxideState {
             cookie_jar_key,
         }
     }
-
-    pub fn new_with_generated_key(
-        render_manager: Arc<RenderManager>,
-        auth_manager: Arc<AuthManager>,
-        resource_manager: Arc<ResourceManager>,
-    ) -> Self {
-        Self::new(
-            render_manager,
-            auth_manager,
-            resource_manager,
-            Key::generate(),
-        )
-    }
 }
 
 impl FromRef<LuxideState> for Key {


### PR DESCRIPTION
## Problem

The `refresh_token` cookie is a signed cookie (`SignedCookieJar`), but the signing key was created with `Key::generate()` on every server start. After any restart, the new key could not verify existing cookie signatures, so `cookie_jar.get("refresh_token")` returned `None` and every user was forced to log in again — even though their refresh tokens were still perfectly valid in the database. The misleading part: this surfaced as the same 401 `"refresh token expired or revoked"` used for genuinely rejected tokens.

## Changes

- **`src/config.rs`**: add required `auth.cookie_jar_signing_key` (a base64-encoded string of 64+ random bytes) to the secrets schema. Also move `admin_github_ids` into `GitHubSecrets` as `admin_user_ids`.
- **`src/bin/api.rs`**: decode the key at startup and build the cookie `Key` via `Key::try_from` (clear startup errors on bad base64 or short keys), passing it through `LuxideState::new`.
- **`src/server/state.rs`**: remove the now-unused `new_with_generated_key` constructor.
- **`src/server/handlers/auth_refresh.rs`**: differentiate the two 401 paths in server logs — "missing or unverifiable cookie (possible signing key mismatch)" vs "refresh token rejected". Client-visible responses are unchanged.
- **`justfile`**: add `just generate-cookie-jar-signing-key` to print a suitable key to the console.

## Deployment note

`luxide.secret.json` must gain the new `auth.cookie_jar_signing_key` field before the server will start (required field, parse error otherwise). Generate one with `just generate-cookie-jar-signing-key`. Existing cookies signed by the old ephemeral key require one final re-login; orphaned `refresh_tokens` rows will age out naturally.

## Verification

- `cargo check --workspace` and `cargo clippy -- -D clippy::correctness` pass
- Manually verified: server restart no longer invalidates sessions; refresh succeeds after restart