### PR TITLE
FEAT: image texture previews in controls/modal + server-side image resize

### DIFF
--- a/src/server/handlers/get_resource_data.rs
+++ b/src/server/handlers/get_resource_data.rs
@@ -9,11 +9,17 @@ use crate::{
     tracing::ResourceID,
 };
 
+#[derive(serde::Deserialize)]
+pub struct ResizeParams {
+    pub max_dim: Option<u32>,
+}
+
 pub async fn get_resource_data(
     State(state): State<LuxideState>,
     claims: Claims,
     Path(id): Path<ResourceID>,
     Query(requested_user_id): Query<RequestedUserID>,
+    Query(resize_params): Query<ResizeParams>,
 ) -> Response {
     println!("Handling request for get_resource_data (id: {})...", id);
 
@@ -25,18 +31,112 @@ pub async fn get_resource_data(
             Err((status, message)) => return (status, message).into_response(),
         };
 
-    match state.resource_manager.get_resource(id, effective_user_id).await {
-        Ok(Some(resource)) => (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, resource.mime_type)],
-            resource.data,
-        )
-            .into_response(),
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            format!("Resource {} not found", id),
-        )
-            .into_response(),
+    match state
+        .resource_manager
+        .get_resource(id, effective_user_id)
+        .await
+    {
+        Ok(Some(resource)) => match resize_params.max_dim {
+            None => (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, resource.mime_type)],
+                resource.data,
+            )
+                .into_response(),
+            Some(0) => (StatusCode::BAD_REQUEST, "max_dim must be at least 1").into_response(),
+            Some(n) => {
+                let max_dim = n;
+
+                // peeking at dimensions via the image header avoids decoding the full image
+                let dims = image::io::Reader::new(std::io::Cursor::new(&resource.data))
+                    .with_guessed_format()
+                    .ok()
+                    .and_then(|r| r.into_dimensions().ok());
+
+                let dims = match dims {
+                    Some(d) => d,
+                    None => {
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Failed to read image dimensions for resource {}", id),
+                        )
+                            .into_response();
+                    }
+                };
+
+                // no resize needed, return original bytes as-is
+                if dims.0.max(dims.1) <= max_dim {
+                    return (
+                        StatusCode::OK,
+                        [(header::CONTENT_TYPE, resource.mime_type)],
+                        resource.data,
+                    )
+                        .into_response();
+                }
+
+                let mime_type = resource.mime_type;
+                let data = resource.data;
+
+                // decode, resize, and re-encode are CPU-heavy — offload to
+                // spawn_blocking to avoid stalling the async runtime
+                match tokio::task::spawn_blocking(move || resize_image(data, mime_type, max_dim))
+                    .await
+                {
+                    Ok(Ok((bytes, content_type))) => (
+                        StatusCode::OK,
+                        [(header::CONTENT_TYPE, content_type)],
+                        bytes,
+                    )
+                        .into_response(),
+                    Ok(Err(msg)) => (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Failed to resize image for resource {}: {}", id, msg),
+                    )
+                        .into_response(),
+                    Err(_) => (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Internal error resizing image for resource {}", id),
+                    )
+                        .into_response(),
+                }
+            }
+        },
+        Ok(None) => (StatusCode::NOT_FOUND, format!("Resource {} not found", id)).into_response(),
         Err(e) => e.into(),
     }
+}
+
+fn resize_image(
+    data: Vec<u8>,
+    mime_type: String,
+    max_dim: u32,
+) -> Result<(Vec<u8>, String), String> {
+    let img = image::load_from_memory(&data).map_err(|e| e.to_string())?;
+    let resized = img.thumbnail(max_dim, max_dim);
+
+    // try to write back in the original format; default to png if unsupported
+    let format_opt = image::ImageFormat::from_mime_type(&mime_type);
+    let (format, content_type) = format_opt
+        .and_then(|f| {
+            if f.can_write() {
+                Some((f, mime_type))
+            } else {
+                None
+            }
+        })
+        .unwrap_or((image::ImageFormat::Png, "image/png".to_string()));
+
+    // jpeg encoder rejects rgba pixels — convert to rgb beforehand
+    let output_image = if format == image::ImageFormat::Jpeg {
+        image::DynamicImage::ImageRgb8(resized.to_rgb8())
+    } else {
+        resized
+    };
+
+    let mut buf = Vec::new();
+    output_image
+        .write_to(&mut std::io::Cursor::new(&mut buf), format)
+        .map_err(|e| e.to_string())?;
+
+    Ok((buf, content_type))
 }

