### PR TITLE
CHORE: Add PR Template and Git Conventions Skill

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- PR title must follow conventional commit style: FEAT: Description in Title Case -->
+
+<!-- Remove this line if there's no associated issue -->
+Closes #
+
+## Context
+
+<!-- Explain the problem this PR is solving. What's the motivation? Why is this needed? -->
+
+## Solution
+
+<!-- Explain how the solution is implemented. Include design decisions, tradeoffs, and any relevant details. -->
+
+## Notes for Reviewers
+
+<!-- Heads-up items, known limitations, follow-up work, or oddities worth calling out. -->
+
+## Verification
+
+<!-- Before opening this PR, verify all changes pass: -->
+- [ ] `just validate` passes (cargo check, test, clippy + UI lint, format, type-check)

--- a/.opencode/skills/git-conventions/SKILL.md
+++ b/.opencode/skills/git-conventions/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: git-conventions
+description: Conventional commit format for PR titles, branch names, and commit messages. Use when creating commits, branches, or pull requests.
+---
+
+# Git Conventions
+
+All git interactions (commits, branches, pull requests) must follow these conventions.
+
+## Rules
+
+1. **PR titles MUST use conventional commit format** — The PR title must start with one of the allowed types in ALL CAPS, followed by a colon and space, then a brief description in Title Case:
+
+   Allowed types:
+   - `FEAT:` — a new feature
+   - `FIX:` — a bug fix
+   - `CHORE:` — maintenance, dependency bumps, tooling changes
+   - `DOCS:` — documentation changes
+   - `STYLE:` — formatting, whitespace, semicolons (no logic changes)
+   - `REFACTOR:` — code restructuring without feature changes or bug fixes
+   - `PERF:` — performance improvements
+   - `TEST:` — adding or updating tests
+
+   ✅ Correct:
+   ```
+   FEAT: Add Confirmation Dialog Before Deleting a Render
+   FIX: Use Frame-Relative Depth for List Item Indentation
+   CHORE: Lower Default Resource Usage Limit for Non-Admins
+   DOCS: Update API Reference for Checkpoint Endpoints
+   ```
+
+   ❌ Anti-pattern:
+   ```
+   feat: add feature          (must be ALL CAPS)
+   Add confirmation dialog    (missing type prefix)
+   Feat: Add confirmation     (wrong casing)
+   FEAT:add feature           (missing space after colon)
+   ```
+
+2. **Commit messages use simple sentence-case** — Describe the change in plain language as a simple action sentence (imperative mood). Do NOT use conventional commit prefixes in commit messages.
+
+   ✅ Correct:
+   ```
+   Add confirmation dialog to the renders screen
+   Fix off-by-one in tile boundary calculation
+   Update Rust edition to 2024
+   ```
+
+   ❌ Anti-pattern:
+   ```
+   FEAT: Add confirmation dialog    (no conventional commit prefix in commits)
+   WIP                               (not descriptive)
+   fix                               (too vague)
+   ```
+
+3. **Branch names** — Use kebab-case with a type prefix. Examples: `feat/user-uploads`, `fix/bvh-intersection`, `chore/update-deps`.
+
+## When creating a PR
+
+Always populate the `.github/pull_request_template.md` template — fill in the Context, Solution, and Notes for Reviewers sections. Apply rules 1 and 3. The PR title MUST use conventional commit format with Title Case. Example: `FEAT: Add Confirmation Dialog Before Deleting a Render`
+
+## When committing
+
+Apply rule 2. Commit messages describe the change in plain sentence-case. No type prefixes.
+
+## When branching
+
+Apply rule 3. Use kebab-case with a type prefix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,10 @@ Dark mode requires THREE things simultaneously:
 - The Rust project is a single crate with two binaries (NOT a workspace with multiple crates).
 - The Rust crate uses `#![forbid(unsafe_code)]` — no unsafe Rust anywhere.
 
-## 7. React Component Conventions
+## 7. Applicable Skills
 
-Load the `react-code-conventions` skill (`.opencode/skills/react-code-conventions/`) when editing any TypeScript file in `ui/src/`. All UI components must use `export type` props, function declaration, and first-line destructure.
+Load the `react-code-conventions` skill (`.opencode/skills/react-code-conventions/`) when editing any TypeScript file in `ui/`.
+
+Load the `postgres-queries` skill (`.opencode/skills/postgres-queries/`) when interacting with live renders, or when asked to view a render.
+
+Load the `git-conventions` skill (`.opencode/skills/git-conventions/`) when creating commits, branches, or pull requests.


### PR DESCRIPTION

## Context

PR titles and commit messages in this repo lacked a consistent, machine-enforceable convention. While existing commits mostly followed `TYPE:` format, there was no mechanism to ensure the LLM (or any contributor) consistently applied it. PRs also had no template, leading to inconsistent structure.

## Solution

**PR template** (`.github/pull_request_template.md`):
- HTML comment reminder about conventional commit PR title format with Title Case
- `Closes #` for issue linking
- Three structured sections: Context, Solution, Notes for Reviewers
- Verification checklist with `just validate`

**Git conventions skill** (`.opencode/skills/git-conventions/SKILL.md`):
- Rule 1: PR titles in `FEAT: Description in Title Case` format (8 allowed types)
- Rule 2: Commit messages in simple sentence-case (no type prefix)
- Rule 3: Branch names in `type/kebab-case` format
- Quick-reference sections for creating PRs, committing, and branching

**AGENTS.md** updated to auto-load the skill when git operations are detected.

## Notes for Reviewers

- The git-conventions skill may require an orchestrator restart to appear in the available skills list. It was verified working after a reload during this PR's creation.
- This is a `CHORE` type since it's tooling/process infrastructure, not a code feature or fix.

## Verification

- [x] `just validate` not applicable (no Rust or UI code changes — only markdown and docs)
