### PR TITLE
FEAT: Support Viewing Resources as Another User

### DIFF
--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -4,6 +4,9 @@ pub use admin_update_user_role::*;
 mod admin_update_user_quotas;
 pub use admin_update_user_quotas::*;
 
+mod admin_user;
+pub use admin_user::*;
+
 mod admin_users;
 pub use admin_users::*;
 

--- a/src/server/handlers/admin_user.rs
+++ b/src/server/handlers/admin_user.rs
@@ -1,0 +1,23 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+use crate::server::{AdminUser, LuxideState};
+use crate::tracing::UserID;
+
+pub async fn get_admin_user(
+    State(state): State<LuxideState>,
+    _admin: AdminUser,
+    Path(id): Path<UserID>,
+) -> Response {
+    println!("Handling request for get_admin_user (id: {})...", id);
+
+    match state.auth_manager.get_user(id).await {
+        Ok(Some(user)) => Json(user).into_response(),
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+    }
+}

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -165,6 +165,7 @@ fn build_auth_router() -> Router<LuxideState> {
 fn build_users_router() -> Router<LuxideState> {
     Router::new()
         .route("/", get(handlers::get_admin_users))
+        .route("/{id}", get(handlers::get_admin_user))
         .route("/{id}/role", put(handlers::update_user_role))
         .route("/{id}/quotas", put(handlers::update_user_quotas))
 }

--- a/ui/src/components/AdminBanner.tsx
+++ b/ui/src/components/AdminBanner.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from '@/providers/Auth';
 import { useAdminUserOverride } from '@/providers/AdminUserOverride';
-import { useAllUsersQuery } from '@/hooks/useAllUsers';
+import { useUserQuery } from '@/hooks/useUser';
 import { Badge, Tooltip } from 'flowbite-react';
 import { HiXMark } from 'react-icons/hi2';
 
@@ -10,15 +10,15 @@ export function AdminBanner() {
 
   const isAdmin = currentUser?.role === 'admin';
 
-  // only fetch users when impersonating AND the current user is an admin
-  const { data: allUsers } = useAllUsersQuery({ enabled: isAdmin && targetUserID !== undefined });
+  // only fetch user when impersonating AND the current user is an admin
+  const { data: targetUser } = useUserQuery(targetUserID!, {
+    enabled: isAdmin && targetUserID !== undefined,
+  });
 
   // don't render if not impersonating or not an admin
   if (targetUserID === undefined || !isAdmin) {
     return null;
   }
-
-  const targetUser = allUsers?.find((u) => u.id === targetUserID);
   const displayName = targetUser?.username ?? `#${targetUserID}`;
 
   return (

--- a/ui/src/hooks/useResourceData.ts
+++ b/ui/src/hooks/useResourceData.ts
@@ -15,13 +15,13 @@ export function useResourceDataQuery(resourceId: number, options: UseResourceDat
   const { targetUserID } = useAdminUserOverride();
 
   return useQuery({
-    queryKey: resourceDataQueryKey(resourceId, maxDim),
+    queryKey: resourceDataQueryKey(resourceId, maxDim, targetUserID),
     queryFn: () => getResourceData(authenticatedFetch, resourceId, targetUserID, maxDim),
     enabled: enabled && accessToken !== undefined,
     staleTime: Infinity,
   });
 }
 
-export function resourceDataQueryKey(resourceId: number, maxDim?: number) {
-  return ['resourceData', resourceId, maxDim ?? 'full'] as const;
+export function resourceDataQueryKey(resourceId: number, maxDim?: number, targetUserID?: number) {
+  return ['resourceData', resourceId, maxDim ?? 'full', targetUserID] as const;
 }

--- a/ui/src/hooks/useResourceMutations.ts
+++ b/ui/src/hooks/useResourceMutations.ts
@@ -13,8 +13,8 @@ export function useCreateResourceMutation() {
   return useMutation({
     mutationFn: (formData: FormData) => createResource(authenticatedFetch, formData, targetUserID),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: allResourceMetadataQueryKey() });
-      queryClient.invalidateQueries({ queryKey: resourceStorageUsageQueryKey() });
+      queryClient.invalidateQueries({ queryKey: allResourceMetadataQueryKey(targetUserID) });
+      queryClient.invalidateQueries({ queryKey: resourceStorageUsageQueryKey(targetUserID) });
     },
   });
 }
@@ -28,8 +28,8 @@ export function useDeleteResourceMutation() {
     mutationFn: (resourceID: number) =>
       deleteResource(authenticatedFetch, resourceID, targetUserID),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: allResourceMetadataQueryKey() });