--- a/ui/src/components/ResourceImagePreview.tsx
+++ b/ui/src/components/ResourceImagePreview.tsx
@@ -7,7 +7,8 @@ export type ResourceImagePreviewProps = {
 export function ResourceImagePreview(props: ResourceImagePreviewProps) {
   const { resourceId } = props;
 
-  const url = useResourceImageUrl(resourceId);
+  // request 2x display size for hi-dpi screens
+  const url = useResourceImageUrl(resourceId, 256);
 
   if (resourceId === undefined) {
     return null;

--- a/ui/src/components/ResourceImagePreview.tsx
+++ b/ui/src/components/ResourceImagePreview.tsx
@@ -1,0 +1,29 @@
+import { useResourceImageUrl } from '@/hooks/useResourceImageUrl';
+
+export type ResourceImagePreviewProps = {
+  resourceId: number | undefined;
+};
+
+export function ResourceImagePreview(props: ResourceImagePreviewProps) {
+  const { resourceId } = props;
+
+  const url = useResourceImageUrl(resourceId);
+
+  if (resourceId === undefined) {
+    return null;
+  }
+
+  if (url === null) {
+    return (
+      <div className="h-32 w-full animate-pulse rounded-md border border-zinc-700 bg-zinc-800" />
+    );
+  }
+
+  return (
+    <img
+      src={url}
+      alt="Texture image preview"
+      className="h-32 w-full rounded-md border border-zinc-700 bg-zinc-900/50 object-contain"
+    />
+  );
+}

--- a/ui/src/hooks/useImageMap.ts
+++ b/ui/src/hooks/useImageMap.ts
@@ -1,20 +1,17 @@
 import { useEffect, useState } from 'react';
 import * as THREE from 'three';
-import { useResourceDataQuery } from './useResourceData';
+import { useResourceImageUrl } from './useResourceImageUrl';
 
 export function useImageMap(resourceId: number | undefined): THREE.Texture | null {
   const [map, setMap] = useState<THREE.Texture | null>(null);
 
-  const { data: blob } = useResourceDataQuery(resourceId ?? 0, {
-    enabled: resourceId !== undefined,
-  });
+  const url = useResourceImageUrl(resourceId);
 
   useEffect(() => {
-    if (!blob) {
+    if (!url) {
       return;
     }
 
-    const url = URL.createObjectURL(blob);
     const loader = new THREE.TextureLoader();
     loader.load(
       url,
@@ -26,11 +23,7 @@ export function useImageMap(resourceId: number | undefined): THREE.Texture | nul
         console.warn('Failed to load texture from resource', resourceId);
       },
     );
-
-    return () => {
-      URL.revokeObjectURL(url);
-    };
-  }, [blob, resourceId]);
+  }, [url, resourceId]);
 
   return resourceId !== undefined ? map : null;
 }

--- a/ui/src/hooks/useImageMap.ts
+++ b/ui/src/hooks/useImageMap.ts
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react';
 import * as THREE from 'three';
 import { useResourceImageUrl } from './useResourceImageUrl';
 
-export function useImageMap(resourceId: number | undefined): THREE.Texture | null {
+export function useImageMap(resourceId: number | undefined, maxDim?: number): THREE.Texture | null {
   const [map, setMap] = useState<THREE.Texture | null>(null);
 
-  const url = useResourceImageUrl(resourceId);
+  const url = useResourceImageUrl(resourceId, maxDim);
 
   useEffect(() => {
     if (!url) {

--- a/ui/src/hooks/useResourceData.ts
+++ b/ui/src/hooks/useResourceData.ts
@@ -5,22 +5,23 @@ import { useAdminUserOverride } from '@/providers/AdminUserOverride';
 
 export type UseResourceDataOptions = {
   enabled?: boolean;
+  maxDim?: number;
 };
 
 export function useResourceDataQuery(resourceId: number, options: UseResourceDataOptions = {}) {
-  const { enabled = true } = options;
+  const { enabled = true, maxDim } = options;
 
   const { authenticatedFetch, accessToken } = useAuth();
   const { targetUserID } = useAdminUserOverride();
 
   return useQuery({
-    queryKey: resourceDataQueryKey(resourceId),
-    queryFn: () => getResourceData(authenticatedFetch, resourceId, targetUserID),
+    queryKey: resourceDataQueryKey(resourceId, maxDim),
+    queryFn: () => getResourceData(authenticatedFetch, resourceId, targetUserID, maxDim),
     enabled: enabled && accessToken !== undefined,
     staleTime: Infinity,
   });
 }
 
-export function resourceDataQueryKey(resourceId: number) {
-  return ['resourceData', resourceId] as const;
+export function resourceDataQueryKey(resourceId: number, maxDim?: number) {
+  return ['resourceData', resourceId, maxDim ?? 'full'] as const;
 }

--- a/ui/src/hooks/useResourceImageUrl.ts
+++ b/ui/src/hooks/useResourceImageUrl.ts
@@ -1,9 +1,13 @@
 import { useEffect, useMemo } from 'react';
 import { useResourceDataQuery } from './useResourceData';
 
-export function useResourceImageUrl(resourceId: number | undefined): string | null {
+export function useResourceImageUrl(
+  resourceId: number | undefined,
+  maxDim?: number,
+): string | null {
   const { data: blob } = useResourceDataQuery(resourceId ?? 0, {
     enabled: resourceId !== undefined,
+    maxDim,
   });
 
   const url = useMemo(() => {

--- a/ui/src/hooks/useResourceImageUrl.ts
+++ b/ui/src/hooks/useResourceImageUrl.ts
@@ -1,0 +1,27 @@
+import { useEffect, useMemo } from 'react';
+import { useResourceDataQuery } from './useResourceData';
+
+export function useResourceImageUrl(resourceId: number | undefined): string | null {
+  const { data: blob } = useResourceDataQuery(resourceId ?? 0, {
+    enabled: resourceId !== undefined,
+  });
+
+  const url = useMemo(() => {
+    if (blob === null || blob === undefined) {
+      return null;
+    }
+    return URL.createObjectURL(blob);
+  }, [blob]);
+
+  useEffect(() => {
+    if (url === null) {
+      return;
+    }
+    // revoke the object URL when it is replaced or unmounted to avoid leaking memory
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [url]);
+
+  return resourceId !== undefined ? url : null;
+}

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -534,10 +534,11 @@ export async function getResourceData(
   fetcher: typeof fetch,
   resourceID: number,
   targetUserID?: number,
+  maxDim?: number,
 ): Promise<Blob | null> {
-  const response = await fetcher(
-    appendUserID(`${getAPIURL()}/resources/${resourceID}/data`, targetUserID),
-  );
+  const baseURL = `${getAPIURL()}/resources/${resourceID}/data`;
+  const urlWithSize = maxDim !== undefined ? `${baseURL}?max_dim=${maxDim}` : baseURL;
+  const response = await fetcher(appendUserID(urlWithSize, targetUserID));
 
   if (response.status === 404) {
     return null;

--- a/ui/src/views/renders/new/Controls/shared/AddEntityModal.tsx
+++ b/ui/src/views/renders/new/Controls/shared/AddEntityModal.tsx
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import type { InstanceType } from '@/components/form-controls/InstancesBuilderControl';
 import type { EntityType, EntitySubType, AddEntityDropdownOption } from './AddEntityDropdown';
 import { useAllResourceMetadataQuery } from '@/hooks/useResources';
+import { ResourceImagePreview } from '@/components/ResourceImagePreview';
 
 export type AddEntityCreateConfig = {
   customName?: string;
@@ -192,6 +193,11 @@ export function AddEntityModal<T extends EntityType>(props: AddEntityModalProps<
                     No resources available. Upload one on the Resources page.
                   </p>
                 )}
+                <div className="mt-3">
+                  <ResourceImagePreview
+                    resourceId={field.state.value === '' ? undefined : Number(field.state.value)}
+                  />
+                </div>
               </div>
             )}
           </form.AppField>

--- a/ui/src/views/renders/new/Controls/tabs/TextureControls/TextureRow.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/TextureControls/TextureRow.tsx
@@ -13,6 +13,7 @@ import { InfoIconDefaultEntity } from '../../shared/icons/InfoIconDefaultEntity'
 import { DuplicateDropdown } from '../../shared/DuplicateDropdown';
 import { duplicateTexture } from '@/utils/render/utils';
 import { useAllResourceMetadataQuery } from '@/hooks/useResources';
+import { ResourceImagePreview } from '@/components/ResourceImagePreview';
 
 export type TextureRowProps = {
   form: RenderForm;
@@ -107,6 +108,7 @@ export function TextureRow(props: TextureRowProps) {
         const resource = resources?.find((r) => r.id === data.resource_id);
         return (
           <div className="flex flex-col gap-1 text-sm text-zinc-400">
+            <ResourceImagePreview resourceId={data.resource_id} />
             <div>
               <span className="text-zinc-500">Resource: </span>
               {resource ? resource.name : `#${data.resource_id}`}

--- a/ui/src/views/renders/new/Scene/MaterialResolver.tsx
+++ b/ui/src/views/renders/new/Scene/MaterialResolver.tsx
@@ -6,6 +6,9 @@ import { getTextureDataSafe } from '@/utils/render/texture';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { useImageMap } from '@/hooks/useImageMap';
 
+// viewport preview textures don't need full resolution; the actual render always uses the original
+const VIEWPORT_TEXTURE_MAX_DIM = 1024;
+
 export type MaterialResolverProps = {
   config: NormalizedRenderConfig;
   materialName: string;
@@ -21,9 +24,11 @@ export function MaterialResolver(props: MaterialResolverProps) {
   const { data: emittanceTexture } = getTextureDataSafe(config, materialData.emittance_texture);
   const reflectanceImageMap = useImageMap(
     reflectanceTexture.type === 'image' ? reflectanceTexture.resource_id : undefined,
+    VIEWPORT_TEXTURE_MAX_DIM,
   );
   const emittanceImageMap = useImageMap(
     emittanceTexture.type === 'image' ? emittanceTexture.resource_id : undefined,
+    VIEWPORT_TEXTURE_MAX_DIM,
   );
 
   const lambertianMaterialRef = useRef<THREE.MeshLambertMaterial>(null);


### PR DESCRIPTION
## Summary

Two related improvements:

### Image texture previews

A preview of the selected resource image now appears in:

- **Texture controls row** — expand an image texture in the Textures tab to see a contained thumbnail above the name/gamma controls.
- **Add Entity modal** — when creating a new image texture, the preview appears below the resource dropdown and updates live as you change the selection.

Done via a new shared component (`ResourceImagePreview`) backed by a new shared hook (`useResourceImageUrl`). The existing `useImageMap` (3D scene textures) was refactored to consume `useResourceImageUrl` internally so the blob→object-URL lifecycle isn't duplicated.

### Server-side image resize (`?max_dim=`)

- **GET /api/v1/resources/\{id\}/data?max_dim=N** — caps the longest edge at N pixels, preserving aspect ratio, without decoding pixels when unnecessary (header-only dimension peek short-circuits).
- Full decode/resize/encode runs inside `spawn_blocking` to keep async workers free.
- Re-encodes in the original format (PNG→PNG, JPEG→JPEG, etc.) with PNG fallback for unwritable formats.
- No param → original bytes returned untouched. The actual render reads images via `resource_manager`, not this handler, so path-tracing is unaffected.
- Frontend: `getResourceData`, `useResourceDataQuery`, `useResourceImageUrl`, and `useImageMap` all carry an optional `maxDim`; the query key includes the size so thumbnail and full-res caches never collide.
- **256px** for UI thumbnails (2× the 128px display box), **1024px** for 3D viewport textures.

### Files

**New:** `ui/src/components/ResourceImagePreview.tsx`, `ui/src/hooks/useResourceImageUrl.ts`

**Modified:** `src/server/handlers/get_resource_data.rs`, `ui/src/hooks/useImageMap.ts`, `ui/src/hooks/useResourceData.ts`, `ui/src/utils/api.ts`, `ui/src/views/renders/new/Controls/shared/AddEntityModal.tsx`, `ui/src/views/renders/new/Controls/tabs/TextureControls/TextureRow.tsx`, `ui/src/views/renders/new/Scene/MaterialResolver.tsx`