### PR TITLE
PERF: Fix CPU Underutilization with Unbounded Progress Channel and Shared Thread Pool

### DIFF
--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{num::NonZero, path::PathBuf, sync::Arc};
 
 use axum_extra::extract::cookie::Key;
 use base64::Engine as _;
@@ -11,7 +11,7 @@ use luxide::{
     server::{self, AuthManager, LuxideState, build_router},
     tracing::{
         FileStorage, InMemoryStorage, PostgresStorage, RenderManager, RenderStorage,
-        ResourceManager, ResourceStorage, UserStorage,
+        ResourceManager, ResourceStorage, Threads, UserStorage,
     },
 };
 
@@ -95,11 +95,16 @@ async fn main() -> Result<(), String> {
     // create resource manager (must be constructed before render manager)
     let resource_manager = Arc::new(ResourceManager::new(Arc::clone(&resource_storage)));
 
-    // create render manager
+    // create render manager with a shared global thread pool
+    // so rayon threads persist across checkpoint iterations
     let render_manager = Arc::new(
-        RenderManager::new(Arc::clone(&render_storage), Arc::clone(&resource_manager))
-            .await
-            .map_err(|e| format!("Failed to initialize render manager: {}", e))?,
+        RenderManager::new_with_global_thread_pool(
+            Arc::clone(&render_storage),
+            Arc::clone(&resource_manager),
+            Threads::AllWithDefault(NonZero::new(24).unwrap()),
+        )
+        .await
+        .map_err(|e| format!("Failed to initialize render manager: {}", e))?,
     );
 
     // create auth manager

--- a/src/tracing/render_manager.rs
+++ b/src/tracing/render_manager.rs
@@ -228,18 +228,20 @@ impl RenderManager {
                 None => PixelData::new(),
             };
 
-            let resources =
-                match resource_manager.get_textures_for_config(&render.config).await {
-                    Ok(data) => data,
-                    Err(e) => {
-                        println!(
-                            "Failed to load resource data for render {} at tracing time: {e}",
-                            render.id
-                        );
-                        running_renders.lock().unwrap().remove(&render.id);
-                        return;
-                    }
-                };
+            let resources = match resource_manager
+                .get_textures_for_config(&render.config)
+                .await
+            {
+                Ok(data) => data,
+                Err(e) => {
+                    println!(
+                        "Failed to load resource data for render {} at tracing time: {e}",
+                        render.id
+                    );
+                    running_renders.lock().unwrap().remove(&render.id);
+                    return;
+                }
+            };
 
             let render_data = match render.config.compile(Some(&resources)) {
                 Ok(data) => data,
@@ -253,7 +255,7 @@ impl RenderManager {
                 }
             };
 
-            let (sender, mut receiver) = mpsc::channel(100);
+            let (sender, mut receiver) = mpsc::unbounded_channel();
 
             let (width, height) = render.config.parameters.image_dimensions;
             let started_at = chrono::Utc::now();
@@ -1037,7 +1039,6 @@ impl RenderManager {
     pub fn render_state_streams(&self) -> &Arc<RenderStreamRegistry> {
         &self.render_state_streams
     }
-
 }
 
 #[derive(Clone, Copy, Serialize)]

--- a/src/tracing/tracer.rs
+++ b/src/tracing/tracer.rs
@@ -46,7 +46,7 @@ impl Tracer {
         checkpoint: u32,
         pixel_data: PixelData,
         render_data: &RenderData,
-        progress_sender: mpsc::Sender<ProgressPacket>,
+        progress_sender: mpsc::UnboundedSender<ProgressPacket>,
     ) -> PixelData {
         self.parallel_render_round(checkpoint, pixel_data, render_data, progress_sender)
     }
@@ -56,7 +56,7 @@ impl Tracer {
         checkpoint: u32,
         mut pixel_data: PixelData,
         render_data: &RenderData,
-        progress_sender: mpsc::Sender<ProgressPacket>,
+        progress_sender: mpsc::UnboundedSender<ProgressPacket>,
     ) -> PixelData {
         let RenderData { parameters, scene } = render_data;
 
@@ -101,8 +101,7 @@ impl Tracer {
                             // done with pixel!
 
                             // send progress
-                            if let Err(e) =
-                                progress_sender.blocking_send(ProgressPacket { coords: (x, y) })
+                            if let Err(e) = progress_sender.send(ProgressPacket { coords: (x, y) })
                             {
                                 println!("Failed to send progress! {:?}", e);
                             }


### PR DESCRIPTION
## Context

In production (Kubernetes, 10-core CPU limit), the path tracer used only ~0.7 cores instead of saturating all 10. A render that should take ~3 hours was projected to take 30+. Root cause: a bounded `mpsc::channel(100)` between 10 rayon producer threads and a single tokio consumer that periodically awaited a remote PostgreSQL write (~50ms latency). The 100-slot buffer filled instantly during each DB write, causing all 10 producer threads to block on `blocking_send`.

Additionally, each checkpoint iteration created and destroyed a fresh rayon thread pool (`Tracer::new()` called per-checkpoint), causing unnecessary thread churn.

Full investigation: https://github.com/paulwrubel/luxide/issues (see CPU utilization issue)

## Solution

Two targeted changes:

1. **Unbounded progress channel** (`src/tracing/render_manager.rs`): Changed `mpsc::channel(100)` → `mpsc::unbounded_channel()`. Producer threads never block on send — max memory overhead is ~2MB (250K tiny packets per checkpoint). Updated `src/tracing/tracer.rs` to use `UnboundedSender` with non-blocking `send()` instead of `blocking_send`.

2. **Shared global thread pool** (`src/bin/api.rs`): Changed `RenderManager::new()` → `RenderManager::new_with_global_thread_pool()` with `Threads::AllWithDefault`. The rayon thread pool now persists across checkpoint iterations instead of being created/destroyed each cycle.

## Notes for Reviewers

- The unbounded channel is safe here because the total packet volume is bounded per checkpoint (250K packets for 500×500 image, ~2MB max)
- No algorithmic changes to the path tracer — pixel computation is identical
- Both `luxide-api` and `luxide-cli` compile cleanly
- After deploy, verify CPU usage rises toward 10 cores and checkpoint duration drops from ~34s toward ~3-5s