### PR TITLE
PERF: Use Per-Render Thread Pools for Fair Concurrent Rendering

### DIFF
--- a/src/bin/api.rs
+++ b/src/bin/api.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZero, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use axum_extra::extract::cookie::Key;
 use base64::Engine as _;
@@ -11,7 +11,7 @@ use luxide::{
     server::{self, AuthManager, LuxideState, build_router},
     tracing::{
         FileStorage, InMemoryStorage, PostgresStorage, RenderManager, RenderStorage,
-        ResourceManager, ResourceStorage, Threads, UserStorage,
+        ResourceManager, ResourceStorage, UserStorage,
     },
 };
 
@@ -95,16 +95,11 @@ async fn main() -> Result<(), String> {
     // create resource manager (must be constructed before render manager)
     let resource_manager = Arc::new(ResourceManager::new(Arc::clone(&resource_storage)));
 
-    // create render manager with a shared global thread pool
-    // so rayon threads persist across checkpoint iterations
+    // create render manager
     let render_manager = Arc::new(
-        RenderManager::new_with_global_thread_pool(
-            Arc::clone(&render_storage),
-            Arc::clone(&resource_manager),
-            Threads::AllWithDefault(NonZero::new(24).unwrap()),
-        )
-        .await
-        .map_err(|e| format!("Failed to initialize render manager: {}", e))?,
+        RenderManager::new(Arc::clone(&render_storage), Arc::clone(&resource_manager))
+            .await
+            .map_err(|e| format!("Failed to initialize render manager: {}", e))?,
     );
 
     // create auth manager


### PR DESCRIPTION
## Context

PR #236 introduced a shared global rayon thread pool so threads persisted across checkpoint iterations. However, it inadvertently serialized concurrent renders: the shared pool's `install()` blocks on one render's parallel work before the second render's tiles get scheduled, causing the second render to show "running" but make no progress until the first finishes its checkpoint.

## Solution

Revert the shared thread pool portion of #236 (keeping the unbounded progress channel):

- Change `api.rs` from `RenderManager::new_with_global_thread_pool(...)` back to `RenderManager::new()`
- Without a shared pool, each render creates its own `Tracer::new()` — its own rayon thread pool
- Two concurrent renders → two independent 10-thread pools → OS scheduler splits cores fairly → both renders make ~50% progress simultaneously
- Thread pool creation overhead per checkpoint (~1ms) is negligible vs render time (~30s)
- Remove now-unused `Threads` and `NonZero` imports

The unbounded progress channel (also from #236) and the watch-channel DB write batching (from #237) remain intact.

## Notes for Reviewers

- Effectively a partial revert of #236 — the shared pool was the second of two changes in that PR
- `Tracer::new()` uses `available_parallelism()` threads (with a 24-thread default fallback), same as before #236

## Verification

- [x] `cargo check` passes cleanly