### PR TITLE
FEAT: Add Inline Field Documentation Tooltips to Render Creation Form

### DIFF
--- a/ui/src/components/FieldLabel.tsx
+++ b/ui/src/components/FieldLabel.tsx
@@ -1,0 +1,33 @@
+import { Tooltip } from 'flowbite-react';
+
+export type FieldLabelProps = {
+  children: React.ReactNode;
+  tooltipContent?: string | string[];
+};
+
+export function FieldLabel(props: FieldLabelProps) {
+  const { children, tooltipContent } = props;
+
+  if (tooltipContent === undefined) {
+    return <>{children}</>;
+  }
+
+  const paragraphs = Array.isArray(tooltipContent) ? tooltipContent : [tooltipContent];
+
+  return (
+    <Tooltip
+      content={
+        <div className="flex flex-col gap-1">
+          {paragraphs.map((paragraph, i) => (
+            <p key={i}>{paragraph}</p>
+          ))}
+        </div>
+      }
+      className="max-w-sm wrap-break-word whitespace-normal"
+    >
+      <span className="cursor-help border-b border-dotted border-zinc-400 hover:border-zinc-300">
+        {children}
+      </span>
+    </Tooltip>
+  );
+}

--- a/ui/src/components/form-controls/RangeControl.tsx
+++ b/ui/src/components/form-controls/RangeControl.tsx
@@ -1,3 +1,4 @@
+import { FieldLabel } from '@/components/FieldLabel';
 import { useFieldContext } from '@/hooks/formContext';
 import { Label, RangeSlider } from 'flowbite-react';
 
