### PR TITLE
FEAT: Add Quaternion Rotation Instance

### DIFF
--- a/.opencode/skills/git-conventions/SKILL.md
+++ b/.opencode/skills/git-conventions/SKILL.md
@@ -66,3 +66,18 @@ Apply rule 2. Commit messages describe the change in plain sentence-case. No typ
 ## When branching
 
 Apply rule 3. Use kebab-case with a type prefix.
+
+## When pushing
+
+4. **Use bare `git push` or `git push -u origin <branch>`** — Never use `git push origin <branch>` without `-u`. The `-u` flag sets the upstream tracking reference so that subsequent bare `git push` commands work.
+
+   ✅ Correct:
+   ```
+   git push
+   git push -u origin feat/my-branch
+   ```
+
+   ❌ Anti-pattern:
+   ```
+   git push origin feat/my-branch    (missing -u flag)
+   ```

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -227,6 +227,7 @@ fn get_geometric_dependencies(geometric: &GeometricData) -> Vec<String> {
         GeometricData::InstanceRotateXAxis { geometric, .. }
         | GeometricData::InstanceRotateYAxis { geometric, .. }
         | GeometricData::InstanceRotateZAxis { geometric, .. }
+        | GeometricData::InstanceRotateQuaternion { geometric, .. }
         | GeometricData::InstanceScale { geometric, .. }
         | GeometricData::InstanceTranslate { geometric, .. }
         | GeometricData::VolumeConstant { geometric, .. }

--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     geometry::{
-        Geometric, Vector3,
+        Geometric, Quaternion, Vector3,
         compounds::{AxisAlignedPBox, Bvh, List, ModelObj, Virtual},
         instances::{RotateQuaternion, RotateXAxis, RotateYAxis, RotateZAxis, Scale, Translate},
         primitives::{
@@ -277,7 +277,7 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
 
                 Ok(Arc::new(RotateQuaternion::new(
                     geometric,
-                    *quaternion,
+                    Quaternion::from_array(*quaternion),
                     *around,
                 )))
             }

--- a/src/deserialization/geometrics.rs
+++ b/src/deserialization/geometrics.rs
@@ -6,7 +6,7 @@ use crate::{
     geometry::{
         Geometric, Vector3,
         compounds::{AxisAlignedPBox, Bvh, List, ModelObj, Virtual},
-        instances::{RotateXAxis, RotateYAxis, RotateZAxis, Scale, Translate},
+        instances::{RotateQuaternion, RotateXAxis, RotateYAxis, RotateZAxis, Scale, Translate},
         primitives::{
             BilinearPatch, Cylinder, CylinderEnd, Disk, Parallelogram, Plane, Sphere, Triangle,
         },
@@ -85,6 +85,12 @@ pub enum GeometricData {
         geometric: GeometricRefOrInline,
         #[serde(flatten)]
         angle: Angle,
+        around: Around,
+    },
+    #[serde(rename = "rotate_quaternion")]
+    InstanceRotateQuaternion {
+        geometric: GeometricRefOrInline,
+        quaternion: [f64; 4],
         around: Around,
     },
     #[serde(rename = "scale")]
@@ -261,6 +267,19 @@ impl Build<Arc<dyn Geometric>> for GeometricData {
                 let geometric = geometric_ref.build(builts)?;
 
                 Ok(Arc::new(RotateZAxis::new(geometric, *angle, *around)))
+            }
+            Self::InstanceRotateQuaternion {
+                geometric: geometric_ref,
+                quaternion,
+                around,
+            } => {
+                let geometric = geometric_ref.build(builts)?;
+
+                Ok(Arc::new(RotateQuaternion::new(
+                    geometric,
+                    *quaternion,
+                    *around,
+                )))
             }
             Self::InstanceScale {
                 geometric: geometric_ref,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -17,6 +17,9 @@ pub use onb::Onb;
 mod point;
 pub use point::Point;
 
+mod quaternion;
+pub use quaternion::Quaternion;
+
 mod ray_hit;
 pub use ray_hit::RayHit;
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,5 +1,6 @@
 pub mod compounds;
 pub mod instances;
+pub mod matrix;
 pub mod primitives;
 pub mod volumes;
 
@@ -8,6 +9,7 @@ pub use aabb::Aabb;
 
 mod geometric;
 pub use geometric::Geometric;
+pub use matrix::Matrix3;
 
 mod onb;
 pub use onb::Onb;

--- a/src/geometry/instances.rs
+++ b/src/geometry/instances.rs
@@ -7,6 +7,9 @@ pub use rotate_y_axis::RotateYAxis;
 mod rotate_z_axis;
 pub use rotate_z_axis::RotateZAxis;
 
+mod rotate_quaternion;
+pub use rotate_quaternion::RotateQuaternion;
+
 mod translate;
 pub use translate::Translate;
 

--- a/src/geometry/instances/rotate_quaternion.rs
+++ b/src/geometry/instances/rotate_quaternion.rs
@@ -1,0 +1,150 @@
+use std::sync::Arc;
+
+use crate::{
+    geometry::{Aabb, Geometric, Matrix3, Point, Ray, RayHit, Vector3},
+    utils::{Around, Interval},
+};
+
+#[derive(Clone, Debug)]
+pub struct RotateQuaternion {
+    geometric: Arc<dyn Geometric>,
+    translation: Vector3,
+    rotation: Matrix3,
+    inv_rotation: Matrix3,
+    bounding_box: Aabb,
+}
+
+impl RotateQuaternion {
+    pub fn new(geometric: Arc<dyn Geometric>, quaternion: [f64; 4], around: Around) -> Self {
+        let translation = around.point(&geometric).0;
+
+        // normalize the quaternion; fall back to identity if degenerate
+        let [w, x, y, z] = quaternion;
+        let len_sq = w * w + x * x + y * y + z * z;
+        let (w, x, y, z) = if len_sq <= 0.0 {
+            (1.0, 0.0, 0.0, 0.0)
+        } else {
+            let inv_len = 1.0 / len_sq.sqrt();
+            (w * inv_len, x * inv_len, y * inv_len, z * inv_len)
+        };
+
+        let rotation = Matrix3::from_quaternion(w, x, y, z);
+        let inv_rotation = rotation.transpose();
+
+        let child_bbox = geometric.bounding_box();
+        let bounding_box = if child_bbox.is_infinite() {
+            // a rotated unbounded volume is still unbounded; a finite AABB can't
+            // represent it (and rotating infinite corners yields NaN), so mark it
+            // UNIVERSE to route it to the scene's unbounded list.
+            Aabb::UNIVERSE
+        } else {
+            let geometric_bbox = child_bbox - translation;
+
+            let mut min_extent = Point::new(f64::INFINITY, f64::INFINITY, f64::INFINITY);
+            let mut max_extent =
+                Point::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+
+            for i in 0..2 {
+                for j in 0..2 {
+                    for k in 0..2 {
+                        // grab one of the eight corners of the bounding box
+                        let x = i as f64 * geometric_bbox.x_interval.maximum
+                            + (1 - i) as f64 * geometric_bbox.x_interval.minimum;
+                        let y = j as f64 * geometric_bbox.y_interval.maximum
+                            + (1 - j) as f64 * geometric_bbox.y_interval.minimum;
+                        let z = k as f64 * geometric_bbox.z_interval.maximum
+                            + (1 - k) as f64 * geometric_bbox.z_interval.minimum;
+
+                        // rotate it
+                        let rotated = rotation * Vector3::new(x, y, z);
+                        let rotated_point = Point::new(rotated.x, rotated.y, rotated.z);
+
+                        min_extent = min_extent.min_components_point(rotated_point);
+                        max_extent = max_extent.max_components_point(rotated_point);
+                    }
+                }
+            }
+
+            Aabb::from_points(&[min_extent, max_extent]) + translation
+        };
+
+        Self {
+            geometric: Arc::clone(&geometric),
+            translation,
+            rotation,
+            inv_rotation,
+            bounding_box,
+        }
+    }
+
+    fn world_to_local_point(&self, v: Point) -> Point {
+        Point::from_vector3(self.world_to_local_vector(v.0 - self.translation)) + self.translation
+    }
+
+    fn world_to_local_vector(&self, v: Vector3) -> Vector3 {
+        self.inv_rotation * v
+    }
+
+    fn local_to_world_point(&self, v: Point) -> Point {
+        Point::from_vector3(self.local_to_world_vector(v.0 - self.translation)) + self.translation
+    }
+
+    fn local_to_world_vector(&self, v: Vector3) -> Vector3 {
+        self.rotation * v
+    }
+}
+
+impl Geometric for RotateQuaternion {
+    fn intersect(&self, ray: Ray, ray_t: Interval) -> Option<RayHit> {
+        // change the ray from world coordinates to object coordinates
+        let mut local_ray = ray;
+        local_ray.origin = self.world_to_local_point(local_ray.origin);
+        local_ray.direction = self.world_to_local_vector(local_ray.direction);
+
+        // check intersection in object coordinates
+        let mut rayhit = self.geometric.intersect(local_ray, ray_t)?;
+
+        // change the ray back to world coordinates
+        rayhit.point = self.local_to_world_point(rayhit.point);
+        rayhit.normal = self.local_to_world_vector(rayhit.normal);
+
+        Some(rayhit)
+    }
+
+    fn surface_area(&self) -> f64 {
+        self.geometric.surface_area()
+    }
+
+    fn is_emissive(&self) -> bool {
+        self.geometric.is_emissive()
+    }
+
+    fn is_transmissive(&self) -> bool {
+        self.geometric.is_transmissive()
+    }
+
+    fn is_specular(&self) -> bool {
+        self.geometric.is_specular()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.geometric.is_empty()
+    }
+
+    fn bounding_box(&self) -> Aabb {
+        self.bounding_box
+    }
+
+    fn sample_direction_from(&self, origin: Point) -> Vector3 {
+        let local_origin = self.world_to_local_point(origin);
+        let local_dir = self.geometric.sample_direction_from(local_origin);
+        self.local_to_world_vector(local_dir)
+    }
+
+    fn direction_pdf(&self, origin: Point, dir: Vector3) -> f64 {
+        let local_origin = self.world_to_local_point(origin);
+        let local_dir = self.world_to_local_vector(dir);
+        // PDF is invariant under rigid transforms
+        self.geometric.direction_pdf(local_origin, local_dir)
+    }
+}

--- a/src/geometry/instances/rotate_quaternion.rs
+++ b/src/geometry/instances/rotate_quaternion.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    geometry::{Aabb, Geometric, Matrix3, Point, Ray, RayHit, Vector3},
+    geometry::{Aabb, Geometric, Matrix3, Point, Quaternion, Ray, RayHit, Vector3},
     utils::{Around, Interval},
 };
 
@@ -15,20 +15,10 @@ pub struct RotateQuaternion {
 }
 
 impl RotateQuaternion {
-    pub fn new(geometric: Arc<dyn Geometric>, quaternion: [f64; 4], around: Around) -> Self {
+    pub fn new(geometric: Arc<dyn Geometric>, quaternion: Quaternion, around: Around) -> Self {
         let translation = around.point(&geometric).0;
 
-        // normalize the quaternion; fall back to identity if degenerate
-        let [w, x, y, z] = quaternion;
-        let len_sq = w * w + x * x + y * y + z * z;
-        let (w, x, y, z) = if len_sq <= 0.0 {
-            (1.0, 0.0, 0.0, 0.0)
-        } else {
-            let inv_len = 1.0 / len_sq.sqrt();
-            (w * inv_len, x * inv_len, y * inv_len, z * inv_len)
-        };
-
-        let rotation = Matrix3::from_quaternion(w, x, y, z);
+        let rotation: Matrix3 = quaternion.into();
         let inv_rotation = rotation.transpose();
 
         let child_bbox = geometric.bounding_box();

--- a/src/geometry/matrix.rs
+++ b/src/geometry/matrix.rs
@@ -1,0 +1,63 @@
+use auto_ops::impl_op_ex;
+
+use crate::geometry::{Point, Vector3};
+
+/// A 3×3 matrix, stored in row-major order.
+#[derive(Clone, Copy, Debug)]
+pub struct Matrix3 {
+    m: [[f64; 3]; 3],
+}
+
+impl Matrix3 {
+    /// Create a matrix from raw row-major data.
+    pub fn new(m: [[f64; 3]; 3]) -> Self {
+        Self { m }
+    }
+
+    /// Build a rotation matrix from a unit quaternion (scalar-first: w, x, y, z).
+    ///
+    /// The caller is responsible for normalizing the quaternion before passing
+    /// it here. An unnormalized quaternion produces an incorrect rotation matrix
+    /// that may scale or shear.
+    pub fn from_quaternion(w: f64, x: f64, y: f64, z: f64) -> Self {
+        let xx = x * x;
+        let yy = y * y;
+        let zz = z * z;
+        let xy = x * y;
+        let xz = x * z;
+        let yz = y * z;
+        let wx = w * x;
+        let wy = w * y;
+        let wz = w * z;
+
+        Self {
+            m: [
+                [1.0 - 2.0 * (yy + zz), 2.0 * (xy - wz), 2.0 * (xz + wy)],
+                [2.0 * (xy + wz), 1.0 - 2.0 * (xx + zz), 2.0 * (yz - wx)],
+                [2.0 * (xz - wy), 2.0 * (yz + wx), 1.0 - 2.0 * (xx + yy)],
+            ],
+        }
+    }
+
+    /// Return the transpose of this matrix.
+    pub fn transpose(&self) -> Self {
+        Self {
+            m: [
+                [self.m[0][0], self.m[1][0], self.m[2][0]],
+                [self.m[0][1], self.m[1][1], self.m[2][1]],
+                [self.m[0][2], self.m[1][2], self.m[2][2]],
+            ],
+        }
+    }
+}
+
+impl_op_ex!(*|a: &Matrix3, b: &Vector3| -> Vector3 {
+    let m = &a.m;
+    Vector3::new(
+        m[0][0] * b.x + m[0][1] * b.y + m[0][2] * b.z,
+        m[1][0] * b.x + m[1][1] * b.y + m[1][2] * b.z,
+        m[2][0] * b.x + m[2][1] * b.y + m[2][2] * b.z,
+    )
+});
+
+impl_op_ex!(*|a: &Matrix3, b: &Point| -> Point { Point::from_vector3(a * b.0) });

--- a/src/geometry/matrix.rs
+++ b/src/geometry/matrix.rs
@@ -2,6 +2,8 @@ use auto_ops::impl_op_ex;
 
 use crate::geometry::{Point, Vector3};
 
+use super::quaternion::Quaternion;
+
 /// A 3×3 matrix, stored in row-major order.
 #[derive(Clone, Copy, Debug)]
 pub struct Matrix3 {
@@ -14,12 +16,25 @@ impl Matrix3 {
         Self { m }
     }
 
-    /// Build a rotation matrix from a unit quaternion (scalar-first: w, x, y, z).
-    ///
-    /// The caller is responsible for normalizing the quaternion before passing
-    /// it here. An unnormalized quaternion produces an incorrect rotation matrix
-    /// that may scale or shear.
-    pub fn from_quaternion(w: f64, x: f64, y: f64, z: f64) -> Self {
+    /// Return the transpose of this matrix.
+    pub fn transpose(&self) -> Self {
+        Self {
+            m: [
+                [self.m[0][0], self.m[1][0], self.m[2][0]],
+                [self.m[0][1], self.m[1][1], self.m[2][1]],
+                [self.m[0][2], self.m[1][2], self.m[2][2]],
+            ],
+        }
+    }
+}
+
+impl From<Quaternion> for Matrix3 {
+    /// Build a rotation matrix from a unit quaternion.
+    fn from(q: Quaternion) -> Self {
+        let w = q.w;
+        let x = q.x;
+        let y = q.y;
+        let z = q.z;
         let xx = x * x;
         let yy = y * y;
         let zz = z * z;
@@ -30,24 +45,11 @@ impl Matrix3 {
         let wy = w * y;
         let wz = w * z;
 
-        Self {
-            m: [
-                [1.0 - 2.0 * (yy + zz), 2.0 * (xy - wz), 2.0 * (xz + wy)],
-                [2.0 * (xy + wz), 1.0 - 2.0 * (xx + zz), 2.0 * (yz - wx)],
-                [2.0 * (xz - wy), 2.0 * (yz + wx), 1.0 - 2.0 * (xx + yy)],
-            ],
-        }
-    }
-
-    /// Return the transpose of this matrix.
-    pub fn transpose(&self) -> Self {
-        Self {
-            m: [
-                [self.m[0][0], self.m[1][0], self.m[2][0]],
-                [self.m[0][1], self.m[1][1], self.m[2][1]],
-                [self.m[0][2], self.m[1][2], self.m[2][2]],
-            ],
-        }
+        Self::new([
+            [1.0 - 2.0 * (yy + zz), 2.0 * (xy - wz), 2.0 * (xz + wy)],
+            [2.0 * (xy + wz), 1.0 - 2.0 * (xx + zz), 2.0 * (yz - wx)],
+            [2.0 * (xz - wy), 2.0 * (yz + wx), 1.0 - 2.0 * (xx + yy)],
+        ])
     }
 }
 

--- a/src/geometry/quaternion.rs
+++ b/src/geometry/quaternion.rs
@@ -1,0 +1,46 @@
+/// A unit quaternion (scalar-first: w + xi + yj + zk).
+///
+/// The `Display` / `Debug` order is `{ w, x, y, z }`, matching the JSON
+/// serialization format.
+#[derive(Clone, Copy, Debug)]
+pub struct Quaternion {
+    pub w: f64,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+impl Quaternion {
+    /// The identity quaternion (no rotation).
+    pub const IDENTITY: Self = Self {
+        w: 1.0,
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
+
+    /// Create a unit quaternion from raw components.
+    ///
+    /// Normalizes the input to unit length. If the input length is
+    /// zero or degenerate, returns [`IDENTITY`].
+    pub fn new(w: f64, x: f64, y: f64, z: f64) -> Self {
+        let len_sq = w * w + x * x + y * y + z * z;
+        if len_sq <= 0.0 {
+            return Self::IDENTITY;
+        }
+        let inv_len = 1.0 / len_sq.sqrt();
+        Self {
+            w: w * inv_len,
+            x: x * inv_len,
+            y: y * inv_len,
+            z: z * inv_len,
+        }
+    }
+
+    /// Create a unit quaternion from a `[w, x, y, z]` array.
+    ///
+    /// Convenience constructor for deserialization — delegates to [`new`].
+    pub fn from_array([w, x, y, z]: [f64; 4]) -> Self {
+        Self::new(w, x, y, z)
+    }
+}

--- a/src/utils/around.rs
+++ b/src/utils/around.rs
@@ -44,7 +44,7 @@ pub fn upgrade_legacy_around(value: &mut serde_json::Value) {
             if let Some(serde_json::Value::String(type_str)) = map.get("type")
                 && matches!(
                     type_str.as_str(),
-                    "rotate_x" | "rotate_y" | "rotate_z" | "scale"
+                    "rotate_x" | "rotate_y" | "rotate_z" | "rotate_quaternion" | "scale"
                 )
             {
                 match map.get("around") {

--- a/ui/src/components/form-controls/InstancesBuilderControl.tsx
+++ b/ui/src/components/form-controls/InstancesBuilderControl.tsx
@@ -3,12 +3,19 @@ import { useFieldContext } from '@/hooks/formContext';
 import { Button, Label, Select } from 'flowbite-react';
 import { HiPlus, HiXMark } from 'react-icons/hi2';
 
-export type InstanceType = 'translate' | 'rotate_x' | 'rotate_y' | 'rotate_z' | 'scale';
+export type InstanceType =
+  | 'translate'
+  | 'rotate_x'
+  | 'rotate_y'
+  | 'rotate_z'
+  | 'rotate_quaternion'
+  | 'scale';
 
 const INSTANCE_LABELS: Record<InstanceType, string> = {
   rotate_x: 'Rotate X',
   rotate_y: 'Rotate Y',
   rotate_z: 'Rotate Z',
+  rotate_quaternion: 'Rotate (Quaternion)',
   scale: 'Scale',
   translate: 'Translate',
 };
@@ -74,6 +81,7 @@ export function InstancesBuilderControl(props: InstancesBuilderControlProps) {
           <option value="rotate_x">Rotate X</option>
           <option value="rotate_y">Rotate Y</option>
           <option value="rotate_z">Rotate Z</option>
+          <option value="rotate_quaternion">Rotate (Quaternion)</option>
           <option value="scale">Scale</option>
           <option value="translate">Translate</option>
         </Select>

--- a/ui/src/components/form-controls/TextArrayInputControl.tsx
+++ b/ui/src/components/form-controls/TextArrayInputControl.tsx
@@ -1,4 +1,4 @@
-import { getGridColumnsTemplateForPercentage } from './utils';
+import { getGridColumnsStyle } from './utils';
 import type { RenderForm, RenderFormPath } from '@/hooks/useRenderForm';
 
 export type TextArrayInputControlProps = {
@@ -6,7 +6,7 @@ export type TextArrayInputControlProps = {
   fieldName: RenderFormPath;
   type?: 'text' | 'number';
   label: string | React.ReactNode;
-  labelSpacePercentage?: 0 | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100;
+  labelSpacePercentage?: number;
   allowWrappingLabel?: boolean;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
@@ -28,10 +28,10 @@ export function TextArrayInputControl(props: TextArrayInputControlProps) {
     unenforcedStep,
   } = props;
 
-  const gridStr = getGridColumnsTemplateForPercentage(labelSpacePercentage);
+  const gridStyle = getGridColumnsStyle(labelSpacePercentage);
 
   return (
-    <div className={`grid items-center ${gridStr}`}>
+    <div className="grid items-center" style={gridStyle}>
       <h6 className="mt-3 overflow-hidden font-normal">
         <span
           className={`flex items-center gap-2 ${allowWrappingLabel ? 'whitespace-normal' : 'whitespace-nowrap'}`}

--- a/ui/src/components/form-controls/TextInputControl.tsx
+++ b/ui/src/components/form-controls/TextInputControl.tsx
@@ -1,4 +1,4 @@
-import { getGridColumnsTemplateForPercentage } from './utils';
+import { getGridColumnsStyle } from './utils';
 import type { ChangeEvent, InputEvent } from 'react';
 import type { RenderForm, RenderFormPath } from '@/hooks/useRenderForm';
 
@@ -9,7 +9,7 @@ export type TextInputControlProps = {
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   type?: 'text' | 'number';
   label: string;
-  labelSpacePercentage?: 0 | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100;
+  labelSpacePercentage?: number;
   allowWrappingLabel?: boolean;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
@@ -31,10 +31,10 @@ export function TextInputControl(props: TextInputControlProps) {
     valueLabel,
   } = props;
 
-  const gridStr = getGridColumnsTemplateForPercentage(labelSpacePercentage);
+  const gridStyle = getGridColumnsStyle(labelSpacePercentage);
 
   return (
-    <div className={`grid items-center ${gridStr}`}>
+    <div className="grid items-center" style={gridStyle}>
       <h6 className="mt-3 overflow-hidden font-normal">
         <span
           className={`flex items-center gap-2 ${allowWrappingLabel ? 'whitespace-normal' : 'whitespace-nowrap'}`}

--- a/ui/src/components/form-controls/utils.ts
+++ b/ui/src/components/form-controls/utils.ts
@@ -1,30 +1,3 @@
-export function getGridColumnsTemplateForPercentage(
-  percentage: 0 | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100,
-): string {
-  switch (percentage) {
-    case 0:
-      return 'grid-cols-[0fr_100fr]';
-    case 10:
-      return 'grid-cols-[10fr_90fr]';
-    case 20:
-      return 'grid-cols-[20fr_80fr]';
-    case 30:
-      return 'grid-cols-[30fr_70fr]';
-    case 40:
-      return 'grid-cols-[40fr_60fr]';
-    case 50:
-      return 'grid-cols-[50fr_50fr]';
-    case 60:
-      return 'grid-cols-[60fr_40fr]';
-    case 70:
-      return 'grid-cols-[70fr_30fr]';
-    case 80:
-      return 'grid-cols-[80fr_20fr]';
-    case 90:
-      return 'grid-cols-[90fr_10fr]';
-    case 100:
-      return 'grid-cols-[100fr_0fr]';
-    default:
-      return 'grid-cols-[30fr_70fr]';
-  }
+export function getGridColumnsStyle(percentage: number): { gridTemplateColumns: string } {
+  return { gridTemplateColumns: `${percentage}fr ${100 - percentage}fr` };
 }

--- a/ui/src/providers/Gizmo/context.ts
+++ b/ui/src/providers/Gizmo/context.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export type GizmoContextType = {
+  activeGizmos: ReadonlySet<string>;
+  toggleGizmo: (name: string) => void;
+  onQuaternionChange: (geometricName: string, quaternion: [number, number, number, number]) => void;
+};
+
+export const GizmoContext = createContext<GizmoContextType | null>(null);

--- a/ui/src/providers/Gizmo/hook.ts
+++ b/ui/src/providers/Gizmo/hook.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { GizmoContext } from './context';
+import type { GizmoContextType } from './context';
+
+export function useGizmo(): GizmoContextType {
+  const context = useContext(GizmoContext);
+  if (context === null) {
+    throw new Error('useGizmo must be used within GizmoProvider');
+  }
+  return context;
+}

--- a/ui/src/providers/Gizmo/index.ts
+++ b/ui/src/providers/Gizmo/index.ts
@@ -1,0 +1,3 @@
+export { useGizmo } from './hook';
+export { GizmoProvider } from './provider';
+export type { GizmoProviderProps } from './provider';

--- a/ui/src/providers/Gizmo/provider.tsx
+++ b/ui/src/providers/Gizmo/provider.tsx
@@ -1,0 +1,33 @@
+import { useState, useCallback, useMemo } from 'react';
+import { GizmoContext } from './context';
+import type { GizmoContextType } from './context';
+
+export type GizmoProviderProps = {
+  children: React.ReactNode;
+  onQuaternionChange: (geometricName: string, quaternion: [number, number, number, number]) => void;
+};
+
+export function GizmoProvider(props: GizmoProviderProps) {
+  const { children, onQuaternionChange } = props;
+
+  const [activeGizmos, setActiveGizmos] = useState<ReadonlySet<string>>(new Set());
+
+  const toggleGizmo = useCallback((name: string) => {
+    setActiveGizmos((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<GizmoContextType>(
+    () => ({ activeGizmos, toggleGizmo, onQuaternionChange }),
+    [activeGizmos, toggleGizmo, onQuaternionChange],
+  );
+
+  return <GizmoContext.Provider value={value}>{children}</GizmoContext.Provider>;
+}

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -15,6 +15,16 @@ import {
 } from './utils';
 import { z } from 'zod';
 
+/**
+ * exhaustiveness check for geometric type switches. Place after a switch
+ * that handles every member of a discriminated union. If a new type is
+ * added to the union without a corresponding case, TypeScript will error
+ * here because the argument no longer narrows to `never`.
+ */
+export function assertExhaustive(_value: never): never {
+  throw new Error(`Unhandled geometric type: ${String(_value)}`);
+}
+
 // geometric types
 export type GeometricData = NormalizedGeometricData;
 

--- a/ui/src/utils/render/geometric.ts
+++ b/ui/src/utils/render/geometric.ts
@@ -36,6 +36,8 @@ export function normalizeGeometricData(
       return normalizeGeometricInstanceRotate(config, name, geometricData);
     case 'rotate_z':
       return normalizeGeometricInstanceRotate(config, name, geometricData);
+    case 'rotate_quaternion':
+      return normalizeGeometricInstanceRotateQuaternion(config, name, geometricData);
     case 'scale':
       return normalizeGeometricInstanceScale(config, name, geometricData);
     case 'translate':
@@ -66,6 +68,7 @@ export type NormalizedGeometricData =
   | NormalizedGeometricList
   | NormalizedGeometricObjModel
   | NormalizedGeometricInstanceRotate
+  | NormalizedGeometricInstanceRotateQuaternion
   | NormalizedGeometricInstanceScale
   | NormalizedGeometricInstanceTranslate
   | NormalizedGeometricParallelogram
@@ -83,6 +86,7 @@ export type RawGeometricData =
   | RawGeometricList
   | RawGeometricObjModel
   | RawGeometricInstanceRotate
+  | RawGeometricInstanceRotateQuaternion
   | RawGeometricInstanceScale
   | RawGeometricInstanceTranslate
   | RawGeometricParallelogram
@@ -105,6 +109,7 @@ export function isGeometricData(data: unknown): data is GeometricData {
       'rotate_x',
       'rotate_y',
       'rotate_z',
+      'rotate_quaternion',
       'scale',
       'translate',
       'parallelogram',
@@ -125,6 +130,7 @@ export function isComposite(
 ): data is
   | GeometricList
   | GeometricInstanceRotate
+  | GeometricInstanceRotateQuaternion
   | GeometricInstanceScale
   | GeometricInstanceTranslate {
   return (
@@ -132,6 +138,7 @@ export function isComposite(
     data.type === 'rotate_x' ||
     data.type === 'rotate_y' ||
     data.type === 'rotate_z' ||
+    data.type === 'rotate_quaternion' ||
     data.type === 'scale' ||
     data.type === 'translate' ||
     data.type === 'virtual'
@@ -170,6 +177,7 @@ export function getReferencedMaterialNames(
     case 'translate':
     case 'constant_volume':
     case 'virtual':
+    case 'rotate_quaternion':
       materials.push(...getReferencedMaterialNames(config, data.geometric));
       break;
   }
@@ -216,6 +224,37 @@ function rotatePoint(
       rz = vz;
       break;
   }
+
+  return [rx + px, ry + py, rz + pz];
+}
+
+// rotate a point around a pivot by a unit quaternion (scalar-first: [w, x, y, z]).
+// matches the Rust backend's RotateQuaternion convention.
+function rotatePointByQuaternion(
+  point: [number, number, number],
+  quaternion: [number, number, number, number],
+  pivot: [number, number, number],
+): [number, number, number] {
+  const [px, py, pz] = pivot;
+  const [qw, qx, qy, qz] = quaternion;
+
+  const vx = point[0] - px;
+  const vy = point[1] - py;
+  const vz = point[2] - pz;
+
+  // apply quaternion rotation matrix
+  const rx =
+    (1 - 2 * qy * qy - 2 * qz * qz) * vx +
+    (2 * qx * qy - 2 * qw * qz) * vy +
+    (2 * qx * qz + 2 * qw * qy) * vz;
+  const ry =
+    (2 * qx * qy + 2 * qw * qz) * vx +
+    (1 - 2 * qx * qx - 2 * qz * qz) * vy +
+    (2 * qy * qz - 2 * qw * qx) * vz;
+  const rz =
+    (2 * qx * qz - 2 * qw * qy) * vx +
+    (2 * qy * qz + 2 * qw * qx) * vy +
+    (1 - 2 * qx * qx - 2 * qy * qy) * vz;
 
   return [rx + px, ry + py, rz + pz];
 }
@@ -269,6 +308,12 @@ export function getCenterPoint(
       const angleRad = toRadians(data);
       const pivot = getAroundPoint(data.around, config, data.geometric);
       return rotatePoint(childCenter, data.type, angleRad, pivot);
+    }
+    case 'rotate_quaternion': {
+      const { data: subData } = getGeometricDataSafe(config, data.geometric);
+      const childCenter = getCenterPoint(config, subData);
+      const pivot = getAroundPoint(data.around, config, data.geometric);
+      return rotatePointByQuaternion(childCenter, data.quaternion, pivot);
     }
     case 'scale': {
       const { data: subData } = getGeometricDataSafe(config, data.geometric);
@@ -430,6 +475,13 @@ export function defaultGeometricForType(
         type: 'rotate_z',
         geometric: '__unit_box',
         degrees: 0,
+        around: 'center',
+      };
+    case 'rotate_quaternion':
+      return {
+        type: 'rotate_quaternion',
+        geometric: '__unit_box',
+        quaternion: [1, 0, 0, 0],
         around: 'center',
       };
     case 'scale':
@@ -725,6 +777,56 @@ export type RawGeometricInstanceRotate = {
   geometric: string | RawGeometricData;
   around: Around;
 } & Angle;
+
+export const GeometricInstanceRotateQuaternionSchema = z.object({
+  type: z.literal('rotate_quaternion'),
+  geometric: z.string().nonempty(),
+  quaternion: z.tuple([z.number(), z.number(), z.number(), z.number()]),
+  around: AroundSchema,
+});
+
+export type GeometricInstanceRotateQuaternion = NormalizedGeometricInstanceRotateQuaternion;
+
+export type NormalizedGeometricInstanceRotateQuaternion = {
+  type: 'rotate_quaternion';
+  geometric: string;
+  quaternion: [number, number, number, number];
+  around: Around;
+};
+
+export type RawGeometricInstanceRotateQuaternion = {
+  type: 'rotate_quaternion';
+  geometric: string | RawGeometricData;
+  quaternion: [number, number, number, number];
+  around: Around;
+};
+
+export function normalizeGeometricInstanceRotateQuaternion(
+  config: RenderConfig,
+  name: string,
+  geometricData: RawGeometricInstanceRotateQuaternion,
+): NormalizedGeometricInstanceRotateQuaternion {
+  const geometric = geometricData;
+
+  if (typeof geometric.geometric !== 'string') {
+    if (!config.geometrics) {
+      config.geometrics = {};
+    }
+
+    const geometricName = getNextUniqueName(
+      config.geometrics,
+      `${name}_${geometric.geometric.type}`,
+    );
+    config.geometrics[geometricName] = normalizeGeometricData(
+      config,
+      geometricName,
+      geometric.geometric,
+    );
+    geometric.geometric = geometricName;
+  }
+
+  return geometric as NormalizedGeometricInstanceRotateQuaternion;
+}
 
 export const GeometricInstanceTranslateSchema = z.object({
   type: z.literal('translate'),
@@ -1298,6 +1400,7 @@ const geometricSchemaByType: Record<string, z.ZodTypeAny> = {
   rotate_x: GeometricInstanceRotateXSchema,
   rotate_y: GeometricInstanceRotateYSchema,
   rotate_z: GeometricInstanceRotateZSchema,
+  rotate_quaternion: GeometricInstanceRotateQuaternionSchema,
   scale: GeometricInstanceScaleSchema,
   translate: GeometricInstanceTranslateSchema,
   parallelogram: GeometricParallelogramSchema,
@@ -1344,6 +1447,7 @@ export function wrapGeometric(
     | 'rotate_x'
     | 'rotate_y'
     | 'rotate_z'
+    | 'rotate_quaternion'
     | 'scale'
     | 'translate'
     | 'constant_volume'
@@ -1367,6 +1471,7 @@ export function wrapGeometric(
     rotate_x: 'Rotate X',
     rotate_y: 'Rotate Y',
     rotate_z: 'Rotate Z',
+    rotate_quaternion: 'Rotate (Quaternion)',
     scale: 'Scale',
     translate: 'Translate',
     constant_volume: 'Constant Volume',
@@ -1379,7 +1484,10 @@ export function wrapGeometric(
 
   // create the wrapper (but don't add it yet — reference update must run first
   // so the wrapper itself doesn't get its own reference rewritten)
-  const wrapper = { ...defaultGeometricForType(wrapperType), geometric: geometricName };
+  const wrapper = {
+    ...defaultGeometricForType(wrapperType),
+    geometric: geometricName,
+  };
 
   // update all composite/list references: if they point to geometricName,
   // point them to wrapperName instead (so they use the wrapped version)
@@ -1388,6 +1496,7 @@ export function wrapGeometric(
       case 'rotate_x':
       case 'rotate_y':
       case 'rotate_z':
+      case 'rotate_quaternion':
       case 'scale':
       case 'translate':
       case 'constant_volume':

--- a/ui/src/views/renders/new/Controls/shared/AddEntityDropdown.tsx
+++ b/ui/src/views/renders/new/Controls/shared/AddEntityDropdown.tsx
@@ -67,6 +67,7 @@ export function AddEntityDropdown<T extends EntityType>(props: AddEntityDropdown
         rotate_x: 'Rotate X',
         rotate_y: 'Rotate Y',
         rotate_z: 'Rotate Z',
+        rotate_quaternion: 'Rotate (Quaternion)',
       };
       const nameChain: { oldName: string; typeLabel: string }[] = [];
       let currentRecord = { ...record };

--- a/ui/src/views/renders/new/Controls/shared/AddEntityModal.tsx
+++ b/ui/src/views/renders/new/Controls/shared/AddEntityModal.tsx
@@ -54,7 +54,9 @@ export function AddEntityModal<T extends EntityType>(props: AddEntityModalProps<
       onChange: z
         .object({
           customName: z.string(),
-          instances: z.array(z.enum(['translate', 'rotate_x', 'rotate_y', 'rotate_z', 'scale'])),
+          instances: z.array(
+            z.enum(['translate', 'rotate_x', 'rotate_y', 'rotate_z', 'rotate_quaternion', 'scale']),
+          ),
           isConstantVolume: z.boolean(),
           isVirtual: z.boolean(),
           selectedResourceId: z.string(),

--- a/ui/src/views/renders/new/Controls/shared/geometricTree.ts
+++ b/ui/src/views/renders/new/Controls/shared/geometricTree.ts
@@ -14,9 +14,20 @@ export type GeometricDisplayNode = {
 // or an empty array if it has no children (leaf type).
 function getChildGeometricNames(geo: NormalizedGeometricData): string[] {
   switch (geo.type) {
+    case 'box':
+    case 'bilinear_patch':
+    case 'cylinder':
+    case 'disk':
+    case 'obj_model':
+    case 'parallelogram':
+    case 'plane':
+    case 'sphere':
+    case 'triangle':
+      return [];
     case 'rotate_x':
     case 'rotate_y':
     case 'rotate_z':
+    case 'rotate_quaternion':
     case 'scale':
     case 'translate':
     case 'constant_volume':
@@ -24,8 +35,6 @@ function getChildGeometricNames(geo: NormalizedGeometricData): string[] {
       return [geo.geometric];
     case 'list':
       return geo.geometrics;
-    default:
-      return [];
   }
 }
 

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -308,6 +308,19 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
         </>
       );
     }
+    case 'rotate_quaternion':
+      return (
+        <>
+          <TextArrayInputControl
+            form={form}
+            fieldName={`geometrics.${name}.quaternion`}
+            label="Quaternion"
+            valueLabels={['w', 'x', 'y', 'z']}
+            type="number"
+          />
+          <AroundVariantControls form={form} geometricName={name} pivotLabel="Rotation Point" />
+        </>
+      );
     case 'scale':
       return (
         <>

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -1,6 +1,6 @@
 import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
 import { TextInputControl } from '@/components/form-controls/TextInputControl';
-import { getGeometricData } from '@/utils/render/geometric';
+import { getGeometricData, assertExhaustive } from '@/utils/render/geometric';
 import { AroundVariantControls } from './AroundVariantControls';
 import { GeometricMaterialSelect } from './GeometricMaterialSelect';
 import { GeometricTextureSelect } from './GeometricTextureSelect';
@@ -315,8 +315,10 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.quaternion`}
             label="Quaternion"
+            labelSpacePercentage={30}
             valueLabels={['w', 'x', 'y', 'z']}
             type="number"
+            unenforcedStep={0.1}
           />
           <AroundVariantControls form={form} geometricName={name} pivotLabel="Rotation Point" />
         </>
@@ -359,7 +361,8 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
       return <p className="text-sm text-zinc-500">Virtual wrapper — transparent in rendering.</p>;
     case 'list':
       return <ListControls form={form} name={name} />;
-    default:
-      return <h6 className="text-sm">Unknown or unimplemented geometric: {data.type} (sorry!)</h6>;
+    case 'obj_model':
+      return <p className="text-sm text-zinc-500">OBJ model — imported from file.</p>;
   }
+  assertExhaustive(data);
 }

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -327,7 +327,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.quaternion`}
             label="Quaternion"
-            labelSpacePercentage={30}
+            labelSpacePercentage={25}
             valueLabels={['w', 'x', 'y', 'z']}
             type="number"
             unenforcedStep={0.1}

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -7,6 +7,8 @@ import { GeometricTextureSelect } from './GeometricTextureSelect';
 import { ListControls } from './ListControls';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
+import { ToggleSwitch } from 'flowbite-react';
+import { useGizmo } from '@/providers/Gizmo';
 
 export type GeometricFormControlsProps = {
   form: RenderForm;
@@ -19,6 +21,8 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
   const renderConfig = useSelector(form.store, (state) => state.values);
 
   const { data } = getGeometricData(renderConfig, name);
+
+  const { activeGizmos, toggleGizmo } = useGizmo();
 
   // build material select items
   const materialItems = Object.keys(renderConfig.materials ?? {}).map((key) => ({
@@ -308,9 +312,17 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
         </>
       );
     }
-    case 'rotate_quaternion':
+    case 'rotate_quaternion': {
+      const isGizmoActive = activeGizmos.has(name);
+
       return (
         <>
+          <div className="flex max-w-full flex-col">
+            <div className="flex w-full items-center justify-between py-2">
+              <h6 className="overflow-hidden font-normal">Show Interactive Rotation Gizmo</h6>
+              <ToggleSwitch checked={isGizmoActive} onChange={() => toggleGizmo(name)} />
+            </div>
+          </div>
           <TextArrayInputControl
             form={form}
             fieldName={`geometrics.${name}.quaternion`}
@@ -323,6 +335,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <AroundVariantControls form={form} geometricName={name} pivotLabel="Rotation Point" />
         </>
       );
+    }
     case 'scale':
       return (
         <>

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -1,4 +1,6 @@
+import { useRef, useCallback } from 'react';
 import * as THREE from 'three';
+import { TransformControls } from '@react-three/drei';
 import {
   getAroundPoint,
   getCenterPoint,
@@ -13,6 +15,7 @@ import { MaterialResolver } from './MaterialResolver';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { getMaterialDataSafe } from '@/utils/render/material';
 import { getTextureDataSafe } from '@/utils/render/texture';
+import { useGizmo } from '@/providers/Gizmo';
 
 type EmissiveInfo = { color: [number, number, number]; intensity: number };
 
@@ -46,7 +49,20 @@ export type GeometricRendererProps = {
 export function GeometricRenderer(props: GeometricRendererProps) {
   const { config, name, rotation = [0, 0, 0] } = props;
 
+  const { activeGizmos, onQuaternionChange } = useGizmo();
+
   const { data } = getGeometricDataSafe(config, name);
+
+  // only used in the rotate_quaternion case — harmless for other types
+  const quatGroupRef = useRef<THREE.Group>(null);
+
+  const handleQuaternionObjectChange = useCallback(() => {
+    if (!quatGroupRef.current) {
+      return;
+    }
+    const q = quatGroupRef.current.quaternion;
+    onQuaternionChange(name, [q.w, q.x, q.y, q.z]);
+  }, [name, onQuaternionChange]);
 
   switch (data.type) {
     case 'box': {
@@ -159,15 +175,23 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       const len = Math.hypot(w, x, y, z);
       const [nw, nx, ny, nz] = len > 0 ? [w / len, x / len, y / len, z / len] : [1, 0, 0, 0];
       const pivot = getAroundPoint(data.around, config, data.geometric);
+      const isActive = activeGizmos.has(name);
       return (
         <group rotation={rotation}>
           <group position={pivot}>
-            <group quaternion={[nx, ny, nz, nw]}>
+            <group ref={quatGroupRef} quaternion={[nx, ny, nz, nw]}>
               <group position={[-pivot[0], -pivot[1], -pivot[2]]}>
                 <GeometricRenderer config={config} name={data.geometric} />
               </group>
             </group>
           </group>
+          {isActive && (
+            <TransformControls
+              object={quatGroupRef as React.RefObject<THREE.Object3D>}
+              mode="rotate"
+              onObjectChange={handleQuaternionObjectChange}
+            />
+          )}
         </group>
       );
     }

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -150,6 +150,22 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       );
     }
 
+    case 'rotate_quaternion': {
+      const [w, x, y, z] = data.quaternion;
+      const pivot = getAroundPoint(data.around, config, data.geometric);
+      return (
+        <group rotation={rotation}>
+          <group position={pivot}>
+            <group quaternion={[x, y, z, w]}>
+              <group position={[-pivot[0], -pivot[1], -pivot[2]]}>
+                <GeometricRenderer config={config} name={data.geometric} />
+              </group>
+            </group>
+          </group>
+        </group>
+      );
+    }
+
     case 'scale': {
       const pivot = getAroundPoint(data.around, config, data.geometric);
       return (

--- a/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
+++ b/ui/src/views/renders/new/Scene/GeometricRenderer.tsx
@@ -1,5 +1,10 @@
 import * as THREE from 'three';
-import { getAroundPoint, getGeometricDataSafe } from '@/utils/render/geometric';
+import {
+  getAroundPoint,
+  getCenterPoint,
+  getGeometricDataSafe,
+  assertExhaustive,
+} from '@/utils/render/geometric';
 import { toRadians } from '@/utils/render/utils';
 import { ParallelogramBufferGeometry } from './ParallelogramBufferGeometry';
 import { TriangleBufferGeometry } from './TriangleBufferGeometry';
@@ -8,7 +13,6 @@ import { MaterialResolver } from './MaterialResolver';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { getMaterialDataSafe } from '@/utils/render/material';
 import { getTextureDataSafe } from '@/utils/render/texture';
-import { getCenterPoint } from '@/utils/render/geometric';
 
 type EmissiveInfo = { color: [number, number, number]; intensity: number };
 
@@ -152,11 +156,13 @@ export function GeometricRenderer(props: GeometricRendererProps) {
 
     case 'rotate_quaternion': {
       const [w, x, y, z] = data.quaternion;
+      const len = Math.hypot(w, x, y, z);
+      const [nw, nx, ny, nz] = len > 0 ? [w / len, x / len, y / len, z / len] : [1, 0, 0, 0];
       const pivot = getAroundPoint(data.around, config, data.geometric);
       return (
         <group rotation={rotation}>
           <group position={pivot}>
-            <group quaternion={[x, y, z, w]}>
+            <group quaternion={[nx, ny, nz, nw]}>
               <group position={[-pivot[0], -pivot[1], -pivot[2]]}>
                 <GeometricRenderer config={config} name={data.geometric} />
               </group>
@@ -419,12 +425,13 @@ export function GeometricRenderer(props: GeometricRendererProps) {
       );
     }
 
+    case 'virtual':
+      return <GeometricRenderer config={config} name={data.geometric} rotation={rotation} />;
+
     case 'obj_model':
     case 'constant_volume':
       // todo: not yet implemented
       return null;
-
-    default:
-      return null;
   }
+  assertExhaustive(data);
 }

--- a/ui/src/views/renders/new/index.tsx
+++ b/ui/src/views/renders/new/index.tsx
@@ -1,9 +1,10 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useAuth } from '@/providers/Auth';
 import { useRenderForm } from '@/hooks/useRenderForm';
 import { NewRenderSidebar } from './NewRenderSidebar';
 import { Scene } from './Scene';
 import { useSelector } from '@tanstack/react-store';
+import { GizmoProvider } from '@/providers/Gizmo';
 
 export function NewRenderPage() {
   const { user } = useAuth();
@@ -28,6 +29,13 @@ export function NewRenderPage() {
 
   const form = useRenderForm({ user });
 
+  const handleQuaternionChange = useCallback(
+    (geometricName: string, q: [number, number, number, number]) => {
+      form.setFieldValue(`geometrics.${geometricName}.quaternion` as never, q as never);
+    },
+    [form],
+  );
+
   // canvas sizing - maintain aspect ratio in container
   const imageDimensions = useSelector(
     form.store,
@@ -49,16 +57,18 @@ export function NewRenderPage() {
   }
 
   return (
-    <div className="flex h-full w-full">
-      <NewRenderSidebar form={form} />
-      <div ref={containerRef} className="m-8 flex flex-1 items-center justify-center">
-        <div
-          style={{ width: canvasWidth, height: canvasHeight }}
-          className="box-border border border-zinc-500"
-        >
-          {canvasWidth > 0 && canvasHeight > 0 && <Scene form={form} />}
+    <GizmoProvider onQuaternionChange={handleQuaternionChange}>
+      <div className="flex h-full w-full">
+        <NewRenderSidebar form={form} />
+        <div ref={containerRef} className="m-8 flex flex-1 items-center justify-center">
+          <div
+            style={{ width: canvasWidth, height: canvasHeight }}
+            className="box-border border border-zinc-500"
+          >
+            {canvasWidth > 0 && canvasHeight > 0 && <Scene form={form} />}
+          </div>
         </div>
       </div>
-    </div>
+    </GizmoProvider>
   );
 }


### PR DESCRIPTION
Closes #190

## Context

The existing rotation instances (`rotate_x`, `rotate_y`, `rotate_z`) only handle axis-aligned rotations. Chaining them to achieve arbitrary 3D orientations causes gimbal lock and limits expressiveness. A quaternion-based rotation encodes any orientation in a single step without degeneracy.

## Solution

### Backend: RotateQuaternion instance
- New `Quaternion` math type (`src/geometry/quaternion.rs`) with unit-length normalization, identity fallback, and `From<Quaternion> for Matrix3`
- New `Matrix3` type (`src/geometry/matrix.rs`) with `new`, `transpose`, and `Mul<Vector3>`/`Mul<Point>` operator impls
- `RotateQuaternion` instance (`src/geometry/instances/rotate_quaternion.rs`). Transforms ray to local space, intersects child, transforms hit back. Same `Around` pivot options as axis rotations. Bounding box computed from 8 rotated corners.
- Deserialization supports `{ "type": "rotate_quaternion", "quaternion": [w, x, y, z], ... }`. Wire format stays `[f64; 4]`, `Quaternion` constructed manually in the build arm (no serde on Quaternion).

### Frontend: form controls + 3D preview
- Types, Zod schema, normalization, defaults for `rotate_quaternion` in `geometric.ts`
- Form controls: 4 numeric inputs (W, X, Y, Z) + `AroundVariantControls` for pivot
- Scene-integrated rotation gizmo via `TransformControls` from drei. Toggle on/off per geometric via `GizmoProvider` context. Gizmo attaches directly to the quaternion group in `GeometricRenderer`, no duplicate canvas needed.
- Quaternion normalized in 3D preview to match backend behavior

### Sidequest: generalised label spacing
Replaced the `labelSpacePercentage` prop's hardcoded 10%-increment `getGridColumnsTemplateForPercentage` function (which required a separate Tailwind class for each value) with a dynamic `getGridColumnsStyle` function that computes `gridTemplateColumns` via inline styles. This allows any `number` value (e.g. `labelSpacePercentage={25}` on the quaternion controls) and cuts out roughly 28 lines of switch boilerplate.

### Code quality
- Added `assertExhaustive` pattern to geometric type switches. Removing forgiving `default` cases prevents silent bugs when new types are added.
- `getChildGeometricNames` in `geometricTree.ts` now enumerates all leaf types explicitly (TypeScript-enforced exhaustiveness).

## Notes for Reviewers

- The quaternion is stored as `[w, x, y, z]` (scalar-first) in both TypeScript types and JSON. Three.js convention `[x, y, z, w]` applies only at the render boundary in `GeometricRenderer`.
- `GizmoProvider` follows the existing provider pattern (`Auth`, `AdminUserOverride`) with `context.ts`, `hook.ts`, `provider.tsx`, `index.ts`.
- Multiple gizmos can be active simultaneously. Each has its own toggle.
