### PR TITLE
FIX: Gamma/Color-Space Mismatch Between 3D Preview and Path-Traced Renders

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -14,7 +14,7 @@ use luxide::{
     shading::{
         ColorRgb, ColorSpectrum, Medium, Texture,
         materials::{Dielectric, Lambertian, Material, Specular},
-        textures::{Checker, Image8Bit, Noise, SolidColor},
+        textures::{Checker, ImageLinearF64, Noise, SolidColor},
     },
     tracing::{
         FileStorage, InMemoryStorage, RenderManager, RenderState, RenderStorage, ResourceManager,
@@ -134,7 +134,7 @@ fn final_scene() -> Scene {
         Arc::new(SolidColor::from_rgb(0.9, 0.9, 0.8));
     let solid_blue_glass: Arc<dyn Texture> = Arc::new(SolidColor::from_rgb(0.2, 0.4, 0.9));
     let image_earth_day: Arc<dyn Texture> =
-        Arc::new(Image8Bit::from_filename("./texture_images/8k_earth_daymap.jpg", 2.0).unwrap());
+        Arc::new(ImageLinearF64::from_filename("./texture_images/8k_earth_daymap.jpg").unwrap());
 
     //perlin noise
     let input_fn = |p: Point| Point::from_vector3(0.1 * p.0);
@@ -736,13 +736,13 @@ fn earth() -> Scene {
     // Textures
     let solid_black: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ZERO));
     let image_earth_day: Arc<dyn Texture> =
-        Arc::new(Image8Bit::from_filename("./texture_images/8k_earth_daymap.jpg", 2.0).unwrap());
+        Arc::new(ImageLinearF64::from_filename("./texture_images/8k_earth_daymap.jpg").unwrap());
     // let image_earth_night: Arc<dyn Texture> =
-    //     Arc::new(Image8Bit::from_filename("./texture_images/8k_earth_nightmap.jpg", 2.0).unwrap());
+    //     Arc::new(ImageLinearF64::from_filename("./texture_images/8k_earth_nightmap.jpg").unwrap());
     let image_moon: Arc<dyn Texture> =
-        Arc::new(Image8Bit::from_filename("./texture_images/8k_moon.jpg", 2.0).unwrap());
+        Arc::new(ImageLinearF64::from_filename("./texture_images/8k_moon.jpg").unwrap());
     // let image_stars_milky_way =
-    //     Arc::new(Image8Bit::from_filename("./texture_images/8k_stars_milky_way.jpg", 2.0).unwrap());
+    //     Arc::new(ImageLinearF64::from_filename("./texture_images/8k_stars_milky_way.jpg").unwrap());
     let solid_white: Arc<dyn Texture> = Arc::new(SolidColor::new(ColorSpectrum::ONE));
 
     // Materials

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -10,7 +10,7 @@ use textures::TextureRefOrInline;
 use crate::{
     camera::Camera,
     geometry::Geometric,
-    shading::textures::Image8Bit,
+    shading::textures::ImageLinearF64,
     shading::{ColorRgb, Texture, materials::Material},
     tracing::ResourceID,
     tracing::{RenderParameters, Scene},
@@ -43,11 +43,11 @@ pub struct Builts<'a> {
     materials: IndexMap<String, Arc<dyn Material>>,
     textures: IndexMap<String, Arc<dyn Texture>>,
 
-    resources: Option<&'a IndexMap<(ResourceID, u64), Arc<Image8Bit>>>,
+    resources: Option<&'a IndexMap<ResourceID, Arc<ImageLinearF64>>>,
 }
 
 impl<'a> Builts<'a> {
-    fn new(resources: Option<&'a IndexMap<(ResourceID, u64), Arc<Image8Bit>>>) -> Self {
+    fn new(resources: Option<&'a IndexMap<ResourceID, Arc<ImageLinearF64>>>) -> Self {
         Self {
             scenes: IndexMap::new(),
             cameras: IndexMap::new(),
@@ -107,7 +107,7 @@ pub struct RenderConfig {
 impl RenderConfig {
     pub fn compile(
         &self,
-        resources: Option<&IndexMap<(ResourceID, u64), Arc<Image8Bit>>>,
+        resources: Option<&IndexMap<ResourceID, Arc<ImageLinearF64>>>,
     ) -> Result<RenderData, String> {
         let mut builts = Builts::new(resources);
 

--- a/src/deserialization/textures.rs
+++ b/src/deserialization/textures.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     shading::{
         ColorRgb, Texture,
-        textures::{Checker, Image8Bit, SolidColor},
+        textures::{Checker, ImageLinearF64, SolidColor},
     },
     tracing::ResourceID,
 };
@@ -41,7 +41,6 @@ pub enum TextureData {
     },
     Image {
         resource_id: ResourceID,
-        gamma: f64,
     },
     #[serde(rename = "color")]
     SolidColor {
@@ -62,24 +61,18 @@ impl Build<Arc<dyn Texture>> for TextureData {
 
                 Ok(Arc::new(Checker::new(*scale, even, odd)))
             }
-            Self::Image { resource_id, gamma } => {
+            Self::Image { resource_id } => {
                 match builts.resources {
-                    // validation mode — return a 1x1 placeholder, no DB fetch needed
-                    None => Ok(Arc::new(Image8Bit::new(image::RgbaImage::from_pixel(
-                        1,
-                        1,
-                        image::Rgba([255, 0, 255, 255]),
-                    )))),
+                    // validation mode - return a 1x1 placeholder, no DB fetch needed
+                    None => Ok(Arc::new(ImageLinearF64 {
+                        width: 1,
+                        height: 1,
+                        data: vec![[1.0, 0.0, 1.0]],
+                    })),
                     Some(resources) => {
-                        let texture =
-                            resources
-                                .get(&(*resource_id, gamma.to_bits()))
-                                .ok_or_else(|| {
-                                    format!(
-                                        "Resource {} with gamma {} not found in pre-loaded data",
-                                        resource_id, gamma
-                                    )
-                                })?;
+                        let texture = resources.get(resource_id).ok_or_else(|| {
+                            format!("Resource {} not found in pre-loaded data", resource_id)
+                        })?;
                         Ok(Arc::clone(texture) as Arc<dyn Texture>)
                     }
                 }

--- a/src/shading/color_rgb.rs
+++ b/src/shading/color_rgb.rs
@@ -4,6 +4,8 @@ use image::Rgba;
 
 use crate::geometry::Vector3;
 
+const SRGB_GAMMA: f64 = 2.2;
+
 #[derive(Debug, Copy, Clone, PartialEq, Default, Encode, Decode)]
 pub struct ColorRgb(Vector3);
 
@@ -30,19 +32,11 @@ impl ColorRgb {
         Self(vector)
     }
 
-    pub fn from_rgba_u8(rgba: &Rgba<u8>) -> Self {
+    pub fn decode_from_srgb_u8(rgba: &Rgba<u8>) -> Self {
         Self(Vector3::new(
-            rgba.0[0] as f64 / u8::MAX as f64,
-            rgba.0[1] as f64 / u8::MAX as f64,
-            rgba.0[2] as f64 / u8::MAX as f64,
-        ))
-    }
-
-    pub fn from_gamma_corrected_rgba_u8(rgba: &Rgba<u8>, decoding_gamma: f64) -> Self {
-        Self(Vector3::new(
-            (rgba.0[0] as f64 / u8::MAX as f64).powf(decoding_gamma),
-            (rgba.0[1] as f64 / u8::MAX as f64).powf(decoding_gamma),
-            (rgba.0[2] as f64 / u8::MAX as f64).powf(decoding_gamma),
+            (rgba.0[0] as f64 / u8::MAX as f64).powf(SRGB_GAMMA),
+            (rgba.0[1] as f64 / u8::MAX as f64).powf(SRGB_GAMMA),
+            (rgba.0[2] as f64 / u8::MAX as f64).powf(SRGB_GAMMA),
         ))
     }
 
@@ -64,12 +58,12 @@ impl ColorRgb {
         ])
     }
 
-    pub fn as_gamma_corrected_rgba_u8(&self, encoding_gamma: f64) -> image::Rgba<u8> {
+    pub fn encode_to_srgb_u8(&self) -> image::Rgba<u8> {
         let vec = self.0.de_nan();
         image::Rgba([
-            (vec.x.powf(encoding_gamma).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
-            (vec.y.powf(encoding_gamma).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
-            (vec.z.powf(encoding_gamma).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
+            (vec.x.powf(1.0 / SRGB_GAMMA).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
+            (vec.y.powf(1.0 / SRGB_GAMMA).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
+            (vec.z.powf(1.0 / SRGB_GAMMA).clamp(0.0, 1.0) * u8::MAX as f64).round() as u8,
             u8::MAX,
         ])
     }

--- a/src/shading/textures.rs
+++ b/src/shading/textures.rs
@@ -6,7 +6,7 @@ mod checker;
 pub use checker::Checker;
 
 mod image;
-pub use image::Image8Bit;
+pub use image::ImageLinearF64;
 
 mod noise;
 pub use noise::Noise;

--- a/src/shading/textures/image.rs
+++ b/src/shading/textures/image.rs
@@ -1,5 +1,3 @@
-use image::RgbaImage;
-
 use crate::{
     geometry::Point,
     shading::{ColorRgb, ColorSpectrum, color_spectrum::SPECTRAL_SAMPLE_COUNT},
@@ -9,53 +7,59 @@ use crate::{
 use super::Texture;
 
 #[derive(Debug, Clone)]
-pub struct Image8Bit {
-    pub image: RgbaImage,
+pub struct ImageLinearF64 {
+    pub width: u32,
+    pub height: u32,
+    pub data: Vec<[f64; 3]>,
 }
 
-impl Image8Bit {
-    pub fn new(image: RgbaImage) -> Self {
-        Self { image }
-    }
+impl ImageLinearF64 {
+    pub fn from_filename(filename: &str) -> Result<Self, image::ImageError> {
+        let image = image::open(filename)?.into_rgba8();
+        let (width, height) = image.dimensions();
 
-    pub fn from_filename(filename: &str, gamma: f64) -> Result<Self, image::ImageError> {
-        let mut image = image::open(filename)?.into_rgba8();
-
-        // gamma correction
-        for p in image.pixels_mut() {
-            *p = ColorRgb::from_rgba_u8(p).as_gamma_corrected_rgba_u8(gamma);
+        let mut data = Vec::with_capacity((width * height) as usize);
+        for p in image.pixels() {
+            let linear: [f64; 3] = ColorRgb::decode_from_srgb_u8(p).into();
+            data.push(linear);
         }
 
-        Ok(Self::new(image))
+        Ok(Self {
+            width,
+            height,
+            data,
+        })
     }
 
-    pub fn from_bytes(bytes: &[u8], gamma: f64) -> Result<Self, image::ImageError> {
-        let mut image = image::load_from_memory(bytes)?.into_rgba8();
+    pub fn from_srgb_bytes(bytes: &[u8]) -> Result<Self, image::ImageError> {
+        let image = image::load_from_memory(bytes)?.into_rgba8();
+        let (width, height) = image.dimensions();
 
-        // gamma correction
-        for p in image.pixels_mut() {
-            *p = ColorRgb::from_rgba_u8(p).as_gamma_corrected_rgba_u8(gamma);
+        let mut data = Vec::with_capacity((width * height) as usize);
+        for p in image.pixels() {
+            let linear: [f64; 3] = ColorRgb::decode_from_srgb_u8(p).into();
+            data.push(linear);
         }
 
-        Ok(Self::new(image))
+        Ok(Self {
+            width,
+            height,
+            data,
+        })
     }
 }
 
-impl Texture for Image8Bit {
+impl Texture for ImageLinearF64 {
     fn value(&self, u: f64, v: f64, _p: Point) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
         let u = Interval::new(0.0, 1.0).clamp(u);
         let v = 1.0 - Interval::new(0.0, 1.0).clamp(v);
 
-        let x = ((u * self.image.width() as f64) as u32).clamp(0, self.image.width() - 1);
-        let y = ((v * self.image.height() as f64) as u32).clamp(0, self.image.height() - 1);
+        let x = ((u * self.width as f64) as u32).clamp(0, self.width.saturating_sub(1));
+        let y = ((v * self.height as f64) as u32).clamp(0, self.height.saturating_sub(1));
 
-        let pixel = self.image.get_pixel(x, y);
+        let idx = (y * self.width + x) as usize;
+        let pixel = self.data[idx];
 
-        ColorRgb::new(
-            pixel[0] as f64 / 255.0,
-            pixel[1] as f64 / 255.0,
-            pixel[2] as f64 / 255.0,
-        )
-        .into()
+        ColorRgb::new(pixel[0], pixel[1], pixel[2]).into()
     }
 }

--- a/src/tracing/parameters.rs
+++ b/src/tracing/parameters.rs
@@ -14,7 +14,6 @@ pub struct RenderParameters {
     pub image_dimensions: (u32, u32),
     pub tile_dimensions: (u32, u32),
 
-    pub gamma_correction: f64,
     pub samples_per_checkpoint: u32,
     pub total_checkpoints: u32,
     pub saved_checkpoint_limit: Option<u32>,

--- a/src/tracing/resource_manager.rs
+++ b/src/tracing/resource_manager.rs
@@ -8,7 +8,7 @@ use axum::{
 use chrono::Utc;
 use serde::Serialize;
 
-use crate::shading::textures::Image8Bit;
+use crate::shading::textures::ImageLinearF64;
 
 use super::{
     Resource, ResourceID, ResourceMeta, ResourceStorage, ResourceType, StorageError, User, UserID,
@@ -41,37 +41,34 @@ impl ResourceManager {
     pub async fn get_textures_for_config(
         &self,
         config: &RenderConfig,
-    ) -> Result<IndexMap<(ResourceID, u64), Arc<Image8Bit>>, StorageError> {
-        // collect unique (resource_id, gamma) pairs from config
-        let mut pairs = HashSet::new();
+    ) -> Result<IndexMap<ResourceID, Arc<ImageLinearF64>>, StorageError> {
+        // collect unique resource IDs from config
+        let mut ids = HashSet::new();
         for texture in config.textures.values() {
-            if let TextureData::Image { resource_id, gamma } = texture {
-                pairs.insert((*resource_id, gamma.to_bits()));
+            if let TextureData::Image { resource_id, .. } = texture {
+                ids.insert(*resource_id);
             }
         }
 
         let mut result = IndexMap::new();
-        for (resource_id, gamma_bits) in pairs {
-            let key = (resource_id, gamma_bits);
-
+        for resource_id in ids {
             // check cache first
-            if let Some(texture) = self.texture_cache.get(&key) {
-                result.insert(key, texture);
+            if let Some(texture) = self.texture_cache.get(&resource_id) {
+                result.insert(resource_id, texture);
                 continue;
             }
 
             // cache miss: fetch from storage, decode, cache
             if let Some(resource) = self.storage.get_resource(resource_id).await? {
-                let gamma = f64::from_bits(gamma_bits);
-                let image = Image8Bit::from_bytes(&resource.data, gamma).map_err(|e| {
+                let image = ImageLinearF64::from_srgb_bytes(&resource.data).map_err(|e| {
                     StorageError(format!(
                         "Failed to decode image for resource {}: {}",
                         resource_id, e
                     ))
                 })?;
                 let texture = Arc::new(image);
-                self.texture_cache.insert(key, Arc::clone(&texture));
-                result.insert(key, texture);
+                self.texture_cache.insert(resource_id, Arc::clone(&texture));
+                result.insert(resource_id, texture);
             }
         }
 
@@ -93,7 +90,7 @@ impl ResourceManager {
         // validate that the uploaded data can actually be used as this resource type
         match resource_type {
             ResourceType::TextureImage => {
-                Image8Bit::from_bytes(&data, 1.0).map_err(|e| {
+                ImageLinearF64::from_srgb_bytes(&data).map_err(|e| {
                     ResourceManagerError::ClientError(
                         StatusCode::BAD_REQUEST,
                         format!("Invalid image file: {}", e),

--- a/src/tracing/storage.rs
+++ b/src/tracing/storage.rs
@@ -106,11 +106,9 @@ impl RenderCheckpoint {
         for ((x, y), color) in pixel_data.iter() {
             let pixel = img.get_pixel_mut(*x, *y);
             *pixel = if params.use_scaling_truncation {
-                color
-                    .scale_down(1.0)
-                    .as_gamma_corrected_rgba_u8(1.0 / params.gamma_correction)
+                color.scale_down(1.0).encode_to_srgb_u8()
             } else {
-                color.as_gamma_corrected_rgba_u8(1.0 / params.gamma_correction)
+                color.encode_to_srgb_u8()
             }
         }
 
@@ -121,16 +119,12 @@ impl RenderCheckpoint {
         render_id: RenderID,
         iteration: u32,
         image: RgbaImage,
-        params: &RenderParameters,
         started_at: chrono::DateTime<chrono::Utc>,
         ended_at: chrono::DateTime<chrono::Utc>,
     ) -> Self {
         let mut pixel_data = PixelData::new();
         for (x, y, pixel) in image.enumerate_pixels() {
-            pixel_data.insert(
-                (x, y),
-                ColorRgb::from_gamma_corrected_rgba_u8(pixel, params.gamma_correction),
-            );
+            pixel_data.insert((x, y), ColorRgb::decode_from_srgb_u8(pixel));
         }
         Self {
             render_id,

--- a/src/tracing/storage/file.rs
+++ b/src/tracing/storage/file.rs
@@ -235,7 +235,7 @@ impl RenderStorage for FileStorage {
         iteration: u32,
     ) -> Result<Option<RenderCheckpoint>, StorageError> {
         let renders = self.renders.read().await;
-        let (render, dir) = match renders.iter().find(|(r, _)| r.id == id) {
+        let (_, dir) = match renders.iter().find(|(r, _)| r.id == id) {
             Some((r, dir)) => (r, dir),
             None => return Err(format!("Render {} not found", id).into()),
         };
@@ -291,7 +291,6 @@ impl RenderStorage for FileStorage {
             id,
             iteration,
             image,
-            &render.config.parameters,
             meta.started_at,
             meta.ended_at,
         )))

--- a/src/tracing/texture_cache.rs
+++ b/src/tracing/texture_cache.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::shading::textures::Image8Bit;
+use crate::shading::textures::ImageLinearF64;
 
 use super::ResourceID;
 
@@ -12,12 +12,12 @@ pub(crate) const TEXTURE_CACHE_TTL: Duration = Duration::from_secs(300); // 5 mi
 pub(crate) const TEXTURE_CACHE_EVICTION_INTERVAL: Duration = Duration::from_secs(30);
 
 struct CacheEntry {
-    texture: Arc<Image8Bit>,
+    texture: Arc<ImageLinearF64>,
     last_accessed: Instant,
 }
 
 pub(crate) struct TextureCache {
-    entries: RwLock<HashMap<(ResourceID, u64), CacheEntry>>,
+    entries: RwLock<HashMap<ResourceID, CacheEntry>>,
 }
 
 impl TextureCache {
@@ -39,7 +39,7 @@ impl TextureCache {
     }
 
     // returns a clone if found, and updates last_accessed
-    pub(crate) fn get(&self, key: &(ResourceID, u64)) -> Option<Arc<Image8Bit>> {
+    pub(crate) fn get(&self, key: &ResourceID) -> Option<Arc<ImageLinearF64>> {
         let mut entries = self.entries.write().unwrap();
         if let Some(entry) = entries.get_mut(key) {
             entry.last_accessed = Instant::now();
@@ -49,7 +49,7 @@ impl TextureCache {
         }
     }
 
-    pub(crate) fn insert(&self, key: (ResourceID, u64), texture: Arc<Image8Bit>) {
+    pub(crate) fn insert(&self, key: ResourceID, texture: Arc<ImageLinearF64>) {
         let mut entries = self.entries.write().unwrap();
         entries.insert(
             key,

--- a/ui/src/hooks/useImageMap.ts
+++ b/ui/src/hooks/useImageMap.ts
@@ -16,6 +16,7 @@ export function useImageMap(resourceId: number | undefined, maxDim?: number): TH
     loader.load(
       url,
       (texture) => {
+        texture.colorSpace = THREE.SRGBColorSpace;
         setMap(texture);
       },
       undefined,

--- a/ui/src/utils/render/parameters.ts
+++ b/ui/src/utils/render/parameters.ts
@@ -22,7 +22,6 @@ export const RenderParametersSchema = z
   .object({
     image_dimensions: z.tuple([z.number().int().min(1), z.number().int().min(1)]),
     tile_dimensions: z.tuple([z.number().int().min(1), z.number().int().min(1)]),
-    gamma_correction: z.number().min(1).max(5),
     samples_per_checkpoint: z.number().int().min(1),
     total_checkpoints: z.number().int().min(1),
     saved_checkpoint_limit: z.number().int().min(0).optional(),

--- a/ui/src/utils/render/templates.ts
+++ b/ui/src/utils/render/templates.ts
@@ -59,7 +59,6 @@ export function getEmptyRenderConfig(): NormalizedRenderConfig {
     parameters: {
       image_dimensions: [500, 500],
       tile_dimensions: [1, 1],
-      gamma_correction: 2.0,
       samples_per_checkpoint: 16,
       total_checkpoints: 100,
       saved_checkpoint_limit: 1,
@@ -238,7 +237,6 @@ export function getCornellBoxBaseRenderConfig(): NormalizedRenderConfig {
     parameters: {
       image_dimensions: [500, 500],
       tile_dimensions: [1, 1],
-      gamma_correction: 2.0,
       samples_per_checkpoint: 16,
       total_checkpoints: 100,
       saved_checkpoint_limit: 1,

--- a/ui/src/utils/render/texture.ts
+++ b/ui/src/utils/render/texture.ts
@@ -100,7 +100,6 @@ export function defaultTextureForType(
       return {
         type: 'image',
         resource_id: options.resource_id,
-        gamma: 1,
       };
     case 'color':
       return {
@@ -164,7 +163,6 @@ export type RawTextureChecker = {
 export const TextureImageSchema = z.object({
   type: z.literal('image'),
   resource_id: z.number().int().nonnegative(),
-  gamma: z.number().min(0),
 });
 
 export type TextureImage = NormalizedTextureImage;
@@ -172,7 +170,6 @@ export type NormalizedTextureImage = RawTextureImage;
 export type RawTextureImage = {
   type: 'image';
   resource_id: number;
-  gamma: number;
 };
 
 export const TextureSolidColorSchema = z.object({

--- a/ui/src/views/renders/new/Controls/tabs/ParametersControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/ParametersControls/index.tsx
@@ -81,17 +81,6 @@ export function ParametersControls(props: ParametersControlsProps) {
 
         <TextInputControl
           form={form}
-          fieldName="parameters.gamma_correction"
-          label="Gamma Correction"
-          labelSpacePercentage={70}
-          allowWrappingLabel
-          valueLabel="gamma"
-          type="number"
-          labelSuffix={<WarningIconAdvancedProperty />}
-        />
-
-        <TextInputControl
-          form={form}
           fieldName="parameters.samples_per_checkpoint"
           label="Samples Per Checkpoint"
           labelSpacePercentage={70}

--- a/ui/src/views/renders/new/Controls/tabs/TextureControls/TextureRow.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/TextureControls/TextureRow.tsx
@@ -117,9 +117,6 @@ export function TextureRow(props: TextureRowProps) {
               <span className="text-zinc-500">MIME: </span>
               {resource?.mime_type ?? 'unknown'}
             </div>
-            <form.AppField name={`textures.${name}.gamma`}>
-              {(field) => <field.RangeControl label="Gamma" min={0.1} max={2} step={0.01} />}
-            </form.AppField>
           </div>
         );
       }


### PR DESCRIPTION
Closes #229

## Context

Image textures (PNG, JPEG) store pixel values gamma-encoded in sRGB color space. Both the backend renderer and frontend 3D preview were treating these encoded values as linear light data, making textures appear ~2.3× too bright in mid-tones. A stored pixel value of 128 should represent ~0.22 linear light (after sRGB decode), but was being used as 0.5 linear.

## Solution

**Backend — ImageLinearF64 (was Image8Bit)**

- Internal storage changed from `RgbaImage` (u8 encoded) to `Vec<[f64; 3]>` (linear f64)
- `from_srgb_bytes` / `from_filename` decode sRGB→linear on load using `decode_from_srgb_u8`, store f64 directly
- `value()` reads f64 directly — no division, no gamma math at sample time
- Gamma parameter removed from all texture APIs — sRGB decode is always gamma 2.2
- Cache key simplified from `(ResourceID, u64)` to just `ResourceID`

**Backend — method renames for clarity**

- `from_gamma_corrected_rgba_u8` → `decode_from_srgb_u8`
- `as_gamma_corrected_rgba_u8` → `encode_to_srgb_u8`
- `from_rgba_u8` removed (was dead code, zero callers)
- `Image8Bit` → `ImageLinearF64`

**Backend — checkpoint output**

- `as_image` and `from_image` now always use sRGB encode/decode (was configurable per render via `gamma_correction`)
- `gamma_correction` render parameter removed — it was dead config

**Frontend**

- `useImageMap.ts`: tagged loaded textures with `texture.colorSpace = THREE.SRGBColorSpace`
- Removed `gamma` field from texture config (schema, types, defaults, UI slider)
- Removed `gamma_correction` from render parameters (schema, templates, UI control)

## Notes for Reviewers

- Raw resource bytes are stored unchanged in the database — no migration needed
- Existing renders with `gamma_correction` in their config deserialize fine (serde silently drops unknown fields since `RenderParameters` has no `deny_unknown_fields`)
- Postgres checkpoint storage uses bincode (linear f64), file storage uses PNG (sRGB). Both paths correctly encode to sRGB for API responses via `as_image()` → `encode_to_srgb_u8()`
- Frontend and backend should deploy together — the backend `TextureData` uses `deny_unknown_fields`, so old frontend sending `gamma` would fail against new backend

## Verification

- [x] `just validate` passes (cargo check, test, clippy + UI lint, format, type-check)