### PR TITLE
PERF: Decouple Progress DB Writes from the Render Compute Loop

### DIFF
--- a/src/tracing/render_manager.rs
+++ b/src/tracing/render_manager.rs
@@ -257,10 +257,39 @@ impl RenderManager {
 
             let (sender, mut receiver) = mpsc::unbounded_channel();
 
+            // watch channel decouples progress reporting from the render's
+            // compute loop. the receiver loop pushes progress to the watch
+            // sender (instant, non-blocking); a spawned task drains the
+            // watch receiver, writing to the DB at its own pace. watch
+            // inherently coalesces: send() overwrites the stored value
+            // and changed() always returns the freshest one. ordering is
+            // guaranteed because the receiver loop is single-threaded.
+            let (progress_watch_tx, mut progress_watch_rx) =
+                tokio::sync::watch::channel(ProgressInfo::empty());
+
+            let db_task = tokio::spawn({
+                let storage = Arc::clone(&storage);
+                async move {
+                    loop {
+                        match progress_watch_rx.changed().await {
+                            Ok(_) => {
+                                let info = *progress_watch_rx.borrow();
+                                storage.update_progress(render.id, info).await;
+                            }
+                            Err(_) => {
+                                // sender dropped — flush the final value
+                                let info = *progress_watch_rx.borrow();
+                                storage.update_progress(render.id, info).await;
+                                break;
+                            }
+                        }
+                    }
+                }
+            });
+
             let (width, height) = render.config.parameters.image_dimensions;
             let started_at = chrono::Utc::now();
             let new_pixel_data = {
-                let storage = Arc::clone(&storage);
                 let render_state_streams = Arc::clone(&render_state_streams);
 
                 let (_, new_pixel_data) = tokio::join!(
@@ -287,12 +316,20 @@ impl RenderManager {
                                     state,
                                     updated_at: chrono::Utc::now(),
                                 });
-                                storage.update_progress(render.id, progress_info)
+                                // push to batcher for async DB write (non-blocking)
+                                let _ = progress_watch_tx.send(progress_info);
+                                // no-op future so mark()'s .await returns instantly
+                                std::future::ready(())
                             },
                         );
                         while receiver.recv().await.is_some() {
                             progress_tracker.mark().await;
                         }
+                        // scope ends: progress_tracker dropped
+                        // --> closure dropped
+                        // --> borrow on progress_watch_tx released
+                        // --> progress_watch_tx dropped
+                        // --> signals db_task to flush and exit
                     },
                     async move {
                         let new_pixel_data = tokio::task::spawn_blocking(move || {
@@ -311,6 +348,9 @@ impl RenderManager {
 
                 new_pixel_data
             };
+
+            // ensure the DB task finishes flushing the final progress value
+            db_task.await.unwrap();
 
             let ended_at = chrono::Utc::now();
 


### PR DESCRIPTION
## Context

After v1.16.0's shared thread pool fix improved CPU utilization by ~2.5×, the renderer still only uses ~2 cores peak out of a 10-core limit. The remaining bottleneck is synchronous PostgreSQL progress updates during the render loop.

Every 250th pixel (~1000 times per checkpoint), the progress receiver loop awaits a remote PostgreSQL write. While awaiting, the receiver stalls. Although the channel is unbounded (so rayon producers don't block), the progress tracker's `.await` serializes processing, creating an ~18s idle gap per cycle where the receiver falls behind.

## Solution

Decouple progress DB writes from the receiver loop using a `tokio::sync::watch` channel:

- **Receiver loop**: the `update_fn` callback now does the SSE broadcast inline (fast, in-memory), pushes the `ProgressInfo` to the watch channel (instant, non-blocking), and returns `std::future::ready(())`. The `.await` in `mark()` becomes a no-op — the receiver loop continues immediately.
- **Background DB task**: a spawned tokio task drains the watch channel and writes to PostgreSQL at its own pace. `watch::changed()` always returns the freshest value, naturally coalescing ~1000 sends per checkpoint into however many DB writes the network latency allows (~tens).
- **Ordering**: guaranteed because the watch channel has a single producer (the single-threaded receiver loop). Values are produced and consumed sequentially — no out-of-order writes.
- **Shutdown**: when the receiver loop ends, dropping the watch sender signals the DB task to flush the final value and exit. `db_task.await` ensures the write completes before the checkpoint save pipeline runs.

Files changed: 1 (`src/tracing/render_manager.rs`, +40/−2). No changes to `progress.rs`, `tracer.rs`, or any other file.

## Notes for Reviewers

- The `storage` clone that was inside the `new_pixel_data` scope was removed — it moved to the `db_task` spawn since the callback no longer needs it.
- The drop order in the `async move` block is correct: `progress_tracker` (local variable) drops before `progress_watch_tx` (captured field), so the closure's borrow is released before the sender is dropped.

## Verification

- [x] `cargo check` passes cleanly (zero warnings)
- [ ] Deploy and observe VictoriaMetrics — target: sustained >5 cores during compute bursts, elimination of ~18s idle gaps