### PR TITLE
FEAT: Add confirmation dialog before deleting a render (#201)

### DIFF
--- a/ui/src/views/renders/[id]/RenderSidebar/DeleteRenderModal.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/DeleteRenderModal.tsx
@@ -1,0 +1,38 @@
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'flowbite-react';
+
+export type DeleteRenderModalProps = {
+  show: boolean;
+  renderName: string;
+  isPending: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+export function DeleteRenderModal(props: DeleteRenderModalProps) {
+  const { show, renderName, isPending, onClose, onConfirm } = props;
+
+  return (
+    <Modal show={show} onClose={onClose}>
+      <ModalHeader>Delete Render</ModalHeader>
+      <ModalBody>
+        <div className="text-zinc-300">
+          <p>
+            Are you sure you want to permanently delete <strong>{renderName}</strong>?
+          </p>
+          <p className="mt-2 text-sm text-zinc-400">
+            All checkpoint data associated with this render will be permanently lost. This action
+            cannot be undone.
+          </p>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="default" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button color="red" onClick={onConfirm} disabled={isPending}>
+          {isPending ? 'Deleting...' : 'Delete'}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/ui/src/views/renders/[id]/RenderSidebar/RenderControls.tsx
+++ b/ui/src/views/renders/[id]/RenderSidebar/RenderControls.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { Button, Spinner } from 'flowbite-react';
 import { useNavigate } from 'react-router-dom';
+import { DeleteRenderModal } from './DeleteRenderModal';
 import { useRenderQuery } from '@/hooks/useRender';
 import {
   usePauseRenderMutation,
@@ -29,6 +31,8 @@ export function RenderControls(props: RenderControlsProps) {
   const { mutate: pauseRender, isPending: isPausePending } = usePauseRenderMutation();
   const { mutate: resumeRender, isPending: isResumePending } = useResumeRenderMutation();
   const { mutate: deleteRender, isPending: isDeletePending } = useDeleteRenderMutation();
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   if (isRenderLoading || !render) {
     return <Spinner size="md" className="fill-zinc-400" />;
@@ -94,7 +98,7 @@ export function RenderControls(props: RenderControlsProps) {
 
       <Button
         color="red"
-        onClick={handleDelete}
+        onClick={() => setShowDeleteModal(true)}
         disabled={isDeletePending || isPausing || isRunning}
       >
         {isDeletePending ? (
@@ -106,6 +110,14 @@ export function RenderControls(props: RenderControlsProps) {
           'Delete Render'
         )}
       </Button>
+
+      <DeleteRenderModal
+        show={showDeleteModal}
+        renderName={render.config.name}
+        isPending={isDeletePending}
+        onClose={() => setShowDeleteModal(false)}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #201

Adds a confirmation modal that triggers when clicking "Delete Render" on the render detail page.

- New `DeleteRenderModal` component in `RenderSidebar/` following the existing `RoleChangeModal` pattern
- Displays the render name and warns about permanent loss of all checkpoint data
- Cancel button (gray) and red "Delete" confirm button (disabled while mutation is pending)
- Delete mutation only fires after explicit confirmation