-      queryClient.invalidateQueries({ queryKey: resourceStorageUsageQueryKey() });
+      queryClient.invalidateQueries({ queryKey: allResourceMetadataQueryKey(targetUserID) });
+      queryClient.invalidateQueries({ queryKey: resourceStorageUsageQueryKey(targetUserID) });
     },
   });
 }

--- a/ui/src/hooks/useResourceStorageUsage.ts
+++ b/ui/src/hooks/useResourceStorageUsage.ts
@@ -8,12 +8,12 @@ export function useResourceStorageUsageQuery() {
   const { targetUserID } = useAdminUserOverride();
 
   return useQuery({
-    queryKey: resourceStorageUsageQueryKey(),
+    queryKey: resourceStorageUsageQueryKey(targetUserID),
     queryFn: () => getResourceStorageUsage(authenticatedFetch, targetUserID),
     enabled: accessToken !== undefined,
   });
 }
 
-export function resourceStorageUsageQueryKey() {
-  return ['resourceStorageUsage'] as const;
+export function resourceStorageUsageQueryKey(targetUserID?: number) {
+  return ['resourceStorageUsage', targetUserID] as const;
 }

--- a/ui/src/hooks/useResources.ts
+++ b/ui/src/hooks/useResources.ts
@@ -8,12 +8,12 @@ export function useAllResourceMetadataQuery() {
   const { targetUserID } = useAdminUserOverride();
 
   return useQuery({
-    queryKey: allResourceMetadataQueryKey(),
+    queryKey: allResourceMetadataQueryKey(targetUserID),
     queryFn: () => getAllResourceMetadata(authenticatedFetch, targetUserID),
     enabled: accessToken !== undefined,
   });
 }
 
-export function allResourceMetadataQueryKey() {
-  return ['allResourceMetadata'] as const;
+export function allResourceMetadataQueryKey(targetUserID?: number) {
+  return ['allResourceMetadata', targetUserID] as const;
 }

--- a/ui/src/hooks/useUser.ts
+++ b/ui/src/hooks/useUser.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { getUser } from '../utils/api';
+import { useAuth } from '../providers/Auth';
+
+export type UseUserOptions = {
+  enabled?: boolean;
+};
+
+export function useUserQuery(userID: number, options: UseUserOptions = {}) {
+  const { enabled = true } = options;
+
+  const { accessToken, authenticatedFetch } = useAuth();
+
+  return useQuery({
+    queryKey: userQueryKey(userID),
+    queryFn: () => getUser(authenticatedFetch, userID),
+    enabled: enabled && accessToken !== undefined,
+  });
+}
+
+export function userQueryKey(userID: number) {
+  return ['user', userID] as const;
+}

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -414,6 +414,17 @@ export async function getAllUsers(fetcher: typeof fetch): Promise<User[]> {
   return (await response.json()) as User[];
 }
 
+export async function getUser(fetcher: typeof fetch, userID: number): Promise<User> {
+  const response = await fetcher(`${getAPIURL()}/users/${userID}`);
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`failed to get user: (${response.status}: ${body})`);
+  }
+
+  return (await response.json()) as User;
+}
+
 export async function updateUserRole(
   fetcher: typeof fetch,
   userID: number,

--- a/ui/src/views/admin/UsersTable.tsx
+++ b/ui/src/views/admin/UsersTable.tsx
@@ -100,6 +100,13 @@ export function UsersTable() {
                       <Button
                         color="default"
                         size="xs"
+                        onClick={() => navigate(`/resources?user_id=${user.id}`)}
+                      >
+                        View Resources
+                      </Button>
+                      <Button
+                        color="default"
+                        size="xs"
                         disabled={user.id === currentUser!.id}
                         onClick={() =>
                           setConfirmTarget({

--- a/ui/src/views/resources/ResourceStorageUsagePanel.tsx
+++ b/ui/src/views/resources/ResourceStorageUsagePanel.tsx
@@ -1,17 +1,29 @@
+import { useMemo } from 'react';
 import { StorageUsagePanel } from '@/components/StorageUsagePanel';
 import { useResourceStorageUsageQuery } from '@/hooks/useResourceStorageUsage';
+import { useAdminUserOverride } from '@/providers/AdminUserOverride';
 import { useAuth } from '@/providers/Auth';
+import { useUserQuery } from '@/hooks/useUser';
 
 export function ResourceStorageUsagePanel() {
   const { user } = useAuth();
+  const { targetUserID } = useAdminUserOverride();
+  const { data: targetUser } = useUserQuery(targetUserID!, { enabled: targetUserID !== undefined });
   const { data, isSuccess, isPending, isError, error } = useResourceStorageUsageQuery();
+
+  const maxBytes = useMemo(() => {
+    if (targetUserID === undefined) {
+      return user?.max_resource_storage_bytes ?? undefined;
+    }
+    return targetUser?.max_resource_storage_bytes ?? undefined;
+  }, [targetUserID, user?.max_resource_storage_bytes, targetUser?.max_resource_storage_bytes]);
 
   return (
     <StorageUsagePanel
       title="Resource Storage Usage"
       label="total resource storage used"
       bytes={data?.bytes ?? 0}
-      maxBytes={user?.max_resource_storage_bytes ?? undefined}
+      maxBytes={maxBytes}
       isSuccess={isSuccess}
       isPending={isPending}
       isError={isError}


### PR DESCRIPTION
## Context

The Resources page lacked parity with the Renders page for admin impersonation. While the backend and API client layer already passed `?user_id=` through, several frontend issues prevented it from working correctly — query keys were static (serving stale cached data when switching users), the storage usage panel showed the admin's own quota instead of the target user's, there was no "View Resources" button in the admin UsersTable, and both `AdminBanner` and `ResourceStorageUsagePanel` wastefully fetched all users just to look up one.

## Solution

### Backend
- **New endpoint** `GET /api/v1/users/{id}` (admin-only, guarded by `AdminUser` extractor) — reuses the existing `auth_manager.get_user(id)` that was already battle-tested by the role/quotas mutation handlers.

### Frontend
- **Query key fixes** — `allResourceMetadataQueryKey`, `resourceStorageUsageQueryKey`, and `resourceDataQueryKey` now include `targetUserID` in the key tuple, matching the `rendersQueryKey(targetUserID)` pattern. This ensures React Query refetches when the impersonated user changes.
- **Mutation invalidation** — `useCreateResourceMutation` and `useDeleteResourceMutation` now pass `targetUserID` to query key functions so cache invalidation targets the correct user.
- **`ResourceStorageUsagePanel`** — When impersonating, looks up the target user's `max_resource_storage_bytes` instead of showing the admin's own quota.
- **`AdminBanner`** — Switched from `useAllUsersQuery` + `.find()` to the targeted `useUserQuery(targetUserID)`.
- **New `useUserQuery` hook** and `getUser` API function — fetches a single user by ID instead of loading the entire user table.
- **Admin UsersTable** — Added "View Resources" button next to the existing "View Renders" button.

## Notes for Reviewers

- The route `/{id}` is registered before `/{id}/role` and `/{id}/quotas` in `build_users_router()` to prevent path segment conflicts.
- The `targetUserID!` non-null assertion in `useUserQuery(targetUserID!, ...)` is safe because the `enabled: targetUserID !== undefined` guard prevents execution when it's undefined.
- All backend and frontend validation passes (`just validate` — cargo check/test/clippy + ESLint + Prettier + TypeScript).