@@ -5,13 +6,14 @@ export type RangeControlProps = {
   label: string;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
+  tooltip?: React.ReactNode;
   min?: number;
   max?: number;
   step?: number;
 };
 
 export function RangeControl(props: RangeControlProps) {
-  const { label, labelPrefix, labelSuffix, min, max, step } = props;
+  const { label, labelPrefix, labelSuffix, tooltip, min, max, step } = props;
 
   const field = useFieldContext<number>();
 
@@ -20,7 +22,7 @@ export function RangeControl(props: RangeControlProps) {
       <span className="flex justify-between">
         <span className="flex gap-2">
           {labelPrefix}
-          {label}
+          <FieldLabel tooltipContent={tooltip}>{label}</FieldLabel>
           {labelSuffix}
         </span>
         <span>{field.state.value}</span>

--- a/ui/src/components/form-controls/RangeControl.tsx
+++ b/ui/src/components/form-controls/RangeControl.tsx
@@ -6,7 +6,7 @@ export type RangeControlProps = {
   label: string;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
-  tooltip?: React.ReactNode;
+  tooltip?: string | string[];
   min?: number;
   max?: number;
   step?: number;

--- a/ui/src/components/form-controls/SelectControl.tsx
+++ b/ui/src/components/form-controls/SelectControl.tsx
@@ -12,7 +12,7 @@ export type SelectControlProps = {
   label: string;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
-  tooltip?: React.ReactNode;
+  tooltip?: string | string[];
   items: SelectItem[];
   onChange?: (value: string) => void;
   mapValue?: (value: string) => string;

--- a/ui/src/components/form-controls/SelectControl.tsx
+++ b/ui/src/components/form-controls/SelectControl.tsx
@@ -1,3 +1,4 @@
+import { FieldLabel } from '@/components/FieldLabel';
 import { useFieldContext } from '@/hooks/formContext';
 import React from 'react';
 import { Label, Select } from 'flowbite-react';
@@ -11,13 +12,14 @@ export type SelectControlProps = {
   label: string;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
+  tooltip?: React.ReactNode;
   items: SelectItem[];
   onChange?: (value: string) => void;
   mapValue?: (value: string) => string;
 };
 
 export function SelectControl(props: SelectControlProps) {
-  const { label, labelPrefix, labelSuffix, items, onChange, mapValue } = props;
+  const { label, labelPrefix, labelSuffix, tooltip, items, onChange, mapValue } = props;
 
   const field = useFieldContext<string>();
 
@@ -30,7 +32,7 @@ export function SelectControl(props: SelectControlProps) {
       <span className="flex justify-between">
         <span className="flex gap-2">
           {labelPrefix}
-          {label}
+          <FieldLabel tooltipContent={tooltip}>{label}</FieldLabel>
           {labelSuffix}
         </span>
         <span>{valueLabel}</span>

--- a/ui/src/components/form-controls/TextArrayInputControl.tsx
+++ b/ui/src/components/form-controls/TextArrayInputControl.tsx
@@ -1,5 +1,6 @@
 import { getGridColumnsStyle } from './utils';
 import type { RenderForm, RenderFormPath } from '@/hooks/useRenderForm';
+import { FieldLabel } from '@/components/FieldLabel';
 
 export type TextArrayInputControlProps = {
   form: RenderForm;
@@ -10,6 +11,7 @@ export type TextArrayInputControlProps = {
   allowWrappingLabel?: boolean;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
+  tooltip?: React.ReactNode;
   valueLabels: string[];
   unenforcedStep?: number;
 };
@@ -24,6 +26,7 @@ export function TextArrayInputControl(props: TextArrayInputControlProps) {
     allowWrappingLabel,
     labelPrefix,
     labelSuffix,
+    tooltip,
     valueLabels,
     unenforcedStep,
   } = props;
@@ -37,7 +40,7 @@ export function TextArrayInputControl(props: TextArrayInputControlProps) {
           className={`flex items-center gap-2 ${allowWrappingLabel ? 'whitespace-normal' : 'whitespace-nowrap'}`}
         >
           {labelPrefix}
-          {label}
+          <FieldLabel tooltipContent={tooltip}>{label}</FieldLabel>
           {labelSuffix}
         </span>
       </h6>

--- a/ui/src/components/form-controls/TextArrayInputControl.tsx
+++ b/ui/src/components/form-controls/TextArrayInputControl.tsx
@@ -11,7 +11,7 @@ export type TextArrayInputControlProps = {
   allowWrappingLabel?: boolean;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
-  tooltip?: React.ReactNode;
+  tooltip?: string | string[];
   valueLabels: string[];
   unenforcedStep?: number;
 };

--- a/ui/src/components/form-controls/TextInputControl.tsx
+++ b/ui/src/components/form-controls/TextInputControl.tsx
@@ -14,7 +14,7 @@ export type TextInputControlProps = {
   allowWrappingLabel?: boolean;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
-  tooltip?: React.ReactNode;
+  tooltip?: string | string[];
   valueLabel: string;
 };
 

--- a/ui/src/components/form-controls/TextInputControl.tsx
+++ b/ui/src/components/form-controls/TextInputControl.tsx
@@ -1,6 +1,7 @@
 import { getGridColumnsStyle } from './utils';
 import type { ChangeEvent, InputEvent } from 'react';
 import type { RenderForm, RenderFormPath } from '@/hooks/useRenderForm';
+import { FieldLabel } from '@/components/FieldLabel';
 
 export type TextInputControlProps = {
   form: RenderForm;
@@ -13,6 +14,7 @@ export type TextInputControlProps = {
   allowWrappingLabel?: boolean;
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
+  tooltip?: React.ReactNode;
   valueLabel: string;
 };
 
@@ -28,6 +30,7 @@ export function TextInputControl(props: TextInputControlProps) {
     allowWrappingLabel,
     labelPrefix,
     labelSuffix,
+    tooltip,
     valueLabel,
   } = props;
 
@@ -40,7 +43,7 @@ export function TextInputControl(props: TextInputControlProps) {
           className={`flex items-center gap-2 ${allowWrappingLabel ? 'whitespace-normal' : 'whitespace-nowrap'}`}
         >
           {labelPrefix}
-          {label}
+          <FieldLabel tooltipContent={tooltip}>{label}</FieldLabel>
           {labelSuffix}
         </span>
       </h6>

--- a/ui/src/components/form-controls/ToggleControl.tsx
+++ b/ui/src/components/form-controls/ToggleControl.tsx
@@ -1,3 +1,4 @@
+import { FieldLabel } from '@/components/FieldLabel';
 import { useFieldContext } from '@/hooks/formContext';
 import { ToggleSwitch } from 'flowbite-react';
 
@@ -7,10 +8,11 @@ export type ToggleControlProps = {
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
   disabled?: boolean;
+  tooltip?: React.ReactNode;
 };
 
 export function ToggleControl(props: ToggleControlProps) {
-  const { label, labelPrefix, labelSuffix, disabled } = props;
+  const { label, labelPrefix, labelSuffix, disabled, tooltip } = props;
 
   const field = useFieldContext<boolean>();
 
@@ -20,7 +22,7 @@ export function ToggleControl(props: ToggleControlProps) {
         <h6 className="overflow-hidden font-normal">
           <span className="flex items-center gap-2">
             {labelPrefix}
-            {label}
+            <FieldLabel tooltipContent={tooltip}>{label}</FieldLabel>
             {labelSuffix}
           </span>
         </h6>

--- a/ui/src/components/form-controls/ToggleControl.tsx
+++ b/ui/src/components/form-controls/ToggleControl.tsx
@@ -8,7 +8,7 @@ export type ToggleControlProps = {
   labelPrefix?: React.ReactNode;
   labelSuffix?: React.ReactNode;
   disabled?: boolean;
-  tooltip?: React.ReactNode;
+  tooltip?: string | string[];
 };
 
 export function ToggleControl(props: ToggleControlProps) {

--- a/ui/src/data/renderFieldCopy.ts
+++ b/ui/src/data/renderFieldCopy.ts
@@ -2,104 +2,150 @@ export type FieldCopy = {
   /** human-readable label shown in the form */
   label: string;
   /** tooltip/help text explaining the field in plain language */
-  description: string;
+  description: string | string[];
 };
 
 export const RENDER_FIELD_COPY = {
   parameters: {
     name: {
       label: 'Name',
-      description: `A unique identifier for this render configuration.
-Used to reference the render in the dashboard and exported file names.`,
+      description: `A human-readable name for this render configuration.
+      Used to reference the render in the dashboard.`,
     },
     imageDimensions: {
       label: 'Size (width x height)',
-      description: `The resolution of the final rendered image, measured in pixels.
-Higher resolutions produce sharper images but take significantly longer to render.
-Common values are 1920x1080 (Full HD) or 3840x2160 (4K).`,
+      description: [
+        `The resolution of the rendered image, measured in pixels. 
+        Higher resolutions produce sharper images but take significantly longer to render, as the time scales linearly with pixel count.`,
+
+        `Common values are 300x300 or 500x500 for testing, or 1920x1080 (Full HD) or 3840x2160 (4K) for production renders.`,
+      ],
     },
     tileDimensions: {
       label: 'Tile Size',
-      description: `The size in pixels of each square tile the renderer processes in parallel.
-Smaller tiles update the preview more frequently but add scheduling overhead.`,
+      description: [
+        `The size in pixels of each square tile the renderer processes in parallel. 
+        Changing this setting is almost certain to have absolutely no effect on your render, in terms of visuals or rendering efficiency.`,
+
+        `It is recommended to leave this at the default value of 1x1 unless you have a specific reason to change it.`,
+      ],
     },
     samplesPerCheckpoint: {
       label: 'Samples Per Checkpoint',
-      description: `How many rays are traced through each pixel before a checkpoint image is saved.
-Higher values reduce noise but make each checkpoint take longer.
-Each checkpoint builds on the previous one, progressively refining the image.`,
+      description: `How many samples are traced for each pixel before a checkpoint image is saved.
+      Higher values reduce noise but make each checkpoint take longer.`,
     },
     totalCheckpoints: {
       label: 'Total Checkpoints',
-      description: `The total number of checkpoint images the renderer will produce before stopping.
-More checkpoints mean a longer render with finer-grained progress updates.
-The final image quality depends on the total samples (samples per checkpoint x total checkpoints).`,
+      description: [
+        `The total number of checkpoint images the renderer will produce before stopping.
+        A greater total checkpoint count means a longer render with a higher sampled final result.`,
+
+        `The final image quality depends on the total samples (samples per checkpoint x total checkpoints).
+        Please note that the same total sample count will take longer if configured with more checkpoints and
+        less samples per checkpoint, due to the overhead of saving more intermediate images to the backend storage.`,
+      ],
+    },
+    useScalingTruncation: {
+      label: 'Use Scaling Truncation',
+      description: [
+        `Whether to scale color channel values when clamping them, to preserve the color hues.`,
+
+        `When a pixel color value exceeds 1.0, it must be clamped to fit within the displayable range.
+        This can cause the hue of a pixel to change if one channel is clamped while others are not.
+        Enabling this parameter ensures all channels are scaled proportionally to preserve the original 
+        hue, at the cost of potentially losing some brightness.`,
+      ],
+    },
+    enforceCheckpointLimit: {
+      label: 'Enforce Checkpoint Limit?',
+      description: [
+        `Whether to enforce a limit on the total number of saved checkpoint images, by discarding old checkpoints.`,
+
+        `When disabled, all checkpoints are kept until the render completes.`,
+      ],
     },
     savedCheckpointLimit: {
       label: 'Saved Checkpoint Limit',
       description: `The maximum number of checkpoint images kept on disk at once.
-When the limit is reached, older checkpoints are discarded as new ones are saved.`,
-    },
-    enforceCheckpointLimit: {
-      label: 'Enforce Checkpoint Limit?',
-      description: `Whether to enforce the saved checkpoint limit by discarding old checkpoints.
-When disabled, all checkpoints are kept until the render completes.`,
+      When the limit is reached, older checkpoints are discarded as new ones are saved.
+      The number is always the most recent n checkpoints.`,
     },
     maxLightBounces: {
       label: 'Max Light Bounces',
       description: `The maximum number of times a light ray can reflect or refract before the tracer stops following it.
-Higher values produce more realistic lighting but increase render time.
-A value of 10–50 is typical for most scenes.`,
-    },
-    useScalingTruncation: {
-      label: 'Use Scaling Truncation',
-      description: `Whether to truncate very small ray contributions instead of following them to zero.
-This can slightly speed up renders by cutting insignificant paths, but may introduce subtle energy loss.`,
+      Higher values produce more realistic lighting but increase render time. A value of 10-50 is typical for most scenes.`,
     },
     useRussianRoulette: {
       label: 'Use Russian Roulette?',
-      description: `A technique that probabilistically terminates low-energy rays to reduce render time without noticeably affecting quality.
-Rays with low contribution are randomly terminated based on their remaining energy.`,
+      description: `A technique that probabilistically terminates low-energy rays to reduce render time without 
+      noticeably affecting quality. Rays with low contribution are randomly terminated based on their remaining energy.`,
     },
     minBouncesBeforeRoulette: {
       label: 'Minimum Bounces Before Activation',
       description: `The minimum number of bounces a ray must complete before Russian roulette can terminate it.
-This ensures early bounces — which carry the most visual energy — are always fully computed.`,
+      This ensures early bounces, which carry the most visual energy, are always fully computed.`,
     },
     useImportanceSampling: {
       label: 'Use Importance Sampling?',
-      description: `Whether to bias ray sampling toward light sources and important directions to reduce noise.
-When enabled, the renderer allocates more samples to significant light paths.`,
+      description: [
+        `Whether to bias ray sampling toward specific directions and geometries to reduce noise and converge faster. 
+        When enabled and tuned correctly, the renderer can converge significantly faster.`,
+        `All values are unitless weights that determine the relative probability of sampling rays in each category.`,
+      ],
     },
     brdfWeight: {
       label: 'BRDF Weight',
-      description: `The sampling weight assigned to the BRDF (surface reflection) component when importance sampling is active.
-Higher values increase the proportion of rays that follow surface reflections.`,
+      description: [
+        `The weight assigned to the BRDF (surface reflection) component when importance sampling is active.
+        Higher values increase the proportion of rays that follow surface reflections.`,
+
+        `This is the default sampling method, and is guaranteed to correctly converge for all scenes, but 
+        may converge much slower than when combined with other importance sampling methods.`,
+
+        `Setting this to 1 and all other weights to 0 effectively disables importance sampling.`,
+      ],
     },
     emissiveWeight: {
       label: 'Emissive Weight',
-      description: `The sampling weight assigned to emissive (self-illuminating) surfaces when importance sampling is active.
-Higher values increase the proportion of rays directed toward light-emitting objects.`,
+      description: [
+        `The weight assigned to emissive (light-emitting) surfaces when importance sampling is active.`,
+
+        `A non-zero weight will result in light being directly sent towards emissive geometrics
+        (where the emissive texture has a non-black component).`,
+      ],
     },
     transmissiveWeight: {
       label: 'Transmissive Weight',
-      description: `The sampling weight assigned to transmissive (light-passing) materials when importance sampling is active.
-Higher values increase the proportion of rays that pass through transparent objects.`,
+      description: [
+        `The weight assigned to transmissive (light-passing) materials when importance sampling is active.`,
+
+        `This may or may not result in the scene converging slower or faster. Use with caution.`,
+      ],
     },
     specularWeight: {
       label: 'Specular Weight',
-      description: `The sampling weight assigned to specular (mirror-like) reflections when importance sampling is active.
-Higher values increase the proportion of rays that produce sharp reflections.`,
+      description: [
+        `The weight assigned to specular (mirror-like) reflections when importance sampling is active.`,
+
+        `This will only accelerate convergence for very specific scenes. Use with caution.`,
+      ],
     },
     virtualWeight: {
       label: 'Virtual Weight',
-      description: `The sampling weight assigned to virtual light paths when importance sampling is active.
-Higher values increase the proportion of rays that follow indirect illumination paths.`,
+      description: [
+        `The weight assigned to virtual geometrics when importance sampling is active.`,
+
+        `This can be used to direct light in directions that are not represented by a physically-placed
+        scene object. For example, this can be used to direct light towards a virtual rectangle near the crack under
+        a door, in a scene where most illumination would come from that direction.`,
+      ],
     },
     useMultipleImportanceSampling: {
       label: 'Use Multiple Importance Sampling',
-      description: `Combines samples from both the BRDF and light source distributions to reduce noise, especially in scenes with small or bright light sources.
-This produces cleaner renders but increases computational cost.`,
+      description: [
+        `An advanced setting that controls some fancy math under the hood. You should probably leave this on.`,
+      ],
     },
   },
   cameras: {
@@ -107,7 +153,7 @@ This produces cleaner renders but increases computational cost.`,
       label: 'Vertical FOV (degrees)',
       description: `How wide the camera's view is, measured in degrees.
 Higher values show more of the scene but can cause fisheye distortion.
-Typical values are 40–90°.`,
+Typical values are 40-90°.`,
     },
     eyeLocation: {
       label: 'Eye (x/y/z)',
@@ -389,8 +435,8 @@ Higher values create stronger refraction effects.`,
       abbeNumber: {
         label: 'Abbe Number',
         description: `Quantifies the material's chromatic dispersion — how much the index of refraction varies by wavelength.
-Lower values (20–40) produce stronger rainbow-like color fringing; higher values (50–80) produce less dispersion.
-Typical glass ranges from 30–60.`,
+Lower values (20-40) produce stronger rainbow-like color fringing; higher values (50-80) produce less dispersion.
+Typical glass ranges from 30-60.`,
       },
       hasInteriorMedium: {
         label: 'Has Interior Medium?',

--- a/ui/src/data/renderFieldCopy.ts
+++ b/ui/src/data/renderFieldCopy.ts
@@ -15,7 +15,7 @@ export const RENDER_FIELD_COPY = {
     imageDimensions: {
       label: 'Size (width x height)',
       description: [
-        `The resolution of the rendered image, measured in pixels. 
+        `The resolution of the rendered image, measured in pixels.
         Higher resolutions produce sharper images but take significantly longer to render, as the time scales linearly with pixel count.`,
 
         `Common values are 300x300 or 500x500 for testing, or 1920x1080 (Full HD) or 3840x2160 (4K) for production renders.`,
@@ -24,7 +24,7 @@ export const RENDER_FIELD_COPY = {
     tileDimensions: {
       label: 'Tile Size',
       description: [
-        `The size in pixels of each square tile the renderer processes in parallel. 
+        `The size in pixels of each square tile the renderer processes in parallel.
         Changing this setting is almost certain to have absolutely no effect on your render, in terms of visuals or rendering efficiency.`,
 
         `It is recommended to leave this at the default value of 1x1 unless you have a specific reason to change it.`,
@@ -53,7 +53,7 @@ export const RENDER_FIELD_COPY = {
 
         `When a pixel color value exceeds 1.0, it must be clamped to fit within the displayable range.
         This can cause the hue of a pixel to change if one channel is clamped while others are not.
-        Enabling this parameter ensures all channels are scaled proportionally to preserve the original 
+        Enabling this parameter ensures all channels are scaled proportionally to preserve the original
         hue, at the cost of potentially losing some brightness.`,
       ],
     },
@@ -78,7 +78,7 @@ export const RENDER_FIELD_COPY = {
     },
     useRussianRoulette: {
       label: 'Use Russian Roulette?',
-      description: `A technique that probabilistically terminates low-energy rays to reduce render time without 
+      description: `A technique that probabilistically terminates low-energy rays to reduce render time without
       noticeably affecting quality. Rays with low contribution are randomly terminated based on their remaining energy.`,
     },
     minBouncesBeforeRoulette: {
@@ -89,7 +89,7 @@ export const RENDER_FIELD_COPY = {
     useImportanceSampling: {
       label: 'Use Importance Sampling?',
       description: [
-        `Whether to bias ray sampling toward specific directions and geometries to reduce noise and converge faster. 
+        `Whether to bias ray sampling toward specific directions and geometries to reduce noise and converge faster.
         When enabled and tuned correctly, the renderer can converge significantly faster.`,
         `All values are unitless weights that determine the relative probability of sampling rays in each category.`,
       ],
@@ -100,7 +100,7 @@ export const RENDER_FIELD_COPY = {
         `The weight assigned to the BRDF (surface reflection) component when importance sampling is active.
         Higher values increase the proportion of rays that follow surface reflections.`,
 
-        `This is the default sampling method, and is guaranteed to correctly converge for all scenes, but 
+        `This is the default sampling method, and is guaranteed to correctly converge for all scenes, but
         may converge much slower than when combined with other importance sampling methods.`,
 
         `Setting this to 1 and all other weights to 0 effectively disables importance sampling.`,
@@ -152,7 +152,7 @@ export const RENDER_FIELD_COPY = {
     verticalFOV: {
       label: 'Vertical FOV (degrees)',
       description: `How wide the camera's view is, measured in degrees.
-      Higher values show more of the scene but cause perspective stretching at the edges, 
+      Higher values show more of the scene but cause perspective stretching at the edges,
       causing objects near the frame border to appear elongated.
       Typical values are 40-90.`,
     },
@@ -182,8 +182,9 @@ export const RENDER_FIELD_COPY = {
     _shared: {
       material: {
         label: 'Material',
-        description: `The material assigned to this geometric surface, determining its visual properties such as color, roughness, and reflectance.
-Select from the materials defined in the Materials tab.`,
+        description: `The material assigned to this geometric surface,
+        determining its visual properties such as color, roughness, and reflectance.
+        Select from the materials defined in the Materials tab.`,
       },
     },
     box: {
@@ -205,7 +206,7 @@ Select from the materials defined in the Materials tab.`,
       },
       radius: {
         label: 'Radius',
-        description: `The radius of the sphere. 
+        description: `The radius of the sphere.
         Larger values create bigger objects that occupy more of the scene.`,
       },
     },
@@ -282,7 +283,7 @@ Select from the materials defined in the Materials tab.`,
       },
       endA: {
         label: 'End A',
-        description: `Whether the cylinder's first end is capped (closed with a disk), 
+        description: `Whether the cylinder's first end is capped (closed with a disk),
         open (hollow), or infinite (extends forever in that direction).`,
       },
       endpointB: {
@@ -291,7 +292,7 @@ Select from the materials defined in the Materials tab.`,
       },
       endB: {
         label: 'End B',
-        description: `Whether the cylinder's second end is capped (closed with a disk), 
+        description: `Whether the cylinder's second end is capped (closed with a disk),
         open (hollow), or infinite (extends forever in that direction).`,
       },
       radius: {
@@ -304,6 +305,7 @@ Select from the materials defined in the Materials tab.`,
         label: 'P00 / P10 / P01 / P11',
         description: [
           `The four corner points of a bilinear patch, a double-ruled and curved surface defined by interpolation between these points.`,
+
           `P00, P10, P01, and P11 represent the four corners in grid order.`,
         ],
       },
@@ -312,80 +314,82 @@ Select from the materials defined in the Materials tab.`,
       degreesOfRotation: {
         label: 'Degrees of Rotation',
         description: `The angle of rotation applied around the chosen axis, measured in degrees.
-A full rotation is 360°.
-Positive values rotate counterclockwise when looking along the axis toward the origin.`,
+        A full rotation is 360 degrees.
+        Positive values rotate counterclockwise when looking along the axis toward the origin.`,
       },
       radiansOfRotation: {
         label: 'Radians of Rotation',
         description: `The angle of rotation applied around the chosen axis, measured in radians.
-A full rotation is 2π (approximately 6.283).
-Positive values rotate counterclockwise when looking along the axis toward the origin.`,
+        A full rotation is 2π (approximately 6.283).
+        Positive values rotate counterclockwise when looking along the axis toward the origin.`,
       },
       rotationPoint: {
         label: 'Rotation Point / Scale Point',
         description: `Controls the pivot around which rotation or scaling is applied.
-"Centroid" uses the geometric center, "Custom" lets you specify a point directly, and "Origin" uses the world origin.`,
+        "Geometric Center" uses the geometric center,
+        "Custom Point" lets you specify a point directly, and 
+        "World Origin" uses the world origin.`,
       },
       customPivotPoint: {
         label: 'Custom Rotation Point / Custom Scale Point',
-        description: `The custom 3D point used as the pivot for rotation or scaling when the pivot mode is set to "Custom".
- Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+        description: `The custom 3D point used as the pivot for rotation or scaling when the pivot mode is set to "Custom Point".`,
       },
     },
     rotate_quaternion: {
       quaternion: {
         label: 'Quaternion',
         description: `A four-component rotation representation (w, x, y, z) that avoids gimbal lock.
- Quaternions define a rotation axis and angle without the singularities of Euler angles.
- The w component represents the cosine of half the rotation angle.`,
+        Quaternions define a rotation axis and angle without the singularities of Euler angles.
+        The w component represents the cosine of half the rotation angle.`,
       },
       rotationPoint: {
         label: 'Rotation Point / Scale Point',
         description: `Controls the pivot around which rotation or scaling is applied.
- "Centroid" uses the geometric center, "Custom" lets you specify a point directly, and "Origin" uses the world origin.`,
+        "Geometric Center" uses the geometric center, 
+        "Custom Point" lets you specify a point directly, and 
+        "World Origin" uses the world origin.`,
       },
       customPivotPoint: {
         label: 'Custom Rotation Point / Custom Scale Point',
-        description: `The custom 3D point used as the pivot for rotation or scaling when the pivot mode is set to "Custom".
- Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+        description: `The custom 3D point used as the pivot for rotation or scaling when the pivot mode is set to "Custom Point".`,
       },
     },
     scale: {
       scale: {
         label: 'Scale',
         description: `A uniform or per-axis scaling factor applied to the geometry.
- A value of 1 leaves the size unchanged.
- Values greater than 1 enlarge the object; values between 0 and 1 shrink it.`,
+        A value of 1 leaves the size unchanged.
+        Values greater than 1 enlarge the object; values between 0 and 1 shrink it.`,
       },
       rotationPoint: {
         label: 'Rotation Point / Scale Point',
         description: `Controls the pivot around which rotation or scaling is applied.
- "Centroid" uses the geometric center, "Custom" lets you specify a point directly, and "Origin" uses the world origin.`,
+        "Geometric Center" uses the geometric center, 
+        "Custom Point" lets you specify a point directly, and 
+        "World Origin" uses the world origin.`,
       },
       customPivotPoint: {
         label: 'Custom Rotation Point / Custom Scale Point',
-        description: `The custom 3D point used as the pivot for rotation or scaling when the pivot mode is set to "Custom".
-Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+        description: `The custom 3D point used as the pivot for rotation or scaling when the pivot mode is set to "Custom Point".`,
       },
     },
     translate: {
       translation: {
         label: 'Translation',
         description: `The offset applied to move the geometry in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-This shifts the object from its original position by the specified amounts.`,
+        This shifts the object from its original position by the specified amounts.`,
       },
     },
     constant_volume: {
       density: {
         label: 'Density',
         description: `The density of the constant-volume medium, controlling how much light is scattered or absorbed as it passes through.
-Higher densities create thicker, more opaque volumes.`,
+        Higher densities create thicker, more opaque volumes.`,
       },
       reflectanceTexture: {
         label: 'Reflectance Texture',
         description: `A texture that maps surface reflectance across the volume, determining how much light is reflected at each point.
-Select from the textures defined in the Textures tab.`,
+        Select from the textures defined in the Textures tab.`,
       },
     },
   },
@@ -394,13 +398,13 @@ Select from the textures defined in the Textures tab.`,
       reflectanceTexture: {
         label: 'Reflectance Texture',
         description: `A texture that maps surface reflectance (color/albedo) across the material, determining the base color at each point on the surface.
-Select from the textures defined in the Textures tab.`,
+        Select from the textures defined in the Textures tab.`,
       },
       emittanceTexture: {
         label: 'Emittance Texture',
         description: `A texture that controls where and how strongly the surface emits light, effectively turning parts of the material into light sources.
-White areas emit strongly; black areas do not emit.
-Select from the textures defined in the Textures tab.`,
+        White areas emit strongly; black areas do not emit.
+        Select from the textures defined in the Textures tab.`,
       },
     },
     lambertian: {},
@@ -408,51 +412,56 @@ Select from the textures defined in the Textures tab.`,
       roughness: {
         label: 'Roughness',
         description: `Controls how rough or smooth the surface is.
-0 = perfectly mirror-like, 1 = completely diffuse/matte.
-Rough surfaces scatter reflected light in many directions, creating soft reflections.`,
+        0 = perfectly mirror-like, 1 = completely diffuse/matte.
+        Rough surfaces scatter reflected light in many directions, creating soft reflections.`,
       },
     },
     dielectric: {
       indexOfRefraction: {
         label: 'Index of Refraction',
         description: `Determines how much light bends when entering the material.
-Water is ~1.33, glass is ~1.5, diamond is ~2.4.
-Higher values create stronger refraction effects.`,
+        Water is ~1.33, glass is ~1.5, diamond is ~2.4.
+        Higher values create stronger refraction effects.`,
       },
       abbeNumber: {
         label: 'Abbe Number',
-        description: `Quantifies the material's chromatic dispersion — how much the index of refraction varies by wavelength.
-Lower values (20-40) produce stronger rainbow-like color fringing; higher values (50-80) produce less dispersion.
-Typical glass ranges from 30-60.`,
+        description: `Quantifies the material's chromatic dispersion, i.e. how much the index of refraction varies by wavelength.
+        Lower values (20-40) produce stronger rainbow-like color fringing; higher values (50-80) produce less dispersion.
+        Typical glass ranges from 30-60.`,
       },
       hasInteriorMedium: {
         label: 'Has Interior Medium?',
-        description: `Whether the dielectric (transparent) material contains an interior medium such as smoke, fog, or colored glass.
-When enabled, light passing through the material interacts with the medium's properties.`,
+        description: [
+          `When enabled, the dielectric is treated as a solid volume with real ray refraction and an interior medium. 
+          When disabled, it uses a fast thin-slab approximation: Rays pass straight through with no bending and no volume effects.`,
+
+          `Most of the time, this setting should probably match the nature of the geometric it is attached to: 
+          3D, volumetric geometrics like spheres and boxes should have an interior medium, and 
+          2D geometrics like parallelograms, planes, disks, and bilinear patches should have this disabled.`,
+        ],
       },
       mediumType: {
         label: 'Type',
-        description: `The type of interior medium.
-"Vacuum" is empty space with no light interaction.
-"Homogeneous" has uniform optical properties throughout — light is scattered or absorbed evenly as it passes through.`,
+        description: `"Vacuum" behaves as clear glass: Real refraction with no absorption or emission. 
+        "Homogeneous" adds uniform absorption and emission throughout the volume, useful for colored glass or glowing gases.`,
       },
       transmittance: {
         label: 'Transmittance',
         description: `The color of light that passes through the homogeneous medium.
-White means all wavelengths pass equally.
-Tinted values (such as a green tint) absorb complementary colors, giving the medium a colored appearance.`,
+        White means all wavelengths pass equally. Tinted values absorb complementary colors,
+        giving the medium a colored appearance. Red tint absorbs blue and green, making the volume look red.`,
       },
       attenuationDistance: {
         label: 'Attenuation Distance',
-        description: `The distance light travels through the homogeneous medium before its intensity is reduced by approximately 63%.
-Smaller values create denser, more opaque media.
-Larger values create clearer, more transparent media.`,
+        description: `The reference distance at which the transmittance value applies.
+        At this distance, the fraction of light surviving equals the transmittance.
+        Smaller values create denser, more opaque media; larger values create clearer, more transparent media.`,
       },
       emittance: {
         label: 'Emittance',
-        description: `The color and intensity of light emitted by the homogeneous medium itself.
-A black value means the medium does not emit light.
-Non-black values cause the medium to glow from within, like a neon tube or fire.`,
+        description: `The color and intensity of light emitted by the medium itself. 
+        A black value means the medium does not glow. Non-black values cause the medium to
+        emit light from within. The glow is strongest where the medium is thickest or densest.`,
       },
     },
   },
@@ -460,8 +469,8 @@ Non-black values cause the medium to glow from within, like a neon tube or fire.
     scale: {
       label: 'Scale',
       description: `Controls the size of the checker pattern.
-Smaller values create more, smaller checks across the surface.
-Larger values create fewer, larger checks.`,
+      Smaller values create more, smaller checks across the surface.
+      Larger values create fewer, larger checks.`,
     },
     color: {
       label: 'Color',

--- a/ui/src/data/renderFieldCopy.ts
+++ b/ui/src/data/renderFieldCopy.ts
@@ -1,0 +1,438 @@
+export type FieldCopy = {
+  /** human-readable label shown in the form */
+  label: string;
+  /** tooltip/help text explaining the field in plain language */
+  description: string;
+};
+
+export const RENDER_FIELD_COPY = {
+  parameters: {
+    name: {
+      label: 'Name',
+      description: `A unique identifier for this render configuration.
+Used to reference the render in the dashboard and exported file names.`,
+    },
+    imageDimensions: {
+      label: 'Size (width x height)',
+      description: `The resolution of the final rendered image, measured in pixels.
+Higher resolutions produce sharper images but take significantly longer to render.
+Common values are 1920x1080 (Full HD) or 3840x2160 (4K).`,
+    },
+    tileDimensions: {
+      label: 'Tile Size',
+      description: `The size in pixels of each square tile the renderer processes in parallel.
+Smaller tiles update the preview more frequently but add scheduling overhead.`,
+    },
+    samplesPerCheckpoint: {
+      label: 'Samples Per Checkpoint',
+      description: `How many rays are traced through each pixel before a checkpoint image is saved.
+Higher values reduce noise but make each checkpoint take longer.
+Each checkpoint builds on the previous one, progressively refining the image.`,
+    },
+    totalCheckpoints: {
+      label: 'Total Checkpoints',
+      description: `The total number of checkpoint images the renderer will produce before stopping.
+More checkpoints mean a longer render with finer-grained progress updates.
+The final image quality depends on the total samples (samples per checkpoint x total checkpoints).`,
+    },
+    savedCheckpointLimit: {
+      label: 'Saved Checkpoint Limit',
+      description: `The maximum number of checkpoint images kept on disk at once.
+When the limit is reached, older checkpoints are discarded as new ones are saved.`,
+    },
+    enforceCheckpointLimit: {
+      label: 'Enforce Checkpoint Limit?',
+      description: `Whether to enforce the saved checkpoint limit by discarding old checkpoints.
+When disabled, all checkpoints are kept until the render completes.`,
+    },
+    maxLightBounces: {
+      label: 'Max Light Bounces',
+      description: `The maximum number of times a light ray can reflect or refract before the tracer stops following it.
+Higher values produce more realistic lighting but increase render time.
+A value of 10–50 is typical for most scenes.`,
+    },
+    useScalingTruncation: {
+      label: 'Use Scaling Truncation',
+      description: `Whether to truncate very small ray contributions instead of following them to zero.
+This can slightly speed up renders by cutting insignificant paths, but may introduce subtle energy loss.`,
+    },
+    useRussianRoulette: {
+      label: 'Use Russian Roulette?',
+      description: `A technique that probabilistically terminates low-energy rays to reduce render time without noticeably affecting quality.
+Rays with low contribution are randomly terminated based on their remaining energy.`,
+    },
+    minBouncesBeforeRoulette: {
+      label: 'Minimum Bounces Before Activation',
+      description: `The minimum number of bounces a ray must complete before Russian roulette can terminate it.
+This ensures early bounces — which carry the most visual energy — are always fully computed.`,
+    },
+    useImportanceSampling: {
+      label: 'Use Importance Sampling?',
+      description: `Whether to bias ray sampling toward light sources and important directions to reduce noise.
+When enabled, the renderer allocates more samples to significant light paths.`,
+    },
+    brdfWeight: {
+      label: 'BRDF Weight',
+      description: `The sampling weight assigned to the BRDF (surface reflection) component when importance sampling is active.
+Higher values increase the proportion of rays that follow surface reflections.`,
+    },
+    emissiveWeight: {
+      label: 'Emissive Weight',
+      description: `The sampling weight assigned to emissive (self-illuminating) surfaces when importance sampling is active.
+Higher values increase the proportion of rays directed toward light-emitting objects.`,
+    },
+    transmissiveWeight: {
+      label: 'Transmissive Weight',
+      description: `The sampling weight assigned to transmissive (light-passing) materials when importance sampling is active.
+Higher values increase the proportion of rays that pass through transparent objects.`,
+    },
+    specularWeight: {
+      label: 'Specular Weight',
+      description: `The sampling weight assigned to specular (mirror-like) reflections when importance sampling is active.
+Higher values increase the proportion of rays that produce sharp reflections.`,
+    },
+    virtualWeight: {
+      label: 'Virtual Weight',
+      description: `The sampling weight assigned to virtual light paths when importance sampling is active.
+Higher values increase the proportion of rays that follow indirect illumination paths.`,
+    },
+    useMultipleImportanceSampling: {
+      label: 'Use Multiple Importance Sampling',
+      description: `Combines samples from both the BRDF and light source distributions to reduce noise, especially in scenes with small or bright light sources.
+This produces cleaner renders but increases computational cost.`,
+    },
+  },
+  cameras: {
+    verticalFOV: {
+      label: 'Vertical FOV (degrees)',
+      description: `How wide the camera's view is, measured in degrees.
+Higher values show more of the scene but can cause fisheye distortion.
+Typical values are 40–90°.`,
+    },
+    eyeLocation: {
+      label: 'Eye (x/y/z)',
+      description: `The 3D position of the camera in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+Moving the eye changes what part of the scene is visible.`,
+    },
+    targetLocation: {
+      label: 'Target (x/y/z)',
+      description: `The 3D point the camera is looking at in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+Moving the target changes the direction the camera faces.`,
+    },
+    viewUp: {
+      label: 'View Up (x/y/z)',
+      description: `The upward direction vector for the camera, defining its roll orientation.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+The default is (0, 1, 0), meaning the camera's top points along the world Y axis.`,
+    },
+    defocusAngle: {
+      label: 'Defocus Angle (degrees)',
+      description: `Controls the depth-of-field blur effect by simulating a finite aperture.
+A value of 0 produces a perfectly sharp image.
+Higher values increase background blur, drawing attention to in-focus subjects.`,
+    },
+  },
+  geometrics: {
+    _shared: {
+      material: {
+        label: 'Material',
+        description: `The material assigned to this geometric surface, determining its visual properties such as color, roughness, and reflectance.
+Select from the materials defined in the Materials tab.`,
+      },
+    },
+    box: {
+      corner1: {
+        label: 'Corner 1',
+        description: `The first corner of the box in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+Together with Corner 2, this defines the box's extents.`,
+      },
+      corner2: {
+        label: 'Corner 2',
+        description: `The opposite corner of the box in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+Together with Corner 1, this defines the box's extents.`,
+      },
+    },
+    sphere: {
+      center: {
+        label: 'Center',
+        description: `The center position of the sphere or disk in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+      },
+      radius: {
+        label: 'Radius',
+        description: `The radius of the sphere, disk, or cylinder. Larger values create bigger objects that occupy more of the scene.`,
+      },
+    },
+    triangle: {
+      pointA: {
+        label: 'Point A',
+        description: `The first vertex of the triangle in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+The triangle is formed by Points A, B, and C in order.`,
+      },
+      pointB: {
+        label: 'Point B',
+        description: `The second vertex of the triangle in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+      },
+      pointC: {
+        label: 'Point C',
+        description: `The third vertex of the triangle in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+      },
+    },
+    parallelogram: {
+      lowerLeft: {
+        label: 'Lower Left',
+        description: `The origin corner of the parallelogram in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+The parallelogram extends along the u and v vectors from this point.`,
+      },
+      uVector: {
+        label: 'u Vector',
+        description: `The first edge direction and length of the parallelogram.
+Together with the v vector, it defines the shape and orientation of the surface.`,
+      },
+      vVector: {
+        label: 'v Vector',
+        description: `The second edge direction and length of the parallelogram.
+Together with the u vector, it defines the shape and orientation of the surface.`,
+      },
+    },
+    plane: {
+      point: {
+        label: 'Point',
+        description: `An anchor point on the infinite plane in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+The plane passes through this point and extends infinitely.`,
+      },
+      normal: {
+        label: 'Normal',
+        description: `The surface normal vector for a plane or disk, defining which direction the surface faces.
+A normal of (0, 1, 0) faces upward.
+The surface is only visible from the side the normal points toward.`,
+      },
+    },
+    disk: {
+      center: {
+        label: 'Center',
+        description: `The center position of the sphere or disk in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+      },
+      normal: {
+        label: 'Normal',
+        description: `The surface normal vector for a plane or disk, defining which direction the surface faces.
+A normal of (0, 1, 0) faces upward.
+The surface is only visible from the side the normal points toward.`,
+      },
+      radius: {
+        label: 'Radius',
+        description: `The radius of the sphere, disk, or cylinder. Larger values create bigger objects that occupy more of the scene.`,
+      },
+      innerRadius: {
+        label: 'Inner Radius',
+        description: `The inner radius of the ring-shaped disk.
+The area between the inner radius and the outer radius forms the visible surface.
+Setting this to 0 creates a solid disk.`,
+      },
+    },
+    cylinder: {
+      endpointA: {
+        label: 'Endpoint A',
+        description: `The first endpoint of the cylinder's center axis in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+The cylinder extends along the line between Endpoint A and Endpoint B.`,
+      },
+      endA: {
+        label: 'End A',
+        description: `Whether the cylinder's first end is capped (closed with a flat surface), open (hollow), or infinite (extends forever in that direction).
+Capped ends block light; open ends let it pass through.`,
+      },
+      endpointB: {
+        label: 'Endpoint B',
+        description: `The second endpoint of the cylinder's center axis in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+      },
+      endB: {
+        label: 'End B',
+        description: `Whether the cylinder's second end is capped (closed with a flat surface), open (hollow), or infinite (extends forever in that direction).
+Capped ends block light; open ends let it pass through.`,
+      },
+      radius: {
+        label: 'Radius',
+        description: `The radius of the sphere, disk, or cylinder. Larger values create bigger objects that occupy more of the scene.`,
+      },
+    },
+    bilinear_patch: {
+      bilinearCorner: {
+        label: 'P00 / P10 / P01 / P11',
+        description: `The four corner points of a bilinear patch, a curved surface defined by interpolation between these points.
+P00, P10, P01, and P11 represent the four corners in grid order.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+      },
+    },
+    rotate: {
+      degreesOfRotation: {
+        label: 'Degrees of Rotation',
+        description: `The angle of rotation applied around the chosen axis, measured in degrees.
+A full rotation is 360°.
+Positive values rotate counterclockwise when looking along the axis toward the origin.`,
+      },
+      radiansOfRotation: {
+        label: 'Radians of Rotation',
+        description: `The angle of rotation applied around the chosen axis, measured in radians.
+A full rotation is 2π (approximately 6.283).
+Positive values rotate counterclockwise when looking along the axis toward the origin.`,
+      },
+      rotationPoint: {
+        label: 'Rotation Point / Scale Point',
+        description: `Controls the pivot around which rotation or scaling is applied.
+"Centroid" uses the geometric center, "Custom" lets you specify a point directly, and "Origin" uses the world origin.`,
+      },
+      customPivotPoint: {
+        label: 'Custom Rotation Point / Custom Scale Point',
+        description: `The custom 3D point used as the pivot for rotation or scaling when the pivot mode is set to "Custom".
+ Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+      },
+    },
+    rotate_quaternion: {
+      quaternion: {
+        label: 'Quaternion',
+        description: `A four-component rotation representation (w, x, y, z) that avoids gimbal lock.
+ Quaternions define a rotation axis and angle without the singularities of Euler angles.
+ The w component represents the cosine of half the rotation angle.`,
+      },
+      rotationPoint: {
+        label: 'Rotation Point / Scale Point',
+        description: `Controls the pivot around which rotation or scaling is applied.
+ "Centroid" uses the geometric center, "Custom" lets you specify a point directly, and "Origin" uses the world origin.`,
+      },
+      customPivotPoint: {
+        label: 'Custom Rotation Point / Custom Scale Point',
+        description: `The custom 3D point used as the pivot for rotation or scaling when the pivot mode is set to "Custom".
+ Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+      },
+    },
+    scale: {
+      scale: {
+        label: 'Scale',
+        description: `A uniform or per-axis scaling factor applied to the geometry.
+ A value of 1 leaves the size unchanged.
+ Values greater than 1 enlarge the object; values between 0 and 1 shrink it.`,
+      },
+      rotationPoint: {
+        label: 'Rotation Point / Scale Point',
+        description: `Controls the pivot around which rotation or scaling is applied.
+ "Centroid" uses the geometric center, "Custom" lets you specify a point directly, and "Origin" uses the world origin.`,
+      },
+      customPivotPoint: {
+        label: 'Custom Rotation Point / Custom Scale Point',
+        description: `The custom 3D point used as the pivot for rotation or scaling when the pivot mode is set to "Custom".
+Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+      },
+    },
+    translate: {
+      translation: {
+        label: 'Translation',
+        description: `The offset applied to move the geometry in world space.
+Uses Y-up coordinates: X = right, Y = up, Z = forward.
+This shifts the object from its original position by the specified amounts.`,
+      },
+    },
+    constant_volume: {
+      density: {
+        label: 'Density',
+        description: `The density of the constant-volume medium, controlling how much light is scattered or absorbed as it passes through.
+Higher densities create thicker, more opaque volumes.`,
+      },
+      reflectanceTexture: {
+        label: 'Reflectance Texture',
+        description: `A texture that maps surface reflectance across the volume, determining how much light is reflected at each point.
+Select from the textures defined in the Textures tab.`,
+      },
+    },
+  },
+  materials: {
+    _shared: {
+      reflectanceTexture: {
+        label: 'Reflectance Texture',
+        description: `A texture that maps surface reflectance (color/albedo) across the material, determining the base color at each point on the surface.
+Select from the textures defined in the Textures tab.`,
+      },
+      emittanceTexture: {
+        label: 'Emittance Texture',
+        description: `A texture that controls where and how strongly the surface emits light, effectively turning parts of the material into light sources.
+White areas emit strongly; black areas do not emit.
+Select from the textures defined in the Textures tab.`,
+      },
+    },
+    lambertian: {},
+    specular: {
+      roughness: {
+        label: 'Roughness',
+        description: `Controls how rough or smooth the surface is.
+0 = perfectly mirror-like, 1 = completely diffuse/matte.
+Rough surfaces scatter reflected light in many directions, creating soft reflections.`,
+      },
+    },
+    dielectric: {
+      indexOfRefraction: {
+        label: 'Index of Refraction',
+        description: `Determines how much light bends when entering the material.
+Water is ~1.33, glass is ~1.5, diamond is ~2.4.
+Higher values create stronger refraction effects.`,
+      },
+      abbeNumber: {
+        label: 'Abbe Number',
+        description: `Quantifies the material's chromatic dispersion — how much the index of refraction varies by wavelength.
+Lower values (20–40) produce stronger rainbow-like color fringing; higher values (50–80) produce less dispersion.
+Typical glass ranges from 30–60.`,
+      },
+      hasInteriorMedium: {
+        label: 'Has Interior Medium?',
+        description: `Whether the dielectric (transparent) material contains an interior medium such as smoke, fog, or colored glass.
+When enabled, light passing through the material interacts with the medium's properties.`,
+      },
+      mediumType: {
+        label: 'Type',
+        description: `The type of interior medium.
+"Vacuum" is empty space with no light interaction.
+"Homogeneous" has uniform optical properties throughout — light is scattered or absorbed evenly as it passes through.`,
+      },
+      transmittance: {
+        label: 'Transmittance',
+        description: `The color of light that passes through the homogeneous medium.
+White means all wavelengths pass equally.
+Tinted values (such as a green tint) absorb complementary colors, giving the medium a colored appearance.`,
+      },
+      attenuationDistance: {
+        label: 'Attenuation Distance',
+        description: `The distance light travels through the homogeneous medium before its intensity is reduced by approximately 63%.
+Smaller values create denser, more opaque media.
+Larger values create clearer, more transparent media.`,
+      },
+      emittance: {
+        label: 'Emittance',
+        description: `The color and intensity of light emitted by the homogeneous medium itself.
+A black value means the medium does not emit light.
+Non-black values cause the medium to glow from within, like a neon tube or fire.`,
+      },
+    },
+  },
+  textures: {
+    scale: {
+      label: 'Scale',
+      description: `Controls the size of the checker pattern.
+Smaller values create more, smaller checks across the surface.
+Larger values create fewer, larger checks.`,
+    },
+    color: {
+      label: 'Color',
+      description: `The solid color value for this texture. This color is applied uniformly across the entire surface.`,
+    },
+  },
+};

--- a/ui/src/data/renderFieldCopy.ts
+++ b/ui/src/data/renderFieldCopy.ts
@@ -152,32 +152,30 @@ export const RENDER_FIELD_COPY = {
     verticalFOV: {
       label: 'Vertical FOV (degrees)',
       description: `How wide the camera's view is, measured in degrees.
-Higher values show more of the scene but can cause fisheye distortion.
-Typical values are 40-90°.`,
+      Higher values show more of the scene but cause perspective stretching at the edges, 
+      causing objects near the frame border to appear elongated.
+      Typical values are 40-90.`,
     },
     eyeLocation: {
       label: 'Eye (x/y/z)',
       description: `The 3D position of the camera in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-Moving the eye changes what part of the scene is visible.`,
+      Moving the eye changes what part of the scene is visible.`,
     },
     targetLocation: {
       label: 'Target (x/y/z)',
       description: `The 3D point the camera is looking at in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-Moving the target changes the direction the camera faces.`,
+      Moving the target changes the direction the camera faces.`,
     },
     viewUp: {
       label: 'View Up (x/y/z)',
       description: `The upward direction vector for the camera, defining its roll orientation.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-The default is (0, 1, 0), meaning the camera's top points along the world Y axis.`,
+      The default is (0, 1, 0), meaning the camera's top points along the world Y axis.`,
     },
     defocusAngle: {
       label: 'Defocus Angle (degrees)',
       description: `Controls the depth-of-field blur effect by simulating a finite aperture.
-A value of 0 produces a perfectly sharp image.
-Higher values increase background blur, drawing attention to in-focus subjects.`,
+      A value of 0 produces a perfectly sharp image.
+      Higher values increase background blur, drawing attention to in-focus subjects.`,
     },
   },
   geometrics: {
@@ -192,133 +190,122 @@ Select from the materials defined in the Materials tab.`,
       corner1: {
         label: 'Corner 1',
         description: `The first corner of the box in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-Together with Corner 2, this defines the box's extents.`,
+        Together with Corner 2, this defines the box's extents.`,
       },
       corner2: {
         label: 'Corner 2',
         description: `The opposite corner of the box in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-Together with Corner 1, this defines the box's extents.`,
+        Together with Corner 1, this defines the box's extents.`,
       },
     },
     sphere: {
       center: {
         label: 'Center',
-        description: `The center position of the sphere or disk in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+        description: `The center position of the sphere or disk in world space.`,
       },
       radius: {
         label: 'Radius',
-        description: `The radius of the sphere, disk, or cylinder. Larger values create bigger objects that occupy more of the scene.`,
+        description: `The radius of the sphere. 
+        Larger values create bigger objects that occupy more of the scene.`,
       },
     },
     triangle: {
       pointA: {
         label: 'Point A',
         description: `The first vertex of the triangle in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-The triangle is formed by Points A, B, and C in order.`,
+        The triangle is formed by Points A, B, and C in order.`,
       },
       pointB: {
         label: 'Point B',
-        description: `The second vertex of the triangle in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+        description: `The second vertex of the triangle in world space.`,
       },
       pointC: {
         label: 'Point C',
-        description: `The third vertex of the triangle in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+        description: `The third vertex of the triangle in world space.`,
       },
     },
     parallelogram: {
       lowerLeft: {
         label: 'Lower Left',
         description: `The origin corner of the parallelogram in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-The parallelogram extends along the u and v vectors from this point.`,
+        The parallelogram extends along the u and v vectors from this point.`,
       },
       uVector: {
         label: 'u Vector',
         description: `The first edge direction and length of the parallelogram.
-Together with the v vector, it defines the shape and orientation of the surface.`,
+        Together with the v vector, it defines the shape and orientation of the surface.`,
       },
       vVector: {
         label: 'v Vector',
         description: `The second edge direction and length of the parallelogram.
-Together with the u vector, it defines the shape and orientation of the surface.`,
+        Together with the u vector, it defines the shape and orientation of the surface.`,
       },
     },
     plane: {
       point: {
         label: 'Point',
         description: `An anchor point on the infinite plane in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-The plane passes through this point and extends infinitely.`,
+        The plane passes through this point and extends infinitely.`,
       },
       normal: {
         label: 'Normal',
         description: `The surface normal vector for a plane or disk, defining which direction the surface faces.
-A normal of (0, 1, 0) faces upward.
-The surface is only visible from the side the normal points toward.`,
+        A normal of (0, 1, 0) faces upward.`,
       },
     },
     disk: {
       center: {
         label: 'Center',
-        description: `The center position of the sphere or disk in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+        description: `The center position of the sphere or disk in world space.`,
       },
       normal: {
         label: 'Normal',
         description: `The surface normal vector for a plane or disk, defining which direction the surface faces.
-A normal of (0, 1, 0) faces upward.
-The surface is only visible from the side the normal points toward.`,
+        A normal of (0, 1, 0) faces upward.`,
       },
       radius: {
         label: 'Radius',
-        description: `The radius of the sphere, disk, or cylinder. Larger values create bigger objects that occupy more of the scene.`,
+        description: `The radius of the disk.`,
       },
       innerRadius: {
         label: 'Inner Radius',
         description: `The inner radius of the ring-shaped disk.
-The area between the inner radius and the outer radius forms the visible surface.
-Setting this to 0 creates a solid disk.`,
+        The area between the inner radius and the outer radius forms the visible surface.
+        Setting this to 0 creates a solid disk.`,
       },
     },
     cylinder: {
       endpointA: {
         label: 'Endpoint A',
         description: `The first endpoint of the cylinder's center axis in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.
-The cylinder extends along the line between Endpoint A and Endpoint B.`,
+        The cylinder extends along the line between Endpoint A and Endpoint B.`,
       },
       endA: {
         label: 'End A',
-        description: `Whether the cylinder's first end is capped (closed with a flat surface), open (hollow), or infinite (extends forever in that direction).
-Capped ends block light; open ends let it pass through.`,
+        description: `Whether the cylinder's first end is capped (closed with a disk), 
+        open (hollow), or infinite (extends forever in that direction).`,
       },
       endpointB: {
         label: 'Endpoint B',
-        description: `The second endpoint of the cylinder's center axis in world space.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+        description: `The second endpoint of the cylinder's center axis in world space.`,
       },
       endB: {
         label: 'End B',
-        description: `Whether the cylinder's second end is capped (closed with a flat surface), open (hollow), or infinite (extends forever in that direction).
-Capped ends block light; open ends let it pass through.`,
+        description: `Whether the cylinder's second end is capped (closed with a disk), 
+        open (hollow), or infinite (extends forever in that direction).`,
       },
       radius: {
         label: 'Radius',
-        description: `The radius of the sphere, disk, or cylinder. Larger values create bigger objects that occupy more of the scene.`,
+        description: `The radius of the cylinder.`,
       },
     },
     bilinear_patch: {
       bilinearCorner: {
         label: 'P00 / P10 / P01 / P11',
-        description: `The four corner points of a bilinear patch, a curved surface defined by interpolation between these points.
-P00, P10, P01, and P11 represent the four corners in grid order.
-Uses Y-up coordinates: X = right, Y = up, Z = forward.`,
+        description: [
+          `The four corner points of a bilinear patch, a double-ruled and curved surface defined by interpolation between these points.`,
+          `P00, P10, P01, and P11 represent the four corners in grid order.`,
+        ],
       },
     },
     rotate: {

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/AroundVariantControls.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/AroundVariantControls.tsx
@@ -4,6 +4,7 @@ import { isAroundPoint } from '@/utils/render/utils';
 import type { Around } from '@/utils/render/utils';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { AnimatedSeparator } from '@/components/AnimatedSeparator';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 
 export type AroundVariantControlsProps = {
   form: RenderForm;
@@ -24,6 +25,7 @@ export function AroundVariantControls(props: AroundVariantControlsProps) {
             <AnimatedSeparator visible={isPoint} />
             <field.SelectControl
               label={pivotLabel}
+              tooltip={RENDER_FIELD_COPY.geometrics.rotate.rotationPoint.description}
               items={[
                 { label: 'Geometric Center', value: 'center' },
                 { label: 'World Origin', value: 'origin' },
@@ -56,6 +58,7 @@ export function AroundVariantControls(props: AroundVariantControlsProps) {
                   form={form}
                   fieldName={`geometrics.${geometricName}.around.point`}
                   label={`Custom ${pivotLabel}`}
+                  tooltip={RENDER_FIELD_COPY.geometrics.rotate.customPivotPoint.description}
                   valueLabels={['x', 'y', 'z']}
                   type="number"
                 />

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricMaterialSelect.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricMaterialSelect.tsx
@@ -4,14 +4,15 @@ export type GeometricMaterialSelectProps = {
   form: RenderForm;
   name: string;
   items: { label: string; value: string }[];
+  tooltip?: React.ReactNode;
 };
 
 export function GeometricMaterialSelect(props: GeometricMaterialSelectProps) {
-  const { form, name, items } = props;
+  const { form, name, items, tooltip } = props;
 
   return (
     <form.AppField name={`geometrics.${name}.material`}>
-      {(field) => <field.SelectControl label="Material" items={items} />}
+      {(field) => <field.SelectControl label="Material" items={items} tooltip={tooltip} />}
     </form.AppField>
   );
 }

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricMaterialSelect.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricMaterialSelect.tsx
@@ -4,7 +4,7 @@ export type GeometricMaterialSelectProps = {
   form: RenderForm;
   name: string;
   items: { label: string; value: string }[];
-  tooltip?: React.ReactNode;
+  tooltip?: string | string[];
 };
 
 export function GeometricMaterialSelect(props: GeometricMaterialSelectProps) {

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricTextureSelect.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricTextureSelect.tsx
@@ -4,14 +4,17 @@ export type GeometricTextureSelectProps = {
   form: RenderForm;
   name: string;
   items: { label: string; value: string }[];
+  tooltip?: React.ReactNode;
 };
 
 export function GeometricTextureSelect(props: GeometricTextureSelectProps) {
-  const { form, name, items } = props;
+  const { form, name, items, tooltip } = props;
 
   return (
     <form.AppField name={`geometrics.${name}.reflectance_texture`}>
-      {(field) => <field.SelectControl label="Reflectance Texture" items={items} />}
+      {(field) => (
+        <field.SelectControl label="Reflectance Texture" items={items} tooltip={tooltip} />
+      )}
     </form.AppField>
   );
 }

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricTextureSelect.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/GeometricTextureSelect.tsx
@@ -4,7 +4,7 @@ export type GeometricTextureSelectProps = {
   form: RenderForm;
   name: string;
   items: { label: string; value: string }[];
-  tooltip?: React.ReactNode;
+  tooltip?: string | string[];
 };
 
 export function GeometricTextureSelect(props: GeometricTextureSelectProps) {

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -9,6 +9,7 @@ import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
 import { ToggleSwitch } from 'flowbite-react';
 import { useGizmo } from '@/providers/Gizmo';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 
 export type GeometricFormControlsProps = {
   form: RenderForm;
@@ -43,6 +44,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.a`}
             label="Corner 1"
+            tooltip={RENDER_FIELD_COPY.geometrics.box.corner1.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -50,10 +52,16 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.b`}
             label="Corner 2"
+            tooltip={RENDER_FIELD_COPY.geometrics.box.corner2.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
-          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+          <GeometricMaterialSelect
+            form={form}
+            name={name}
+            items={materialItems}
+            tooltip={RENDER_FIELD_COPY.geometrics._shared.material.description}
+          />
         </>
       );
     case 'sphere':
@@ -63,6 +71,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.center`}
             label="Center"
+            tooltip={RENDER_FIELD_COPY.geometrics.sphere.center.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -70,10 +79,16 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.radius`}
             label="Radius"
+            tooltip={RENDER_FIELD_COPY.geometrics.sphere.radius.description}
             valueLabel="radius"
             type="number"
           />
-          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+          <GeometricMaterialSelect
+            form={form}
+            name={name}
+            items={materialItems}
+            tooltip={RENDER_FIELD_COPY.geometrics._shared.material.description}
+          />
         </>
       );
     case 'triangle':
@@ -83,6 +98,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.a`}
             label="Point A"
+            tooltip={RENDER_FIELD_COPY.geometrics.triangle.pointA.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -90,6 +106,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.b`}
             label="Point B"
+            tooltip={RENDER_FIELD_COPY.geometrics.triangle.pointB.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -97,10 +114,16 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.c`}
             label="Point C"
+            tooltip={RENDER_FIELD_COPY.geometrics.triangle.pointC.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
-          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+          <GeometricMaterialSelect
+            form={form}
+            name={name}
+            items={materialItems}
+            tooltip={RENDER_FIELD_COPY.geometrics._shared.material.description}
+          />
         </>
       );
     case 'parallelogram':
@@ -110,6 +133,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.lower_left`}
             label="Lower Left"
+            tooltip={RENDER_FIELD_COPY.geometrics.parallelogram.lowerLeft.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -123,6 +147,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
                 <em>u</em> Vector
               </>
             }
+            tooltip={RENDER_FIELD_COPY.geometrics.parallelogram.uVector.description}
           />
           <TextArrayInputControl
             form={form}
@@ -134,8 +159,14 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
                 <em>v</em> Vector
               </>
             }
+            tooltip={RENDER_FIELD_COPY.geometrics.parallelogram.vVector.description}
           />
-          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+          <GeometricMaterialSelect
+            form={form}
+            name={name}
+            items={materialItems}
+            tooltip={RENDER_FIELD_COPY.geometrics._shared.material.description}
+          />
         </>
       );
     case 'plane':
@@ -145,6 +176,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.point`}
             label="Point"
+            tooltip={RENDER_FIELD_COPY.geometrics.plane.point.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -152,10 +184,16 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.normal`}
             label="Normal"
+            tooltip={RENDER_FIELD_COPY.geometrics.plane.normal.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
-          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+          <GeometricMaterialSelect
+            form={form}
+            name={name}
+            items={materialItems}
+            tooltip={RENDER_FIELD_COPY.geometrics._shared.material.description}
+          />
         </>
       );
     case 'disk':
@@ -165,6 +203,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.center`}
             label="Center"
+            tooltip={RENDER_FIELD_COPY.geometrics.disk.center.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -172,6 +211,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.normal`}
             label="Normal"
+            tooltip={RENDER_FIELD_COPY.geometrics.disk.normal.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -179,6 +219,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.radius`}
             label="Radius"
+            tooltip={RENDER_FIELD_COPY.geometrics.disk.radius.description}
             valueLabel="radius"
             type="number"
           />
@@ -186,10 +227,16 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.inner_radius`}
             label="Inner Radius"
+            tooltip={RENDER_FIELD_COPY.geometrics.disk.innerRadius.description}
             valueLabel="inner_radius"
             type="number"
           />
-          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+          <GeometricMaterialSelect
+            form={form}
+            name={name}
+            items={materialItems}
+            tooltip={RENDER_FIELD_COPY.geometrics._shared.material.description}
+          />
         </>
       );
     case 'cylinder':
@@ -199,6 +246,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.a`}
             label="Endpoint A"
+            tooltip={RENDER_FIELD_COPY.geometrics.cylinder.endpointA.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -206,6 +254,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             {(field) => (
               <field.SelectControl
                 label="End A"
+                tooltip={RENDER_FIELD_COPY.geometrics.cylinder.endA.description}
                 items={[
                   { label: 'Capped', value: 'capped' },
                   { label: 'Open', value: 'open' },
@@ -218,6 +267,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.b`}
             label="Endpoint B"
+            tooltip={RENDER_FIELD_COPY.geometrics.cylinder.endpointB.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -225,6 +275,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             {(field) => (
               <field.SelectControl
                 label="End B"
+                tooltip={RENDER_FIELD_COPY.geometrics.cylinder.endB.description}
                 items={[
                   { label: 'Capped', value: 'capped' },
                   { label: 'Open', value: 'open' },
@@ -237,10 +288,16 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.radius`}
             label="Radius"
+            tooltip={RENDER_FIELD_COPY.geometrics.cylinder.radius.description}
             valueLabel="radius"
             type="number"
           />
-          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+          <GeometricMaterialSelect
+            form={form}
+            name={name}
+            items={materialItems}
+            tooltip={RENDER_FIELD_COPY.geometrics._shared.material.description}
+          />
         </>
       );
     case 'bilinear_patch':
@@ -250,6 +307,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.p00`}
             label="P00 (corner 0,0)"
+            tooltip={RENDER_FIELD_COPY.geometrics.bilinear_patch.bilinearCorner.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -257,6 +315,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.p10`}
             label="P10 (corner 1,0)"
+            tooltip={RENDER_FIELD_COPY.geometrics.bilinear_patch.bilinearCorner.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -264,6 +323,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.p01`}
             label="P01 (corner 0,1)"
+            tooltip={RENDER_FIELD_COPY.geometrics.bilinear_patch.bilinearCorner.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -271,10 +331,16 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.p11`}
             label="P11 (corner 1,1)"
+            tooltip={RENDER_FIELD_COPY.geometrics.bilinear_patch.bilinearCorner.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
-          <GeometricMaterialSelect form={form} name={name} items={materialItems} />
+          <GeometricMaterialSelect
+            form={form}
+            name={name}
+            items={materialItems}
+            tooltip={RENDER_FIELD_COPY.geometrics._shared.material.description}
+          />
         </>
       );
     case 'rotate_x':
@@ -287,6 +353,11 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             {(field) => (
               <field.RangeControl
                 label={hasDegrees ? 'Degrees of Rotation' : 'Radians of Rotation'}
+                tooltip={
+                  hasDegrees
+                    ? RENDER_FIELD_COPY.geometrics.rotate.degreesOfRotation.description
+                    : RENDER_FIELD_COPY.geometrics.rotate.radiansOfRotation.description
+                }
                 min={0}
                 max={hasDegrees ? 360 : 2 * Math.PI}
                 step={hasDegrees ? 1.0 : 0.01}
@@ -312,6 +383,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.quaternion`}
             label="Quaternion"
+            tooltip={RENDER_FIELD_COPY.geometrics.rotate_quaternion.quaternion.description}
             labelSpacePercentage={25}
             valueLabels={['w', 'x', 'y', 'z']}
             type="number"
@@ -328,6 +400,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.scale`}
             label="Scale"
+            tooltip={RENDER_FIELD_COPY.geometrics.scale.scale.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -341,6 +414,7 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
             form={form}
             fieldName={`geometrics.${name}.translation`}
             label="Translation"
+            tooltip={RENDER_FIELD_COPY.geometrics.translate.translation.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
           />
@@ -350,9 +424,22 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
       return (
         <>
           <form.AppField name={`geometrics.${name}.density`}>
-            {(field) => <field.RangeControl label="Density" min={0} max={1} step={0.01} />}
+            {(field) => (
+              <field.RangeControl
+                label="Density"
+                tooltip={RENDER_FIELD_COPY.geometrics.constant_volume.density.description}
+                min={0}
+                max={1}
+                step={0.01}
+              />
+            )}
           </form.AppField>
-          <GeometricTextureSelect form={form} name={name} items={textureItems} />
+          <GeometricTextureSelect
+            form={form}
+            name={name}
+            items={textureItems}
+            tooltip={RENDER_FIELD_COPY.geometrics.constant_volume.reflectanceTexture.description}
+          />
         </>
       );
     case 'virtual':

--- a/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/GeometricControls/GeometricRow/GeometricFormControls/index.tsx
@@ -306,7 +306,8 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <TextArrayInputControl
             form={form}
             fieldName={`geometrics.${name}.p00`}
-            label="P00 (corner 0,0)"
+            label="P00"
+            labelSpacePercentage={20}
             tooltip={RENDER_FIELD_COPY.geometrics.bilinear_patch.bilinearCorner.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
@@ -314,7 +315,8 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <TextArrayInputControl
             form={form}
             fieldName={`geometrics.${name}.p10`}
-            label="P10 (corner 1,0)"
+            label="P10"
+            labelSpacePercentage={20}
             tooltip={RENDER_FIELD_COPY.geometrics.bilinear_patch.bilinearCorner.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
@@ -322,7 +324,8 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <TextArrayInputControl
             form={form}
             fieldName={`geometrics.${name}.p01`}
-            label="P01 (corner 0,1)"
+            label="P01"
+            labelSpacePercentage={20}
             tooltip={RENDER_FIELD_COPY.geometrics.bilinear_patch.bilinearCorner.description}
             valueLabels={['x', 'y', 'z']}
             type="number"
@@ -330,7 +333,8 @@ export function GeometricFormControls(props: GeometricFormControlsProps) {
           <TextArrayInputControl
             form={form}
             fieldName={`geometrics.${name}.p11`}
-            label="P11 (corner 1,1)"
+            label="P11"
+            labelSpacePercentage={20}
             tooltip={RENDER_FIELD_COPY.geometrics.bilinear_patch.bilinearCorner.description}
             valueLabels={['x', 'y', 'z']}
             type="number"

--- a/ui/src/views/renders/new/Controls/tabs/MaterialControls/MaterialRow.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/MaterialControls/MaterialRow.tsx
@@ -9,6 +9,7 @@ import { InfoIconDefaultEntity } from '../../shared/icons/InfoIconDefaultEntity'
 import { DuplicateDropdown } from '../../shared/DuplicateDropdown';
 import { duplicateMaterial } from '@/utils/render/utils';
 import { MediumControls } from './MediumControls';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 
 export type MaterialRowProps = {
   form: RenderForm;
@@ -72,10 +73,22 @@ export function MaterialRow(props: MaterialRowProps) {
     return (
       <>
         <form.AppField name={`materials.${name}.reflectance_texture`}>
-          {(field) => <field.SelectControl label="Reflectance Texture" items={textureItems} />}
+          {(field) => (
+            <field.SelectControl
+              label="Reflectance Texture"
+              items={textureItems}
+              tooltip={RENDER_FIELD_COPY.materials._shared.reflectanceTexture.description}
+            />
+          )}
         </form.AppField>
         <form.AppField name={`materials.${name}.emittance_texture`}>
-          {(field) => <field.SelectControl label="Emittance Texture" items={textureItems} />}
+          {(field) => (
+            <field.SelectControl
+              label="Emittance Texture"
+              items={textureItems}
+              tooltip={RENDER_FIELD_COPY.materials._shared.emittanceTexture.description}
+            />
+          )}
         </form.AppField>
       </>
     );
@@ -90,12 +103,26 @@ export function MaterialRow(props: MaterialRowProps) {
           <>
             <form.AppField name={`materials.${name}.index_of_refraction`}>
               {(field) => (
-                <field.RangeControl label="Index of Refraction" min={1.0} max={10.0} step={0.01} />
+                <field.RangeControl
+                  label="Index of Refraction"
+                  min={1.0}
+                  max={10.0}
+                  step={0.01}
+                  tooltip={RENDER_FIELD_COPY.materials.dielectric.indexOfRefraction.description}
+                />
               )}
             </form.AppField>
             <MediumControls form={form} materialName={name} />
             <form.AppField name={`materials.${name}.abbe_number`}>
-              {(field) => <field.RangeControl label="Abbe Number" min={1} max={100} step={1} />}
+              {(field) => (
+                <field.RangeControl
+                  label="Abbe Number"
+                  min={1}
+                  max={100}
+                  step={1}
+                  tooltip={RENDER_FIELD_COPY.materials.dielectric.abbeNumber.description}
+                />
+              )}
             </form.AppField>
             <TextureSelects name={name} />
           </>
@@ -106,7 +133,15 @@ export function MaterialRow(props: MaterialRowProps) {
         return (
           <>
             <form.AppField name={`materials.${name}.roughness`}>
-              {(field) => <field.RangeControl label="Roughness" min={0.0} max={1.0} step={0.01} />}
+              {(field) => (
+                <field.RangeControl
+                  label="Roughness"
+                  min={0.0}
+                  max={1.0}
+                  step={0.01}
+                  tooltip={RENDER_FIELD_COPY.materials.specular.roughness.description}
+                />
+              )}
             </form.AppField>
             <TextureSelects name={name} />
           </>

--- a/ui/src/views/renders/new/Controls/tabs/MaterialControls/MediumControls.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/MaterialControls/MediumControls.tsx
@@ -8,6 +8,8 @@ import { TextInputControl } from '@/components/form-controls/TextInputControl';
 import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
 import type { RenderForm, RenderFormPath } from '@/hooks/useRenderForm';
 import type { MediumData, NormalizedMaterialData } from '@/utils/render/material';
+import { FieldLabel } from '@/components/FieldLabel';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 
 export type MediumControlsProps = {
   form: RenderForm;
@@ -80,7 +82,13 @@ export function MediumControls(props: MediumControlsProps) {
     <>
       <AnimatedSeparator visible={hasInteriorMedium} />
       <div className="flex w-full items-center justify-between py-2">
-        <h6 className="overflow-hidden font-normal">Has Interior Medium?</h6>
+        <h6 className="overflow-hidden font-normal">
+          <FieldLabel
+            tooltipContent={RENDER_FIELD_COPY.materials.dielectric.hasInteriorMedium.description}
+          >
+            Has Interior Medium?
+          </FieldLabel>
+        </h6>
         <ToggleSwitch checked={hasInteriorMedium} onChange={handleToggle} />
       </div>
       <ExpandableSection expanded={hasInteriorMedium} onExpandEnd={() => form.validate('change')}>
@@ -97,6 +105,7 @@ export function MediumControls(props: MediumControlsProps) {
                   { label: 'Homogeneous', value: 'homogeneous' },
                 ]}
                 onChange={(value) => handleTypeChange(value)}
+                tooltip={RENDER_FIELD_COPY.materials.dielectric.mediumType.description}
               />
             )}
           </form.AppField>
@@ -110,6 +119,7 @@ export function MediumControls(props: MediumControlsProps) {
                 valueLabels={['r', 'g', 'b']}
                 type="number"
                 unenforcedStep={0.01}
+                tooltip={RENDER_FIELD_COPY.materials.dielectric.transmittance.description}
               />
               <TextInputControl
                 form={form}
@@ -119,6 +129,7 @@ export function MediumControls(props: MediumControlsProps) {
                 labelSpacePercentage={60}
                 type="number"
                 valueLabel="units"
+                tooltip={RENDER_FIELD_COPY.materials.dielectric.attenuationDistance.description}
               />
               <TextArrayInputControl
                 form={form}
@@ -128,6 +139,7 @@ export function MediumControls(props: MediumControlsProps) {
                 valueLabels={['r', 'g', 'b']}
                 type="number"
                 unenforcedStep={0.01}
+                tooltip={RENDER_FIELD_COPY.materials.dielectric.emittance.description}
               />
             </>
           )}

--- a/ui/src/views/renders/new/Controls/tabs/ParametersControls/CheckpointLimitControls.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/ParametersControls/CheckpointLimitControls.tsx
@@ -5,6 +5,8 @@ import { useAuth } from '@/providers/Auth';
 import { TextInputControl } from '@/components/form-controls/TextInputControl';
 import { AnimatedSeparator } from '@/components/AnimatedSeparator';
 import { ExpandableSection } from '@/components/ExpandableSection';
+import { FieldLabel } from '@/components/FieldLabel';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 import { WarningIconAdvancedProperty } from '../../shared/icons/WarningIconAdvancedProperty';
 import { useSelector } from '@tanstack/react-store';
 import type { RenderForm } from '@/hooks/useRenderForm';
@@ -40,7 +42,11 @@ export function CheckpointLimitControls(props: CheckpointLimitControlsProps) {
       <div className="flex w-full items-center justify-between py-2">
         <h6 className="overflow-hidden font-normal">
           <span className="flex items-center gap-2">
-            Enforce Checkpoint Limit?
+            <FieldLabel
+              tooltipContent={RENDER_FIELD_COPY.parameters.enforceCheckpointLimit.description}
+            >
+              Enforce Checkpoint Limit?
+            </FieldLabel>
             <WarningIconAdvancedProperty />
           </span>
         </h6>
@@ -65,6 +71,7 @@ export function CheckpointLimitControls(props: CheckpointLimitControlsProps) {
             valueLabel="checkpoints"
             type="number"
             labelSuffix={<WarningIconAdvancedProperty />}
+            tooltip={RENDER_FIELD_COPY.parameters.savedCheckpointLimit.description}
           />
         </div>
         {/* <Separator /> */}

--- a/ui/src/views/renders/new/Controls/tabs/ParametersControls/ImportanceSamplingControls.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/ParametersControls/ImportanceSamplingControls.tsx
@@ -4,6 +4,8 @@ import { Separator } from '@/components/Separator';
 import { TextInputControl } from '@/components/form-controls/TextInputControl';
 import { AnimatedSeparator } from '@/components/AnimatedSeparator';
 import { ExpandableSection } from '@/components/ExpandableSection';
+import { FieldLabel } from '@/components/FieldLabel';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 import { WarningIconAdvancedProperty } from '../../shared/icons/WarningIconAdvancedProperty';
 import { useSelector } from '@tanstack/react-store';
 import type { RenderForm } from '@/hooks/useRenderForm';
@@ -47,7 +49,11 @@ export function ImportanceSamplingControls(props: ImportanceSamplingControlsProp
       <div className="flex w-full items-center justify-between py-2">
         <h6 className="overflow-hidden font-normal">
           <span className="flex items-center gap-2">
-            Use Importance Sampling?
+            <FieldLabel
+              tooltipContent={RENDER_FIELD_COPY.parameters.useImportanceSampling.description}
+            >
+              Use Importance Sampling?
+            </FieldLabel>
             <WarningIconAdvancedProperty />
           </span>
         </h6>
@@ -71,6 +77,7 @@ export function ImportanceSamplingControls(props: ImportanceSamplingControlsProp
             valueLabel="weight"
             type="number"
             labelSuffix={<WarningIconAdvancedProperty />}
+            tooltip={RENDER_FIELD_COPY.parameters.brdfWeight.description}
           />
           <TextInputControl
             form={form}
@@ -80,6 +87,7 @@ export function ImportanceSamplingControls(props: ImportanceSamplingControlsProp
             valueLabel="weight"
             type="number"
             labelSuffix={<WarningIconAdvancedProperty />}
+            tooltip={RENDER_FIELD_COPY.parameters.emissiveWeight.description}
           />
           <TextInputControl
             form={form}
@@ -89,6 +97,7 @@ export function ImportanceSamplingControls(props: ImportanceSamplingControlsProp
             valueLabel="weight"
             type="number"
             labelSuffix={<WarningIconAdvancedProperty />}
+            tooltip={RENDER_FIELD_COPY.parameters.transmissiveWeight.description}
           />
           <TextInputControl
             form={form}
@@ -98,6 +107,7 @@ export function ImportanceSamplingControls(props: ImportanceSamplingControlsProp
             valueLabel="weight"
             type="number"
             labelSuffix={<WarningIconAdvancedProperty />}
+            tooltip={RENDER_FIELD_COPY.parameters.specularWeight.description}
           />
           <TextInputControl
             form={form}
@@ -107,12 +117,14 @@ export function ImportanceSamplingControls(props: ImportanceSamplingControlsProp
             valueLabel="weight"
             type="number"
             labelSuffix={<WarningIconAdvancedProperty />}
+            tooltip={RENDER_FIELD_COPY.parameters.virtualWeight.description}
           />
           <form.AppField name="parameters.importance_sampling.use_multiple_importance_sampling">
             {(field) => (
               <field.ToggleControl
                 label="Use Multiple Importance Sampling"
                 labelSuffix={<WarningIconAdvancedProperty />}
+                tooltip={RENDER_FIELD_COPY.parameters.useMultipleImportanceSampling.description}
               />
             )}
           </form.AppField>

--- a/ui/src/views/renders/new/Controls/tabs/ParametersControls/RussianRouletteControls.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/ParametersControls/RussianRouletteControls.tsx
@@ -3,6 +3,8 @@ import { ToggleSwitch } from 'flowbite-react';
 import { TextInputControl } from '@/components/form-controls/TextInputControl';
 import { AnimatedSeparator } from '@/components/AnimatedSeparator';
 import { ExpandableSection } from '@/components/ExpandableSection';
+import { FieldLabel } from '@/components/FieldLabel';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 import { WarningIconAdvancedProperty } from '../../shared/icons/WarningIconAdvancedProperty';
 import { useSelector } from '@tanstack/react-store';
 import type { RenderForm } from '@/hooks/useRenderForm';
@@ -36,7 +38,11 @@ export function RussianRouletteControls(props: RussianRouletteControlsProps) {
       <div className="flex w-full items-center justify-between py-2">
         <h6 className="overflow-hidden font-normal">
           <span className="flex items-center gap-2">
-            Use Russian Roulette?
+            <FieldLabel
+              tooltipContent={RENDER_FIELD_COPY.parameters.useRussianRoulette.description}
+            >
+              Use Russian Roulette?
+            </FieldLabel>
             <WarningIconAdvancedProperty />
           </span>
         </h6>
@@ -57,6 +63,7 @@ export function RussianRouletteControls(props: RussianRouletteControlsProps) {
             valueLabel="bounces"
             type="number"
             labelSuffix={<WarningIconAdvancedProperty />}
+            tooltip={RENDER_FIELD_COPY.parameters.minBouncesBeforeRoulette.description}
           />
         </div>
       </ExpandableSection>

--- a/ui/src/views/renders/new/Controls/tabs/ParametersControls/index.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/ParametersControls/index.tsx
@@ -1,5 +1,5 @@
 import { AccordionRow } from '../../shared/AccordionRow';
-import { WarningIconAdvancedProperty } from '../../shared/icons/WarningIconAdvancedProperty';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 import { TextInputControl } from '@/components/form-controls/TextInputControl';
 import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
 import { HelperText } from 'flowbite-react';
@@ -9,6 +9,7 @@ import { useSelector } from '@tanstack/react-store';
 import { CheckpointLimitControls } from './CheckpointLimitControls';
 import { RussianRouletteControls } from './RussianRouletteControls';
 import { ImportanceSamplingControls } from './ImportanceSamplingControls';
+import { WarningIconAdvancedProperty } from '../../shared/icons/WarningIconAdvancedProperty';
 
 export type ParametersControlsProps = {
   form: RenderForm;
@@ -23,7 +24,13 @@ export function ParametersControls(props: ParametersControlsProps) {
   return (
     <AccordionRow leftLabel="Parameters" leftLabelStyle="light" startExpanded>
       <div className="flex flex-col gap-2">
-        <TextInputControl form={form} fieldName="name" label="Name" valueLabel="name" />
+        <TextInputControl
+          form={form}
+          fieldName="name"
+          label="Name"
+          valueLabel="name"
+          tooltip={RENDER_FIELD_COPY.parameters.name.description}
+        />
 
         <form.AppField name="parameters.image_dimensions">
           {(arrayField) => (
@@ -34,6 +41,7 @@ export function ParametersControls(props: ParametersControlsProps) {
                 label="Size"
                 valueLabels={['width', 'height']}
                 type="number"
+                tooltip={RENDER_FIELD_COPY.parameters.imageDimensions.description}
               />
               {(() => {
                 const [w, h] = parameters.image_dimensions;
@@ -77,6 +85,7 @@ export function ParametersControls(props: ParametersControlsProps) {
           valueLabels={['width', 'height']}
           type="number"
           labelSuffix={<WarningIconAdvancedProperty />}
+          tooltip={RENDER_FIELD_COPY.parameters.tileDimensions.description}
         />
 
         <TextInputControl
@@ -86,6 +95,7 @@ export function ParametersControls(props: ParametersControlsProps) {
           labelSpacePercentage={70}
           valueLabel="samples"
           type="number"
+          tooltip={RENDER_FIELD_COPY.parameters.samplesPerCheckpoint.description}
         />
 
         <TextInputControl
@@ -95,7 +105,18 @@ export function ParametersControls(props: ParametersControlsProps) {
           labelSpacePercentage={70}
           valueLabel="checkpoints"
           type="number"
+          tooltip={RENDER_FIELD_COPY.parameters.totalCheckpoints.description}
         />
+
+        <form.AppField name="parameters.use_scaling_truncation">
+          {(field) => (
+            <field.ToggleControl
+              label="Use Scaling Truncation"
+              labelSuffix={<WarningIconAdvancedProperty />}
+              tooltip={RENDER_FIELD_COPY.parameters.useScalingTruncation.description}
+            />
+          )}
+        </form.AppField>
 
         <CheckpointLimitControls form={form} />
 
@@ -107,16 +128,8 @@ export function ParametersControls(props: ParametersControlsProps) {
           valueLabel="bounces"
           type="number"
           labelSuffix={<WarningIconAdvancedProperty />}
+          tooltip={RENDER_FIELD_COPY.parameters.maxLightBounces.description}
         />
-
-        <form.AppField name="parameters.use_scaling_truncation">
-          {(field) => (
-            <field.ToggleControl
-              label="Use Scaling Truncation"
-              labelSuffix={<WarningIconAdvancedProperty />}
-            />
-          )}
-        </form.AppField>
 
         <RussianRouletteControls form={form} />
 

--- a/ui/src/views/renders/new/Controls/tabs/SceneControls/CameraPanel.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/SceneControls/CameraPanel.tsx
@@ -1,11 +1,12 @@
 import { AccordionRow } from '../../shared/AccordionRow';
-import { WarningIconUnaffectedPreview } from '../../shared/icons/WarningIconUnaffectedPreview';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
 import { renameCamera } from '@/utils/render/utils';
 import type { RenderForm, RenderFormPath } from '@/hooks/useRenderForm';
 import type { DeepKeys } from '@tanstack/react-form';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import { useSelector } from '@tanstack/react-store';
+import { WarningIconUnaffectedPreview } from '../../shared/icons/WarningIconUnaffectedPreview';
 
 export type CameraPanelProps = {
   form: RenderForm;
@@ -36,7 +37,13 @@ export function CameraPanel(props: CameraPanelProps) {
       <div className="flex flex-col gap-2">
         <form.AppField name={`${formPath}.vertical_field_of_view_degrees`}>
           {(field) => (
-            <field.RangeControl label="Vertical FOV (degrees)" min={1.0} max={170.0} step={1.0} />
+            <field.RangeControl
+              label="Vertical FOV (degrees)"
+              min={1.0}
+              max={170.0}
+              step={1.0}
+              tooltip={RENDER_FIELD_COPY.cameras.verticalFOV.description}
+            />
           )}
         </form.AppField>
         <TextArrayInputControl
@@ -45,6 +52,7 @@ export function CameraPanel(props: CameraPanelProps) {
           label="Eye"
           valueLabels={['x', 'y', 'z']}
           type="number"
+          tooltip={RENDER_FIELD_COPY.cameras.eyeLocation.description}
         />
         <TextArrayInputControl
           form={form}
@@ -52,6 +60,7 @@ export function CameraPanel(props: CameraPanelProps) {
           label="Target"
           valueLabels={['x', 'y', 'z']}
           type="number"
+          tooltip={RENDER_FIELD_COPY.cameras.targetLocation.description}
         />
         <TextArrayInputControl
           form={form}
@@ -59,6 +68,7 @@ export function CameraPanel(props: CameraPanelProps) {
           label="View Up"
           valueLabels={['x', 'y', 'z']}
           type="number"
+          tooltip={RENDER_FIELD_COPY.cameras.viewUp.description}
         />
         <form.AppField name={`${formPath}.defocus_angle_degrees`}>
           {(field) => (
@@ -68,6 +78,7 @@ export function CameraPanel(props: CameraPanelProps) {
               max={180.0}
               step={1.0}
               labelPrefix={<WarningIconUnaffectedPreview />}
+              tooltip={RENDER_FIELD_COPY.cameras.defocusAngle.description}
             />
           )}
         </form.AppField>

--- a/ui/src/views/renders/new/Controls/tabs/TextureControls/TextureRow.tsx
+++ b/ui/src/views/renders/new/Controls/tabs/TextureControls/TextureRow.tsx
@@ -1,13 +1,14 @@
 import { AccordionRow } from '../../shared/AccordionRow';
 import { TextInputControl } from '@/components/form-controls/TextInputControl';
 import { TextArrayInputControl } from '@/components/form-controls/TextArrayInputControl';
-import { InfoIconAdditionalInfo } from '../../shared/icons/InfoIconAdditionalInfo';
 import { getTextureData } from '@/utils/render/texture';
+import { RENDER_FIELD_COPY } from '@/data/renderFieldCopy';
 import { fixReferences, renameTexture } from '@/utils/render/utils';
 import type { NormalizedRenderConfig } from '@/utils/render/config';
 import type { RenderForm } from '@/hooks/useRenderForm';
 import { useSelector } from '@tanstack/react-store';
 import { Separator } from '@/components/Separator';
+import { InfoIconAdditionalInfo } from '../../shared/icons/InfoIconAdditionalInfo';
 import { WarningIconOrphanGeometric } from '../../shared/icons/WarningIconOrphanGeometric';
 import { InfoIconDefaultEntity } from '../../shared/icons/InfoIconDefaultEntity';
 import { DuplicateDropdown } from '../../shared/DuplicateDropdown';
@@ -85,6 +86,7 @@ export function TextureRow(props: TextureRowProps) {
               label="Scale"
               valueLabel="scale"
               type="number"
+              tooltip={RENDER_FIELD_COPY.textures.scale.description}
             />
             <Separator />
             <div className="flex items-baseline justify-between py-1">
@@ -138,6 +140,7 @@ export function TextureRow(props: TextureRowProps) {
                 ]}
               />
             }
+            tooltip={RENDER_FIELD_COPY.textures.color.description}
           />
         );
       }


### PR DESCRIPTION
## Context

The `/renders/new` form has ~60+ fields across 5 tabs with no inline documentation. A few fields had amber warning icons but they only warned about preview inaccuracy rather than explaining what the field actually does. This PR adds hoverable tooltips to every field label.

## Solution

### New infrastructure
- **`FieldLabel` component** — wraps label text in a dotted-underline hover target with a flowbite `Tooltip`. Accepts an optional `tooltipContent` prop (backward-compatible — no visual change when omitted). Supports both `string` and `string[]` (array entries render as separate paragraphs).
- **`renderFieldCopy.ts`** — centralized data file with field documentation for all 63+ form fields, organized by category and nested by geometric/material type. Designed to be reused by a future reference page.

### Form control primitives (5 files)
All five primitives (`TextInputControl`, `TextArrayInputControl`, `RangeControl`, `SelectControl`, `ToggleControl`) now accept an optional `tooltip` prop. The label text gets the tooltip while `labelPrefix`/`labelSuffix` (amber warning icons) remain separate hover targets with their own tooltips.

### Form cards (12 files)
Every field label on the form now has a description tooltip. Existing amber warning icons (`WarningIconAdvancedProperty`, `WarningIconUnaffectedPreview`) and info icons (`InfoIconAdditionalInfo`) are preserved as separate hover targets.

### Documentation structure
```
RENDER_FIELD_COPY.parameters.name.description
RENDER_FIELD_COPY.cameras.verticalFOV.description
RENDER_FIELD_COPY.geometrics.box.corner1.description
RENDER_FIELD_COPY.geometrics._shared.material.description
RENDER_FIELD_COPY.materials.specular.roughness.description
RENDER_FIELD_COPY.materials._shared.reflectanceTexture.description
```

## Notes for Reviewers

- Descriptions were verified against the actual backend implementation where possible, but some may still need refinement.
- The `renderFieldCopy.ts` naming is a working name — rename to `renderFieldDocs.ts` or similar before final merge.