### PR TITLE
FIX: Light Leaking Through Opaque Surfaces from Wrong-Hemisphere BRDF Evaluation

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -238,6 +238,14 @@ impl Camera {
 
             let outgoing_direction = (-ray.direction).unit_vector();
 
+            // flip the geometric normal so shading calculations use the hemisphere
+            // the ray is actually incident from (back-face hit → normal points toward ray)
+            let shading_normal = if ray.direction.dot(ray_hit.normal) > 0.0 {
+                -ray_hit.normal
+            } else {
+                ray_hit.normal
+            };
+
             match srec {
                 ScatterRecord::Spectral(ss) => {
                     let SpectralScatter { rays, reflectance } = *ss;
@@ -294,11 +302,14 @@ impl Camera {
 
                     let (incident_direction, index_of_strategy) = pdf.sample();
 
-                    let cos_theta = ray_hit.normal.dot(incident_direction).abs();
+                    let cos_theta = shading_normal.dot(incident_direction);
+                    if cos_theta <= 0.0 {
+                        return accumulated;
+                    }
                     let brdf_val = ray_hit.material.brdf(
                         outgoing_direction,
                         incident_direction,
-                        ray_hit.normal,
+                        shading_normal,
                         ray_hit.u,
                         ray_hit.v,
                         ray_hit.point,

--- a/src/shading/materials/lambertian.rs
+++ b/src/shading/materials/lambertian.rs
@@ -79,13 +79,16 @@ impl Material for Lambertian {
 
     fn brdf(
         &self,
-        _outgoing_direction: Vector3,
-        _incident_direction: Vector3,
-        _normal: Vector3,
+        outgoing_direction: Vector3,
+        incident_direction: Vector3,
+        normal: Vector3,
         u: f64,
         v: f64,
         p: Point,
     ) -> ColorSpectrum<SPECTRAL_SAMPLE_COUNT> {
+        if normal.dot(outgoing_direction) * normal.dot(incident_direction) <= 0.0 {
+            return ColorSpectrum::ZERO;
+        }
         let albedo = self.reflectance_texture.value(u, v, p);
         albedo / std::f64::consts::PI
     }


### PR DESCRIPTION
## Context

After removing `is_culled` back-face culling (#232), opaque Lambertian surfaces rendered as though light could pass through them. A camera ray hitting the outside face of a solid wall would sometimes return non-zero radiance because emissive importance sampling could select a direction toward a light source on the opposite side of the surface.

## Solution

Two changes, matching the standard PBRT pattern (`SameHemisphere(wo, wi)` check):

1. **`camera.rs`**: Compute a `shading_normal` (flipped for back-face hits, matching Lambertian scatter's convention) and use it for both `cos_theta` and the `brdf()` call. Reject sampled directions with `cos_theta <= 0` instead of using `.abs()`.

2. **`lambertian.rs`**: Add a same-hemisphere guard in `brdf()` — return `ColorSpectrum::ZERO` when `dot(wo, n) * dot(wi, n) <= 0`, i.e., the incident and outgoing directions are on opposite sides of the surface normal.

## Notes for Reviewers

- The CosineHemisphere BRDF strategy always produces valid-hemisphere directions — the leak only occurs when the emissive/transmissive/specular geometric importance sampling strategies select a direction that points through the surface.
- Both fixes are defensive: either alone would prevent the leak, but having both protects against future changes to either code path.