### PR TITLE
FIX: Exclude Checker Sub-Textures from Texture Controls Rows

### DIFF
--- a/ui/src/views/renders/new/Controls/tabs/TextureControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/TextureControls/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useSelector } from '@tanstack/react-store';
 import { getSceneData } from '@/utils/render/scene';
-import { removeDefaults } from '@/utils/render/utils';
+import { removeDefaults, getTopLevelTextureNames } from '@/utils/render/utils';
 import { buildGeometricTree } from '../../shared/geometricTree';
 
 import {
@@ -86,10 +86,7 @@ export function TextureControls(props: { form: RenderForm }) {
     return used;
   }, [geometricTree, usedMaterialNames, renderConfig.materials, renderConfig.geometrics]);
 
-  const textureNames = useMemo(
-    () => Object.keys(renderConfig.textures ?? {}),
-    [renderConfig.textures],
-  );
+  const textureNames = useMemo(() => getTopLevelTextureNames(renderConfig), [renderConfig]);
 
   const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
 


### PR DESCRIPTION
Closes #161

## Context

Issue #161 requested clone/duplicate functionality for geometrics, materials, and textures in the UI. The bulk of this was implemented in PR #178 (drag-and-drop reordering), but one gap remained: checker sub-textures (`even_texture`, `odd_texture`) were appearing as separate accordion rows with their own Duplicate buttons, contrary to the spec which says "The clone button should only appear on the top-level texture card — NOT on checker sub-texture headers."

## Solution

Changed `TextureControls/index.tsx` to use the existing `getTopLevelTextureNames()` helper instead of `Object.keys(renderConfig.textures ?? {})`. This function filters out any texture name that is referenced as `even_texture` or `odd_texture` inside a checker texture. Sub-textures remain visible inline within their parent checker's expanded row, but no longer appear as separate rows with clone/rename/delete actions.

The `getTopLevelTextureNames` function already existed in `utils.ts` but was unused — this PR puts it to work.

## Notes for Reviewers

- Single-file change, two lines (one import addition, one function call replacement)
- No impact on drag-and-drop reordering — `textureNames` is still a `string[]`, just filtered