### PR TITLE
FIX: Use frame-relative depth for list item indentation in geometric tree

### DIFF
--- a/ui/src/views/renders/new/Controls/shared/DraggableGroup.tsx
+++ b/ui/src/views/renders/new/Controls/shared/DraggableGroup.tsx
@@ -7,10 +7,11 @@ export type DraggableGroupProps = {
   id: string;
   children: React.ReactNode;
   depth?: number;
+  handleOffset?: boolean;
 };
 
 export function DraggableGroup(props: DraggableGroupProps) {
-  const { id, children, depth = 0 } = props;
+  const { id, children, depth = 0, handleOffset = false } = props;
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
@@ -24,12 +25,18 @@ export function DraggableGroup(props: DraggableGroupProps) {
     '--row-depth': depth,
   } as React.CSSProperties;
 
+  // when handleOffset is set, the drag handle "hangs" into the indent gutter
+  // so the row's content edge lands exactly on the depth grid
+  const marginClass = handleOffset
+    ? 'ml-[calc(var(--row-depth)*0.75rem-1.5rem)]'
+    : 'ml-[calc(var(--row-depth)*0.75rem)]';
+
   const childArray = Children.toArray(children);
   const [first, ...rest] = childArray;
   const hasRest = rest.length > 0;
 
   return (
-    <div ref={setNodeRef} style={style} className="ml-[calc(var(--row-depth)*0.75rem)] min-w-0">
+    <div ref={setNodeRef} style={style} className={`${marginClass} min-w-0`}>
       <div className="flex items-center">
         <button
           type="button"

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/index.tsx
@@ -212,13 +212,22 @@ export function GeometricControls(props: GeometricControlsProps) {
 
   // renders a node and its descendants recursively.
   // parentIsList: true when the direct parent is a list (children get DraggableGroup).
-  function renderNode(node: GeometricDisplayNode, parentIsList: boolean): React.ReactNode {
+  // frameDepth: depth of the nearest ancestor that owns a DraggableGroup rest area,
+  // so indentation is relative to that owner's row edge rather than absolute depth.
+  function renderNode(
+    node: GeometricDisplayNode,
+    parentIsList: boolean,
+    frameDepth: number,
+  ): React.ReactNode {
     const children = childrenByParent.get(node.formName) ?? [];
     const isRoot = node.parentID === null;
     const isList = node.type === 'list';
     const nextIsList = isList;
 
-    const grandchildren = children.map((child) => renderNode(child, nextIsList));
+    // roots and list children start a new frame, shifting the coordinate base.
+    // plain nodes inherit the current frame.
+    const nextFrameDepth = isRoot || parentIsList ? node.depth : frameDepth;
+    const grandchildren = children.map((child) => renderNode(child, nextIsList, nextFrameDepth));
 
     if (isRoot) {
       // root always gets a DraggableGroup. list children are rendered as flat siblings
@@ -238,13 +247,14 @@ export function GeometricControls(props: GeometricControlsProps) {
     }
 
     if (parentIsList) {
-      // list child — gets its own DraggableGroup for reordering.
-      // rendered as a flat sibling by the parent list root.
+      // frame-relative depth: the parent DraggableGroup's rest area shifts the
+      // coordinate base to the parent row edge, so indent from there.
       return (
         <DraggableGroup
           key={node.formName}
           id={makeListChildID(node.parentID!, node.formName)}
-          depth={1}
+          depth={node.depth - frameDepth}
+          handleOffset
         >
           <GeometricRow
             form={form}
@@ -263,7 +273,7 @@ export function GeometricControls(props: GeometricControlsProps) {
         <GeometricRow
           form={form}
           geometricName={node.formName}
-          depth={node.depth}
+          depth={node.depth - frameDepth}
           isUsedByActiveScene={node.isUsedByActiveScene}
           isDirectlyInActiveScene={node.isDirectlyInActiveScene}
         />
@@ -284,7 +294,7 @@ export function GeometricControls(props: GeometricControlsProps) {
       onDragEnd={handleDragEnd}
     >
       <SortableContext items={allSortableIDs} strategy={verticalListSortingStrategy}>
-        <div className="flex flex-col">{roots.map((node) => renderNode(node, false))}</div>
+        <div className="flex flex-col">{roots.map((node) => renderNode(node, false, 0))}</div>
       </SortableContext>
       <DragOverlay>
         {activeID
@@ -309,7 +319,7 @@ export function GeometricControls(props: GeometricControlsProps) {
                     isUsedByActiveScene={node.isUsedByActiveScene}
                     isDirectlyInActiveScene={node.isDirectlyInActiveScene}
                   />
-                  {childNodes.map((child) => renderNode(child, false))}
+                  {childNodes.map((child) => renderNode(child, false, 0))}
                 </div>
               );
             })()


### PR DESCRIPTION
## Problem

In the geometric tree on the new render form, list children were always indented as if they were exactly 3 depth units deep, regardless of how deeply nested the list itself was. Deeply nested lists could even render their children *left* of the list row itself.

Root cause (in `GeometricControls/index.tsx:renderNode`):
- list children used a hardcoded `depth={1}` on their `DraggableGroup` instead of the tree's computed depth (1 unit)
- each list child carries its own inline drag handle (~1.5rem), pushing its row a further 2 units right

Meanwhile, plain (non-list) rows used absolute-depth margins, but `DraggableGroup` rest areas shift the coordinate base to the owner's row edge — so absolute and static offsets never reconciled.

## Fix

- **`DraggableGroup.tsx`**: new optional `handleOffset` prop. When set, the left margin becomes `calc(depth*0.75rem - 1.5rem)` so the drag handle hangs into the indent gutter and the row's content edge lands exactly on the depth grid. Default behavior unchanged.
- **`GeometricControls/index.tsx`**: `renderNode` now threads a `frameDepth` (depth of the nearest ancestor owning a `DraggableGroup` rest area). Plain rows and list-child groups use frame-relative depth (`node.depth - frameDepth`); list-child groups also get `handleOffset`. Roots and the `DragOverlay` are unchanged.

Result: every nesting level — plain children, list children, nested lists, lists wrapped in transforms — steps by a uniform 0.75rem.

## Verification

- `npm run type-check` passes
- `eslint` and `prettier --check` clean on both files